### PR TITLE
Enable rocm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/hipify-torch"]
+	path = third_party/hipify-torch
+	url = https://github.com/ROCmSoftwarePlatform/hipify-torch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_library(TERMINFO_LIBRARY tinfo)
 # Compiler flags
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 if (TRITON_USE_ROCM)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS -fvisibility=default -std=gnu++17 -Wno-unused-result -Wno-attributes")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17 -Wno-unused-result -Wno-attributes")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,28 +42,27 @@ endif()
 ##########
 # LLVM
 ##########
-if("${LLVM_LIBRARY_DIR}" STREQUAL "")
 if (TRITON_USE_ROCM)
-    find_package(LLVM 11 REQUIRED COMPONENTS "amdgpu")
+    find_package(LLVM 12 REQUIRED COMPONENTS "amdgpu")
 else()
-    find_package(LLVM 11 REQUIRED COMPONENTS "nvptx")
-endif()
-    
-    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-    if(APPLE)
-      set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+    if("${LLVM_LIBRARY_DIR}" STREQUAL "")
+        find_package(LLVM 11 REQUIRED COMPONENTS "nvptx")
+        message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+        if(APPLE)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+        endif()
+    # sometimes we don't want to use llvm-config, since it may have been downloaded for some specific linux distros
+    else()
+        set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIR}")
+        set(LLVM_LIBRARIES libLLVMNVPTXCodeGen.a libLLVMSelectionDAG.a libLLVMipo.a libLLVMInstrumentation.a
+                        libLLVMVectorize.a libLLVMLinker.a libLLVMIRReader.a libLLVMAsmParser.a libLLVMFrontendOpenMP.a
+                        libLLVMAsmPrinter.a libLLVMDebugInfoDWARF.a libLLVMCodeGen.a libLLVMTarget.a libLLVMScalarOpts.a
+                        libLLVMInstCombine.a libLLVMAggressiveInstCombine.a libLLVMTransformUtils.a libLLVMBitWriter.a
+                        libLLVMAnalysis.a libLLVMProfileData.a libLLVMObject.a libLLVMTextAPI.a libLLVMMCParser.a
+                        libLLVMBitReader.a libLLVMCore.a libLLVMRemarks.a libLLVMBitstreamReader.a libLLVMNVPTXDesc.a
+                        libLLVMMC.a libLLVMDebugInfoCodeView.a libLLVMDebugInfoMSF.a libLLVMBinaryFormat.a libLLVMNVPTXInfo.a
+                        libLLVMSupport.a libLLVMDemangle.a)
     endif()
-# sometimes we don't want to use llvm-config, since it may have been downloaded for some specific linux distros
-else()
-    set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIR}")
-    set(LLVM_LIBRARIES libLLVMNVPTXCodeGen.a libLLVMSelectionDAG.a libLLVMipo.a libLLVMInstrumentation.a
-                       libLLVMVectorize.a libLLVMLinker.a libLLVMIRReader.a libLLVMAsmParser.a libLLVMFrontendOpenMP.a
-                       libLLVMAsmPrinter.a libLLVMDebugInfoDWARF.a libLLVMCodeGen.a libLLVMTarget.a libLLVMScalarOpts.a
-                       libLLVMInstCombine.a libLLVMAggressiveInstCombine.a libLLVMTransformUtils.a libLLVMBitWriter.a
-                       libLLVMAnalysis.a libLLVMProfileData.a libLLVMObject.a libLLVMTextAPI.a libLLVMMCParser.a
-                       libLLVMBitReader.a libLLVMCore.a libLLVMRemarks.a libLLVMBitstreamReader.a libLLVMNVPTXDesc.a
-                       libLLVMMC.a libLLVMDebugInfoCodeView.a libLLVMDebugInfoMSF.a libLLVMBinaryFormat.a libLLVMNVPTXInfo.a
-                       libLLVMSupport.a libLLVMDemangle.a)
 endif()
 include_directories("${LLVM_INCLUDE_DIRS}")
 
@@ -93,7 +92,6 @@ if(BUILD_PYTHON_MODULE)
         set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
     endif()
 endif()
-
 
 # Triton
 file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.6)
 include(ExternalProject)
 
+set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}")
+
 if(NOT TRITON_LLVM_BUILD_DIR)
     set(TRITON_LLVM_BUILD_DIR ${CMAKE_BINARY_DIR})
 endif()
@@ -8,7 +10,13 @@ endif()
 
 project(triton)
 include(CTest)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+if (TRITON_USE_ROCM)
+    message("COMPILING WITH ROCM")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DIR}/third_party/hipify-torch/cmake")
+    include(Hipify)
+else()
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+endif()
 
 # Options
 option(BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
@@ -24,14 +32,23 @@ find_library(TERMINFO_LIBRARY tinfo)
 
 # Compiler flags
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17")
+if (TRITON_USE_ROCM)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS -fvisibility=default -std=gnu++17 -Wno-unused-result -Wno-attributes")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17")
+endif()
 
 
 ##########
 # LLVM
 ##########
 if("${LLVM_LIBRARY_DIR}" STREQUAL "")
+if (TRITON_USE_ROCM)
+    find_package(LLVM 11 REQUIRED COMPONENTS "amdgpu")
+else()
     find_package(LLVM 11 REQUIRED COMPONENTS "nvptx")
+endif()
+    
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
     if(APPLE)
       set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
@@ -58,18 +75,57 @@ if(BUILD_PYTHON_MODULE)
     set(CUTLASS_INCLUDE_DIR "$ENV{CUTLASS_INCLUDE_DIR}")
     set(CUTLASS_LIBRARY_DIR "$ENV{CUTLASS_LIBRARY_DIR}")
     if(NOT("${CUTLASS_INCLUDE_DIR}" STREQUAL "") AND NOT("${CUTLASS_LIBRARY_DIR}" STREQUAL ""))
+    if (TRITON_USE_ROCM)
+        set(CUTLASS_SRC ${PYTHON_SRC_PATH}/cutlass_hip.cc)
+    else()
         set(CUTLASS_SRC ${PYTHON_SRC_PATH}/cutlass.cc)
+    endif()
         add_definitions(-DWITH_CUTLASS_BINDINGS)
         set(CUTLASS_LIBRARIES "cutlass.a")
     endif()
+    message(STATUS ${CUTLASS_INCLUDE_PATH})
     include_directories("." ${PYTHON_SRC_PATH} ${PYTHON_INCLUDE_DIRS} ${CUTLASS_INCLUDE_DIR})
     link_directories(${PYTHON_LINK_DIRS} ${CUTLASS_LIBRARY_DIR})
-    set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
+    if (TRITON_USE_ROCM)
+        add_definitions(-D__HIP_PLATFORM_AMD__)
+        set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton_hip.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
+    else()
+        set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
+    endif()
 endif()
 
 
 # Triton
 file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
+
+if (TRITON_USE_ROCM)
+    # collect hip src files
+    file(GLOB_RECURSE LIBTRITON_HIP_SRC *_hip.*)
+    list(FILTER LIBTRITON_HIP_SRC EXCLUDE REGEX ".*triton/python/build.*$") # don't include file from build
+
+    # get CUDA analog of HIP srcs
+    set(LIBTRITON_CUDA_ANALOG_SRC ${LIBTRITON_CUDA_ANALOG_SRC})
+    foreach(HIP_SRC IN LISTS LIBTRITON_HIP_SRC)
+        string(REPLACE "_hip." "." CUDA_SRC ${HIP_SRC})
+        list(APPEND LIBTRITON_CUDA_ANALOG_SRC ${CUDA_SRC})
+    endforeach()
+
+    # remove CUDA analogs of HIP srcs
+    foreach(SRC IN LISTS LIBTRITON_SRC)
+        if (${SRC} IN_LIST LIBTRITON_CUDA_ANALOG_SRC)
+            list(REMOVE_ITEM LIBTRITON_SRC ${SRC})
+        endif()
+    endforeach()
+else ()
+    # fitler hip files
+    file(GLOB_RECURSE LIBTRITON_HIP_SRC *_hip.*)
+    foreach(SRC IN LISTS LIBTRITON_SRC)
+        if (${SRC} IN_LIST LIBTRITON_HIP_SRC)
+            list(REMOVE_ITEM LIBTRITON_SRC ${SRC})
+        endif()
+    endforeach()
+endif()
+
 add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
 target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 target_link_libraries(triton ${LLVM_LIBRARIES} z ${TERMINFO_LIBRARY})

--- a/include/triton/driver/backend.h
+++ b/include/triton/driver/backend.h
@@ -7,7 +7,11 @@
 #include <map>
 #include <list>
 #include <vector>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/context_hip.h"
+#else
 #include "triton/driver/context.h"
+#endif
 
 namespace llvm
 {

--- a/include/triton/driver/buffer.h
+++ b/include/triton/driver/buffer.h
@@ -3,8 +3,13 @@
 #ifndef _TRITON_DRIVER_BUFFER_H_
 #define _TRITON_DRIVER_BUFFER_H_
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/handle_hip.h"
+#include "triton/driver/context_hip.h"
+#else
 #include "triton/driver/handle.h"
 #include "triton/driver/context.h"
+#endif
 
 namespace triton
 {

--- a/include/triton/driver/context.h
+++ b/include/triton/driver/context.h
@@ -3,8 +3,13 @@
 #ifndef _TRITON_DRIVER_CONTEXT_H_
 #define _TRITON_DRIVER_CONTEXT_H_
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/device_hip.h"
+#include "triton/driver/handle_hip.h"
+#else
 #include "triton/driver/device.h"
 #include "triton/driver/handle.h"
+#endif
 
 namespace triton
 {

--- a/include/triton/driver/device.h
+++ b/include/triton/driver/device.h
@@ -4,7 +4,11 @@
 #define _TRITON_DRIVER_DEVICE_H_
 
 #include "triton/driver/platform.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/handle_hip.h"
+#else
 #include "triton/driver/handle.h"
+#endif
 
 namespace triton
 {

--- a/include/triton/driver/dispatch.h
+++ b/include/triton/driver/dispatch.h
@@ -8,7 +8,7 @@
 
 #ifdef __HIP_PLATFORM_AMD__
 //HIP Backend
-#include "hip/hip_runtime.h"
+#include "triton/external/CUDA/hip.h"
 #include "triton/external/CUDA/nvml_hip.h"
 #else
 //CUDA Backend

--- a/include/triton/driver/dispatch.h
+++ b/include/triton/driver/dispatch.h
@@ -6,9 +6,15 @@
 #include <type_traits>
 #include <dlfcn.h>
 
+#ifdef __HIP_PLATFORM_AMD__
+//HIP Backend
+#include "hip/hip_runtime.h"
+#include "triton/external/CUDA/nvml_hip.h"
+#else
 //CUDA Backend
 #include "triton/external/CUDA/cuda.h"
 #include "triton/external/CUDA/nvml.h"
+#endif
 
 //Exceptions
 #include <iostream>
@@ -85,10 +91,12 @@ public:
   static CUresult cuModuleUnload(CUmodule hmod);
   static CUresult cuModuleLoadDataEx(CUmodule *module, const void *image, unsigned int numOptions, CUjit_option *options, void **optionValues);
 
+#ifndef __HIP_PLATFORM_AMD__
   static CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type, void* data, size_t size, const char* name, unsigned int numOptions, CUjit_option* options, void** optionValues);
   static CUresult cuLinkCreate_v2(unsigned int  numOptions, CUjit_option* options, void** optionValues, CUlinkState* stateOut);
   static CUresult cuLinkComplete(CUlinkState state, void** cubinOut, size_t* sizeOut);
   static CUresult cuLinkDestroy(CUlinkState state);
+#endif
 
   static CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev);
   static CUresult cuDeviceGetCount(int *count);
@@ -104,12 +112,18 @@ public:
   static CUresult cuStreamDestroy_v2(CUstream hStream);
   static CUresult cuEventDestroy_v2(CUevent hEvent);
   static CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize);
+#ifdef __HIP_PLATFORM_AMD__
+  static hipError_t hipPointerGetAttribute(void * data, hipPointerAttribute_t attribute, hipDeviceptr_t ptr);
+#else
   static CUresult cuPointerGetAttribute(void * data, CUpointer_attribute attribute, CUdeviceptr ptr);
+#endif
   static CUresult cuCtxGetDevice(CUdevice* result);
   static CUresult cuMemsetD8Async(CUdeviceptr dst, unsigned char x, size_t N, CUstream stream);
+#ifndef __HIP_PLATFORM_AMD__
   static CUresult cuFuncGetAttribute(int* pi, CUfunction_attribute attrib, CUfunction hfunc);
   static CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int  value);
   static CUresult cuFuncSetCacheConfig (CUfunction hfunc, CUfunc_cache config);
+#endif
   // NVML
   static nvmlReturn_t nvmlDeviceGetHandleByPciBusId_v2( const char* pciBusId, nvmlDevice_t* device);
   static nvmlReturn_t nvmlDeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int *clock);
@@ -133,6 +147,48 @@ private:
   static void* opengl_;
 
 
+#ifdef __HIP_PLATFORM_AMD__
+  // HIP functions
+  static void* hipCtxGetCurrent_;
+  static void* hipCtxSetCurrent_;
+  static void* hipCtxDestroy_;
+  static void* hipEventCreate_;
+  static void* hipGetDevice_;
+  static void* hipMemcpyDtoH_;
+  static void* hipStreamCreate___;
+  static void* hipEventElapsedTime_;
+  static void* hipFree_;
+  static void* hipMemcpyDtoHAsync_;
+  static void* hipDriverGetVersion_;
+  static void* hipDeviceGetName_;
+  static void* hipDeviceGetPCIBusId_;
+  static void* hipModuleGetGlobal_;
+  static void* hipMemcpyHtoDAsync_;
+  static void* hipModuleLoad_;
+  static void* hipModuleLaunchKernel_;
+  static void* hipModuleUnload_;
+  static void* hipModuleLoadDataEx_;
+  static void* hipDeviceGetAttribute_;
+  static void* hipGetDeviceCount_;
+  static void* hipMemcpyHtoD_;
+  static void* hipInit_;
+  static void* hipEventRecord_;
+  static void* hipCtxCreate_;
+  static void* hipModuleGetFunction_;
+  static void* hipStreamSynchronize_;
+  static void* hipStreamDestroy_;
+  static void* cuStreamGetCtx_;
+  static void* hipEventDestroy_;
+  static void* hipMalloc_;
+  static void* hipPointerGetAttribute_;
+  static void* hipCtxGetDevice_;
+  static void* hipMemsetD8Async_;
+  static void* hipCtxPushCurrent_;
+  static void* hipCtxPopCurrent_;
+  static void* hipFuncGetAttribute_;
+  static void* cuFuncSetAttribute_;
+  static void* hipFuncSetCacheConfig_;
+#else
   // CUDA functions
   static void* cuCtxGetCurrent_;
   static void* cuCtxSetCurrent_;
@@ -178,6 +234,7 @@ private:
   static void* cuFuncGetAttribute_;
   static void* cuFuncSetAttribute_;
   static void* cuFuncSetCacheConfig_;
+#endif
   // NVML
   static void* nvmlInit_v2_;
   static void* nvmlDeviceGetHandleByPciBusId_v2_;

--- a/include/triton/driver/error.h
+++ b/include/triton/driver/error.h
@@ -4,7 +4,11 @@
 #define _TRITON_DRIVER_ERROR_H_
 
 #include <exception>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/dispatch_hip.h"
+#else
 #include "triton/driver/dispatch.h"
+#endif
 
 
 namespace triton

--- a/include/triton/driver/handle.h
+++ b/include/triton/driver/handle.h
@@ -8,7 +8,11 @@
 #include <iostream>
 #include <functional>
 #include <type_traits>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/dispatch_hip.h"
+#else
 #include "triton/driver/dispatch.h"
+#endif
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"

--- a/include/triton/driver/kernel.h
+++ b/include/triton/driver/kernel.h
@@ -3,8 +3,13 @@
 #ifndef _TRITON_DRIVER_KERNEL_H_
 #define _TRITON_DRIVER_KERNEL_H_
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/module_hip.h"
+#include "triton/driver/handle_hip.h"
+#else
 #include "triton/driver/module.h"
 #include "triton/driver/handle.h"
+#endif
 #include <memory>
 
 namespace llvm

--- a/include/triton/driver/module.h
+++ b/include/triton/driver/module.h
@@ -4,9 +4,15 @@
 #define _TRITON_DRIVER_MODULE_H_
 
 #include <map>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/handle_hip.h"
+#include "triton/driver/context_hip.h"
+#include "triton/driver/buffer_hip.h"
+#else
 #include "triton/driver/handle.h"
 #include "triton/driver/context.h"
 #include "triton/driver/buffer.h"
+#endif
 
 namespace llvm
 {

--- a/include/triton/driver/platform.h
+++ b/include/triton/driver/platform.h
@@ -6,7 +6,11 @@
 #include <vector>
 #include <string>
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/handle_hip.h"
+#else
 #include "triton/driver/handle.h"
+#endif
 
 namespace triton
 {

--- a/include/triton/driver/stream.h
+++ b/include/triton/driver/stream.h
@@ -4,10 +4,17 @@
 #define _TRITON_DRIVER_STREAM_H_
 
 #include <map>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/context_hip.h"
+#include "triton/driver/device_hip.h"
+#include "triton/driver/handle_hip.h"
+#include "triton/driver/buffer_hip.h"
+#else
 #include "triton/driver/context.h"
 #include "triton/driver/device.h"
 #include "triton/driver/handle.h"
 #include "triton/driver/buffer.h"
+#endif
 
 namespace triton
 {

--- a/include/triton/external/CUDA/cuda.h
+++ b/include/triton/external/CUDA/cuda.h
@@ -47,6 +47,9 @@
  * Users Notice.
  */
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "hip/hip_runtime.h"
+#else
 #ifndef __cuda_cuda_h__
 #define __cuda_cuda_h__
 
@@ -14501,3 +14504,4 @@ CUresult CUDAAPI cuEventDestroy(CUevent hEvent);
 #undef __CUDA_DEPRECATED
 
 #endif /* __cuda_cuda_h__ */
+#endif

--- a/include/triton/tools/rocm_helper.h
+++ b/include/triton/tools/rocm_helper.h
@@ -4,18 +4,18 @@
 #include <sstream>
 
 template <typename T>
-std::string str_join(const T &v, const std::string &delim)
+std::string str_join(const T &token_vector, const std::string &delim)
 {
-    std::ostringstream s;
-    for (const auto &i : v)
+    std::ostringstream joined_token;
+    for (const auto &token : token_vector)
     {
-        if (&i != &v[0])
+        if (&token != &token_vector[0])
         {
-            s << delim;
+            joined_token << delim;
         }
-        s << i;
+        joined_token << token;
     }
-    return s.str();
+    return joined_token.str();
 }
 
 std::vector<std::string> str_split(const std::string &str, const std::string &delim)
@@ -35,21 +35,19 @@ std::vector<std::string> str_split(const std::string &str, const std::string &de
     return tokens;
 }
 
-std::string GetROCMGPUInfo()
+std::string GetAMDGPUInfo()
 {
     system("/opt/rocm/bin/rocminfo |grep -o -m 1 'gfx.*:.*:.*' >/tmp/rocminfo.log");
     std::ifstream t("/tmp/rocminfo.log");
     std::string rocminfo((std::istreambuf_iterator<char>(t)),
                          std::istreambuf_iterator<char>());
-    rocminfo.erase(remove_if(rocminfo.begin(), rocminfo.end(), isspace), rocminfo.end());
+    rocminfo.erase(std::remove_if(rocminfo.begin(), rocminfo.end(), isspace), rocminfo.end());
     return rocminfo;
 }
 
 #define ROCM_VERSION 42000
 std::string MapGCNArchNameTokenToFeatureStr(std::string token)
 {
-    // return  token[token.size() - 1] + token.substr(0, token.size() - 1);;
-
     if (token == "sramecc+")
     {
         return "+sramecc";

--- a/include/triton/tools/rocm_helper.h
+++ b/include/triton/tools/rocm_helper.h
@@ -1,0 +1,108 @@
+#include <vector>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+template <typename T>
+std::string str_join(const T &v, const std::string &delim)
+{
+    std::ostringstream s;
+    for (const auto &i : v)
+    {
+        if (&i != &v[0])
+        {
+            s << delim;
+        }
+        s << i;
+    }
+    return s.str();
+}
+
+std::vector<std::string> str_split(const std::string &str, const std::string &delim)
+{
+    std::vector<std::string> tokens;
+    size_t prev = 0, pos = 0;
+    do
+    {
+        pos = str.find(delim, prev);
+        if (pos == std::string::npos)
+            pos = str.length();
+        std::string token = str.substr(prev, pos - prev);
+        if (!token.empty())
+            tokens.push_back(token);
+        prev = pos + delim.length();
+    } while (pos < str.length() && prev < str.length());
+    return tokens;
+}
+
+std::string GetROCMGPUInfo()
+{
+    system("/opt/rocm/bin/rocminfo |grep -o -m 1 'gfx.*:.*:.*' >/tmp/rocminfo.log");
+    std::ifstream t("/tmp/rocminfo.log");
+    std::string rocminfo((std::istreambuf_iterator<char>(t)),
+                         std::istreambuf_iterator<char>());
+    rocminfo.erase(remove_if(rocminfo.begin(), rocminfo.end(), isspace), rocminfo.end());
+    return rocminfo;
+}
+
+#define ROCM_VERSION 42000
+std::string MapGCNArchNameTokenToFeatureStr(std::string token)
+{
+    // return  token[token.size() - 1] + token.substr(0, token.size() - 1);;
+
+    if (token == "sramecc+")
+    {
+        return "+sramecc";
+    }
+    else if (token == "sramecc-")
+    {
+#if ROCM_VERSION < 40100
+        return "";
+#else
+        return "-sramecc";
+#endif
+    }
+    else if (token == "xnack+")
+    {
+        return "+xnack";
+    }
+    else if (token == "xnack-")
+    {
+        return "-xnack";
+    }
+    return "";
+}
+
+std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
+    const std::string &gcn_arch_name)
+{
+    std::string feature_str;
+    std::string gfx = gcn_arch_name;
+#if ROCM_VERSION < 30900
+    // For ROCm versions older than 3.9, hardcode it to "+code-object-v3"
+    // This is simply to preserve how things were...nohing else
+    feature_str = "+code-object-v3";
+#elif ROCM_VERSION < 40000
+    // For ROCM versions 3.9 and 3.10, hardcode it to empty string
+    feature_str = "";
+#else
+    // For ROCm versions 4.0 and greater, we need to specify the correct
+    // feature str, based on the underlying GPU HW to get max performance.
+    std::vector<std::string> tokens = str_split(gcn_arch_name, ":");
+    std::vector<std::string> mapped_tokens;
+    if (tokens.size() > 0)
+        gfx = tokens[0];
+
+    // Skip the first token, that is the gfxNNN str
+    // The rest of the tokens are the feature/targetid strings
+    for (int i = 1; i < tokens.size(); i++)
+    {
+        std::string mapped_token = MapGCNArchNameTokenToFeatureStr(tokens[i]);
+        mapped_tokens.push_back(mapped_token);
+    }
+    feature_str = str_join(mapped_tokens, ",");
+#endif
+
+    // std::cout << "feature_str: " << feature_str << std::endl;
+    return make_pair(gfx, feature_str);
+}

--- a/include/triton/tools/rocm_helper.h
+++ b/include/triton/tools/rocm_helper.h
@@ -103,6 +103,5 @@ std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
     feature_str = str_join(mapped_tokens, ",");
 #endif
 
-    // std::cout << "feature_str: " << feature_str << std::endl;
     return make_pair(gfx, feature_str);
 }

--- a/lib/codegen/analysis/layout.cc
+++ b/lib/codegen/analysis/layout.cc
@@ -141,7 +141,12 @@ mma_layout::mma_layout(size_t num_warps,
                        shared_layout *layout_a, shared_layout *layout_b): data_layout(MMA, axes, shape, values, align) {
   /* fragments per warp */
   // try to make things as square as possible to maximize data re-use
+#ifdef __HIP_PLATFORM_AMD__
+      if (false)
+      {
+#else
   if(tgt->as_nvidia()->sm() < 80){
+#endif
     fpw_ = {2, 2, 1};
 //    std::vector<int> fpw_nm1;
 //    unsigned num_fragments = std::min<unsigned>((shape_[0]/8)*(shape_[1]/8), 4);

--- a/lib/codegen/analysis/swizzle.cc
+++ b/lib/codegen/analysis/swizzle.cc
@@ -30,7 +30,12 @@ void swizzle::run(ir::module &) {
       if(!in_layout)
         continue;
       int dtsize = layout->get_type()->get_scalar_ty()->get_primitive_size_in_bits() / 8;
+#ifdef __HIP_PLATFORM_AMD__
+      if (false)
+      {
+#else
       if(tgt_->as_nvidia()->sm() < 80){
+#endif
         int inner = mma_dot_a ? 0 : 1;
         per_phase_[layout] = std::max<int>(128 / (in_layout->mts(ord[0])*in_layout->nts(ord[0])*dtsize), 1);
         max_phase_[layout] = (ord[inner] == 1 ? 8 : 4) / per_phase_[layout];

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -34,7 +34,11 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps, 
   std::unique_ptr<llvm::Module> llvm(new llvm::Module(name, ctx));
   // optimizations
   std::unique_ptr<codegen::target> target = dev->make_target();
+#ifdef __HIP_PLATFORM_AMD__
+  bool cts_use_async = false;
+#else
   bool cts_use_async = target->as_nvidia()->sm() >= 80;
+#endif
   // create passes
   codegen::analysis::align align;
   codegen::analysis::axes axes;

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -13,9 +13,15 @@
 #include "triton/codegen/transform/peephole.h"
 #include "triton/codegen/transform/pipeline.h"
 #include "triton/codegen/transform/prefetch.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/device_hip.h"
+#include "triton/driver/kernel_hip.h"
+#include "triton/driver/module_hip.h"
+#else
 #include "triton/driver/device.h"
 #include "triton/driver/kernel.h"
 #include "triton/driver/module.h"
+#endif
 #include "triton/ir/function.h"
 #include "triton/ir/module.h"
 #include "triton/ir/print.h"

--- a/lib/codegen/transform/peephole.cc
+++ b/lib/codegen/transform/peephole.cc
@@ -248,8 +248,10 @@ void peephole::run(ir::module &mod) {
       was_modified = was_modified || rewrite_unit_red(i, builder);
       was_modified = was_modified || rewrite_gep_ptr_min_off_plus_off(i, builder);
       was_modified = was_modified || rewrite_select_masked_load(i, builder);
+#ifndef __HIP_PLATFORM_AMD__
       if(tgt_->as_nvidia()->sm() >= 80)
         was_modified = was_modified || rewrite_load_to_shared(i, builder);
+#endif
       if(was_modified)
         seen.insert(i);
     }

--- a/lib/codegen/transform/prefetch.cc
+++ b/lib/codegen/transform/prefetch.cc
@@ -82,8 +82,13 @@ void prefetch::run(ir::module &mod) {
     prefetched_vals_.insert(next_b);
   }
 
+#ifdef __HIP_PLATFORM_AMD__
+  if (false)
+  {
+#else
   // move loads to the beginning of the loop
   if (tgt_->as_nvidia()->sm() < 80) {
+#endif
     for (ir::function *fn : mod.get_function_list())
     for (ir::basic_block *bb : fn->blocks()) {
       // only apply to loop body

--- a/lib/driver/backend.cc
+++ b/lib/driver/backend.cc
@@ -22,12 +22,21 @@
 
 #include <vector>
 #include <stdexcept>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/dispatch_hip.h"
+#include "triton/driver/backend_hip.h"
+#include "triton/driver/buffer_hip.h"
+#include "triton/driver/context_hip.h"
+#include "triton/driver/stream_hip.h"
+#include "triton/driver/kernel_hip.h"
+#else
 #include "triton/driver/dispatch.h"
 #include "triton/driver/backend.h"
 #include "triton/driver/buffer.h"
 #include "triton/driver/context.h"
 #include "triton/driver/stream.h"
 #include "triton/driver/kernel.h"
+#endif
 
 
 namespace triton

--- a/lib/driver/context.cc
+++ b/lib/driver/context.cc
@@ -21,8 +21,13 @@
 */
 
 #include <cassert>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/context_hip.h"
+#include "triton/driver/module_hip.h"
+#else
 #include "triton/driver/context.h"
 #include "triton/driver/module.h"
+#endif
 #include "triton/tools/sys/getenv.hpp"
 #include "triton/tools/sys/mkdir.hpp"
 
@@ -109,7 +114,11 @@ cu_context::cu_context(CUcontext context, bool take_ownership): driver::context(
 }
 
 cu_context::cu_context(driver::device* device): context(device, CUcontext(), true){
+#ifdef __HIP_PLATFORM_AMD__
+  dispatch::hipCtxCreate(&*cu_, 0, *((driver::cu_device*)dev_)->cu());
+#else
   dispatch::cuCtxCreate(&*cu_, CU_CTX_SCHED_AUTO, *((driver::cu_device*)dev_)->cu());
+#endif
 //  dispatch::cuCtxPopCurrent_v2(NULL);
 }
 

--- a/lib/driver/device.cc
+++ b/lib/driver/device.cc
@@ -25,8 +25,13 @@
 #include <sstream>
 #include <cstring>
 #include <memory>
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/device_hip.h"
+#include "triton/driver/context_hip.h"
+#else
 #include "triton/driver/device.h"
 #include "triton/driver/context.h"
+#endif
 #include "triton/codegen/target.h"
 
 namespace triton
@@ -173,7 +178,11 @@ std::string cu_device::infos() const{
 
 // target
 std::unique_ptr<codegen::target> cu_device::make_target() const {
+#ifdef __HIP_PLATFORM_AMD__
+  return std::unique_ptr<codegen::amd_cl_target>(new codegen::amd_cl_target());
+#else
   return std::unique_ptr<codegen::nvidia_cu_target>(new codegen::nvidia_cu_target(compute_capability()));
+#endif
 }
 
 

--- a/lib/driver/device.cc
+++ b/lib/driver/device.cc
@@ -113,7 +113,11 @@ size_t cu_device::max_threads_per_block() const {
 
 // maximum amount of shared memory per block
 size_t cu_device::max_shared_memory() const {
+#ifdef __HIP_PLATFORM_AMD__
+  return cuGetInfo<hipDeviceAttributeMaxSharedMemoryPerBlock>();
+#else
   return cuGetInfo<CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN>();
+#endif
 }
 
 // warp size

--- a/lib/driver/error.cc
+++ b/lib/driver/error.cc
@@ -72,6 +72,24 @@ void check(CUresult err)
   case CUDA_ERROR_ILLEGAL_ADDRESS                : throw illegal_address();
   case CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES        : throw launch_out_of_resources();
   case CUDA_ERROR_LAUNCH_TIMEOUT                 : throw launch_timeout();
+#ifdef __HIP_PLATFORM_AMD__
+  // case hipErrorLaunchIncompatibleTexturing  : throw launch_incompatible_texturing();
+  case hipErrorPeerAccessAlreadyEnabled    : throw peer_access_already_enabled();
+  case hipErrorPeerAccessNotEnabled        : throw peer_access_not_enabled();
+  // case hipErrorPrimaryContextActive         : throw primary_context_active();
+  // case hipErrorContextIsDestroyed           : throw context_is_destroyed();
+  case hipErrorAssert                         : throw assert_error();
+  // case hipErrorTooManyPeers                 : throw too_many_peers();
+  case hipErrorHostMemoryAlreadyRegistered : throw host_memory_already_registered();
+  case hipErrorHostMemoryNotRegistered     : throw host_memory_not_registered();
+  // case hipErrorHardwareStackError           : throw hardware_stack_error();
+  // case hipErrorIllegalInstruction            : throw illegal_instruction();
+  // case hipErrorMisalignedAddress             : throw misaligned_address();
+  // case hipErrorInvalidAddressSpace          : throw invalid_address_space();
+  // case hipErrorInvalidPc                     : throw invalid_pc();
+  case hipErrorLaunchFailure                  : throw launch_failed();
+  // case hipErrorNotPermitted                  : throw not_permitted();
+#else
   case CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING  : throw launch_incompatible_texturing();
   case CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED    : throw peer_access_already_enabled();
   case CUDA_ERROR_PEER_ACCESS_NOT_ENABLED        : throw peer_access_not_enabled();
@@ -88,6 +106,7 @@ void check(CUresult err)
   case CUDA_ERROR_INVALID_PC                     : throw invalid_pc();
   case CUDA_ERROR_LAUNCH_FAILED                  : throw launch_failed();
   case CUDA_ERROR_NOT_PERMITTED                  : throw not_permitted();
+#endif
   case CUDA_ERROR_NOT_SUPPORTED                  : throw not_supported();
   case CUDA_ERROR_UNKNOWN                        : throw unknown();
   default                                        : throw unknown();

--- a/lib/driver/handle.cc
+++ b/lib/driver/handle.cc
@@ -20,7 +20,11 @@
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/handle_hip.h"
+#else
 #include "triton/driver/handle.h"
+#endif
 #include "triton/driver/error.h"
 
 namespace triton
@@ -38,12 +42,21 @@ inline void _delete(host_stream_t)   { }
 inline void _delete(host_buffer_t x)   { if(x.data) delete[] x.data; }
 inline void _delete(host_function_t) { }
 
+#ifdef __HIP_PLATFORM_AMD__
+//HIP
+inline void _delete(hipCtx_t x) { dispatch::hipCtxDestroy(x); }
+inline void _delete(hipDeviceptr_t x) { dispatch::hipFree(x); }
+inline void _delete(hipStream_t x) { dispatch::hipStreamDestroy(x); }
+inline void _delete(hipDevice_t) { }
+inline void _delete(hipEvent_t x) { dispatch::hipEventDestroy(x); }
+#else
 //CUDA
 inline void _delete(CUcontext x) { dispatch::cuCtxDestroy(x); }
 inline void _delete(CUdeviceptr x) { dispatch::cuMemFree(x); }
 inline void _delete(CUstream x) { dispatch::cuStreamDestroy(x); }
 inline void _delete(CUdevice) { }
 inline void _delete(CUevent x) { dispatch::cuEventDestroy(x); }
+#endif
 inline void _delete(CUfunction) { }
 inline void _delete(CUmodule x) { dispatch::cuModuleUnload(x); }
 inline void _delete(cu_event_t x) { _delete(x.first); _delete(x.second); }

--- a/lib/driver/module.cc
+++ b/lib/driver/module.cc
@@ -291,7 +291,7 @@ std::string cu_module::compile_llvm_module(llvm::Module* module, driver::device*
   // create
   llvm::SmallVector<char, 0> buffer;
 #ifdef __HIP_PLATFORM_AMD__
-  std::string rocminfo = GetROCMGPUInfo();
+  std::string rocminfo = GetAMDGPUInfo();
   
   std::string triple = "amdgcn-amd-amdhsa";
   std::string layout = "";

--- a/lib/driver/module.cc
+++ b/lib/driver/module.cc
@@ -334,7 +334,7 @@ std::string cu_module::compile_llvm_module(llvm::Module* module, driver::device*
   std::error_code ec;
 
   // Save GCN ISA binary.
-  std::string isabin_path = module_name + std::string(".o");
+  std::string isabin_path = std::string("/tmp/") + module_name + std::string(".o");
   std::unique_ptr<llvm::raw_fd_ostream> isabin_fs(
       new llvm::raw_fd_ostream(isabin_path, ec, llvm::sys::fs::OF_Text));
   if (ec)
@@ -352,14 +352,14 @@ std::string cu_module::compile_llvm_module(llvm::Module* module, driver::device*
 
 #ifdef __HIP_PLATFORM_AMD__
   // Save GCN ISA.
-  std::string amdgcn_path = module_name + std::string(".gcn");
+  std::string amdgcn_path = std::string("/tmp/") + module_name + std::string(".gcn");
   std::string result(buffer.begin(), buffer.end());
   std::ofstream amdgcn(amdgcn_path);
   amdgcn << result;
   amdgcn.close();
 
   // generate HASCO file
-  std::string hsaco_path = module_name + std::string(".hsaco");
+  std::string hsaco_path = std::string("/tmp/") + module_name + std::string(".hsaco");
   std::string error_message;
   int lld_result =
       llvm::sys::ExecuteAndWait("/opt/rocm/llvm/bin/ld.lld", {"/opt/rocm/llvm/bin/ld.lld", "-flavor", "gnu", "-shared", "-o", hsaco_path, isabin_path},

--- a/lib/driver/module.cc
+++ b/lib/driver/module.cc
@@ -73,11 +73,19 @@ std::string exec(const char* cmd) {
     return result;
 }
 
+#ifdef __HIP_PLATFORM_AMD__
+  void LLVMInitializeAMDGPUTargetInfo();
+  void LLVMInitializeAMDGPUTarget();
+  void LLVMInitializeAMDGPUTargetMC();
+  void LLVMInitializeAMDGPUAsmPrinter();
+  void LLVMInitializeAMDGPUAsmParser();
+#else
   void LLVMInitializeNVPTXTargetInfo();
   void LLVMInitializeNVPTXTarget();
   void LLVMInitializeNVPTXTargetMC();
   void LLVMInitializeNVPTXAsmPrinter();
   void LLVMInitializeNVPTXAsmParser();
+#endif
 
 
 namespace triton
@@ -93,10 +101,17 @@ namespace driver
 void module::init_llvm() {
   static bool init = false;
   if(!init){
+#ifdef __HIP_PLATFORM_AMD__
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTarget();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUAsmPrinter();
+#else
     LLVMInitializeNVPTXTargetInfo();
     LLVMInitializeNVPTXTarget();
     LLVMInitializeNVPTXTargetMC();
     LLVMInitializeNVPTXAsmPrinter();
+#endif 
     init = true;
   }
 }

--- a/lib/driver/platform.cc
+++ b/lib/driver/platform.cc
@@ -22,7 +22,11 @@
 
 #include <string>
 #include "triton/driver/platform.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/device_hip.h"
+#else
 #include "triton/driver/device.h"
+#endif
 
 
 namespace triton

--- a/python/setup.py
+++ b/python/setup.py
@@ -88,7 +88,10 @@ class CMakeBuild(build_ext):
         if not os.path.exists(llvm_build_dir):
             os.makedirs(llvm_build_dir)
         # python directories
-        python_include_dirs = [distutils.sysconfig.get_python_inc()] + ['/usr/local/cuda/include'] + ['/opt/rocm/include']
+        if os.environ['TRITON_USE_ROCM'] == 'ON':
+            python_include_dirs = [distutils.sysconfig.get_python_inc()] +['/opt/rocm/include']
+        else:
+            python_include_dirs = [distutils.sysconfig.get_python_inc()] + ['/usr/local/cuda/include']
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DBUILD_TUTORIALS=OFF",

--- a/python/setup.py
+++ b/python/setup.py
@@ -88,7 +88,7 @@ class CMakeBuild(build_ext):
         if not os.path.exists(llvm_build_dir):
             os.makedirs(llvm_build_dir)
         # python directories
-        python_include_dirs = [distutils.sysconfig.get_python_inc()] + ['/usr/local/cuda/include']
+        python_include_dirs = [distutils.sysconfig.get_python_inc()] + ['/usr/local/cuda/include'] + ['/opt/rocm/include']
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DBUILD_TUTORIALS=OFF",

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1,7 +1,13 @@
 ﻿#include "triton/codegen/pass.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "triton/driver/kernel_hip.h"
+#include "triton/driver/module_hip.h"
+#include "triton/driver/stream_hip.h"
+#else
 #include "triton/driver/kernel.h"
 #include "triton/driver/module.h"
 #include "triton/driver/stream.h"
+#endif
 #include "triton/ir/builder.h"
 #include "triton/ir/dispatch.h"
 #include "triton/ir/enums.h"

--- a/python/test/test_language.py
+++ b/python/test/test_language.py
@@ -35,6 +35,18 @@ def patch_kernel(template, to_replace):
 
 
 # generic test functions
+def _test_empty_kernel(dtype_x, expr, torch_expr=None, device='cuda'):
+    SIZE = 128
+    # define the kernel / launch-grid
+    @triton.jit
+    def kernel(X, **meta):
+        pid = tl.program_id(0) 
+    # inputs
+    x = triton.testing.random(SIZE, dtype=cvt[dtype_x], device=device)
+    # run empty kernel  
+    kernel[(1, )](x, SIZE=SIZE, num_warps=4)
+    
+# generic test functions
 def _test_unary(dtype_x, expr, torch_expr=None, device='cuda'):
     SIZE = 128
     # define the kernel / launch-grid
@@ -123,6 +135,17 @@ def test_bitwise_op(dtype_x, dtype_y, expr, device='cuda'):
 ])
 def test_compare_op(dtype_x, dtype_y, expr, device='cuda'):
     _test_binary(dtype_x, dtype_y, expr, device=device)
+
+# ---------------
+# test empty ops
+# ---------------
+@pytest.mark.parametrize("dtype_x, expr", [
+    (dtype_x, f' -x') for dtype_x in float_dtypes
+] + [\
+    (dtype_x, f' ~x') for dtype_x in int_dtypes
+     ])
+def test_empty_kernel(dtype_x, expr, device='cuda'):
+    _test_empty_kernel(dtype_x, expr, device=device)
 
 
 # ---------------


### PR DESCRIPTION
This PR enables trition on rocm. There is still more work to do but we are able to compile on rocm and run an empty kernel. This is the first of many prs. 

This pr uses a lot of ifdefs to work around some of the limitations of the current version of hipify torch. We can remove them as hipify torch is updated.  

That being said, in order for this PR to work, this PR in hipify torch must be merged https://github.com/ROCmSoftwarePlatform/hipify-torch/pull/7. It basically removes bad unicode characters from source code

The major changes are in the following files
- include/triton/driver/dispatch.h
- lib/driver/dispatch.cc
- lib/driver/module.cc
- CMakeLists.txt