### PR TITLE
[ROCm] Introducing dump support for AMDGCN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ target_link_libraries(triton
   TritonGPUTransforms
   TritonLLVMIR
   TritonPTX
+  TritonAMDGCN
   ${dialect_libs}
   ${conversion_libs}
   # optimizations

--- a/include/triton/Target/AMDGCN/AMDGCNTranslation.h
+++ b/include/triton/Target/AMDGCN/AMDGCNTranslation.h
@@ -1,0 +1,19 @@
+#ifndef TRITON_TARGET_AMDGCNTRANSLATION_H
+#define TRITON_TARGET_AMDGCNTRANSLATION_H
+
+#include <memory>
+#include <string>
+
+namespace llvm {
+class Module;
+} // namespace llvm
+
+namespace triton {
+
+// Translate LLVM IR to AMDGCN code.
+std::string translateLLVMIRToAMDGCN(llvm::Module &module,
+                                 const std::string &_proc);
+
+} // namespace triton
+
+#endif

--- a/include/triton/Target/AMDGCN/AMDGCNTranslation.h
+++ b/include/triton/Target/AMDGCN/AMDGCNTranslation.h
@@ -12,7 +12,7 @@ namespace triton {
 
 // Translate LLVM IR to AMDGCN code.
 std::string translateLLVMIRToAMDGCN(llvm::Module &module,
-                                 const std::string &_proc);
+                                    const std::string &_proc);
 
 } // namespace triton
 

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -3697,7 +3697,8 @@ public:
     mlir::populateStdToLLVMConversionPatterns(typeConverter, patterns);
 
 #ifdef USE_ROCM
-    mlir::populateGpuToROCDLConversionPatterns(typeConverter, patterns, mlir::gpu::amd::HIP);
+    mlir::populateGpuToROCDLConversionPatterns(typeConverter, patterns,
+                                               mlir::gpu::amd::HIP);
 #else
     mlir::populateGpuToNVVMConversionPatterns(typeConverter, patterns);
 #endif

--- a/lib/Target/AMDGCN/AMDGCNTranslation.cpp
+++ b/lib/Target/AMDGCN/AMDGCNTranslation.cpp
@@ -39,7 +39,8 @@ static void init_llvm() {
   LLVMInitializeAMDGPUAsmPrinter();
 }
 
-static std::string llir_to_amdgcn(llvm::Module *module, const std::string &_proc) {
+static std::string llir_to_amdgcn(llvm::Module *module,
+                                  const std::string &_proc) {
   init_llvm();
 
   llvm::SmallVector<char, 0> buffer;
@@ -92,7 +93,7 @@ static std::string llir_to_amdgcn(llvm::Module *module, const std::string &_proc
 }
 
 std::string translateLLVMIRToAMDGCN(llvm::Module &module,
-                                 const std::string &_proc) {
+                                    const std::string &_proc) {
   auto gcnCode = llir_to_amdgcn(&module, _proc);
   return gcnCode;
 }

--- a/lib/Target/AMDGCN/AMDGCNTranslation.cpp
+++ b/lib/Target/AMDGCN/AMDGCNTranslation.cpp
@@ -1,0 +1,100 @@
+#include "triton/Target/AMDGCN/AMDGCNTranslation.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/ExecutionEngine/ExecutionEngine.h"
+#include "mlir/ExecutionEngine/OptUtils.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
+#include "triton/Target/LLVMIR/LLVMIRTranslation.h"
+
+#include "llvm/ExecutionEngine/ExecutionEngine.h"
+#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/CodeGen.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
+#include "llvm/Transforms/Scalar.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+namespace triton {
+
+static void init_llvm() {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTarget();
+  LLVMInitializeAMDGPUTargetMC();
+  LLVMInitializeAMDGPUAsmPrinter();
+}
+
+static std::string llir_to_amdgcn(llvm::Module *module, const std::string &_proc) {
+  init_llvm();
+
+  llvm::SmallVector<char, 0> buffer;
+  std::string triple = "amdgcn-amd-amdhsa";
+  std::string layout = "";
+  std::string features = "+sramecc,-xnack";
+  // verify and store llvm
+  llvm::legacy::PassManager pm;
+  pm.add(llvm::createVerifierPass());
+  pm.run(*module);
+  // create machine
+  module->setTargetTriple(triple);
+  std::string error;
+  auto target =
+      llvm::TargetRegistry::lookupTarget(module->getTargetTriple(), error);
+  llvm::TargetOptions opt;
+
+  opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+  opt.UnsafeFPMath = false;
+  opt.NoInfsFPMath = false;
+  opt.NoNaNsFPMath = true;
+
+  llvm::TargetMachine *machine = target->createTargetMachine(
+      module->getTargetTriple(), _proc, features, opt, llvm::Reloc::PIC_,
+      llvm::None, llvm::CodeGenOpt::None);
+
+  // set data layout
+  if (layout.empty())
+    module->setDataLayout(machine->createDataLayout());
+  else
+    module->setDataLayout(layout);
+  // emit machine code
+  for (llvm::Function &f : module->functions())
+    f.addFnAttr(llvm::Attribute::AlwaysInline);
+
+  llvm::legacy::PassManager pass;
+  llvm::raw_svector_ostream stream(buffer);
+
+  // create dump files
+  std::error_code ec;
+
+  // emit
+  machine->addPassesToEmitFile(pass, stream, nullptr,
+                               llvm::CodeGenFileType::CGFT_AssemblyFile);
+  pass.run(*module);
+
+  std::string amdgcn(buffer.begin(), buffer.end());
+
+  return amdgcn;
+}
+
+std::string translateLLVMIRToAMDGCN(llvm::Module &module,
+                                 const std::string &_proc) {
+  auto gcnCode = llir_to_amdgcn(&module, _proc);
+  return gcnCode;
+}
+
+} // namespace triton

--- a/lib/Target/AMDGCN/CMakeLists.txt
+++ b/lib/Target/AMDGCN/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_mlir_translation_library(TritonAMDGCN
+        AMDGCNTranslation.cpp
+
+        LINK_COMPONENTS
+        Core
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRLLVMIR
+        MLIRSupport
+        MLIRTargetLLVMIRExport
+        )

--- a/lib/Target/CMakeLists.txt
+++ b/lib/Target/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(AMDGCN)
 add_subdirectory(LLVMIR)
 add_subdirectory(PTX)

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -20,6 +20,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Target/LLVMIR/LLVMIRTranslation.h"
 #include "triton/Target/PTX/PTXTranslation.h"
+#include "triton/Target/AMDGCN/AMDGCNTranslation.h"
 #include "triton/tools/sys/getenv.hpp"
 
 #include "llvm/IR/LegacyPassManager.h"
@@ -1270,6 +1271,24 @@ void init_triton_translation(py::module &m) {
         auto ptxCode =
             triton::translateLLVMIRToPTX(*module, capability, version);
         return ptxCode;
+      },
+      ret::take_ownership);
+
+  m.def(
+      "translate_llvmir_to_amdgcn",
+      [](const std::string llvmIR, int gfx_number) -> std::string {
+        // create LLVM module from C++
+        llvm::LLVMContext context;
+        std::unique_ptr<llvm::MemoryBuffer> buffer =
+            llvm::MemoryBuffer::getMemBuffer(llvmIR.c_str());
+        llvm::SMDiagnostic error;
+        std::unique_ptr<llvm::Module> module =
+            llvm::parseIR(buffer->getMemBufferRef(), error, context);
+        // translate module to AMDGCN
+        std::string target = "gfx" + std::to_string(gfx_number); 
+        auto gcnCode = 
+            triton::translateLLVMIRToAMDGCN(*module, target);
+        return gcnCode;
       },
       ret::take_ownership);
 

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -18,9 +18,9 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Target/AMDGCN/AMDGCNTranslation.h"
 #include "triton/Target/LLVMIR/LLVMIRTranslation.h"
 #include "triton/Target/PTX/PTXTranslation.h"
-#include "triton/Target/AMDGCN/AMDGCNTranslation.h"
 #include "triton/tools/sys/getenv.hpp"
 
 #include "llvm/IR/LegacyPassManager.h"
@@ -1285,9 +1285,8 @@ void init_triton_translation(py::module &m) {
         std::unique_ptr<llvm::Module> module =
             llvm::parseIR(buffer->getMemBufferRef(), error, context);
         // translate module to AMDGCN
-        std::string target = "gfx" + std::to_string(gfx_number); 
-        auto gcnCode = 
-            triton::translateLLVMIRToAMDGCN(*module, target);
+        std::string target = "gfx" + std::to_string(gfx_number);
+        auto gcnCode = triton::translateLLVMIRToAMDGCN(*module, target);
         return gcnCode;
       },
       ret::take_ownership);

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -890,6 +890,8 @@ def optimize_tritongpu_ir(mod, num_stages):
 def make_llvm_ir(mod):
     return _triton.translate_triton_gpu_to_llvmir(mod)
 
+def make_amdgcn(mod: Any, gfx_number: int):
+    return _triton.translate_llvmir_to_amdgcn(mod, gfx_number)
 
 def make_ptx(mod: Any, compute_capability: int, ptx_version: int) -> Tuple[str, int]:
     '''

--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -6,7 +6,7 @@ import triton._C.libtriton.triton as libtriton
 if __name__ == '__main__':
 
     # valid source and target formats
-    VALID_FORMATS = ['triton-ir', 'triton-gpu-ir', 'llvm-ir', 'ptx']
+    VALID_FORMATS = ['triton-ir', 'triton-gpu-ir', 'llvm-ir', 'ptx', 'amdgcn']
 
     # set up the argument parser
     # TODO: conditional requirements
@@ -16,7 +16,7 @@ if __name__ == '__main__':
                         help="Target format, one of: " + ', '.join(VALID_FORMATS))
     parser.add_argument('--sm', type=int, help="Compute capability to compile for")
     parser.add_argument('--ptx-version', type=int, help="PTX version to compile for")
-
+    parser.add_argument('--gfx', type=int, help="AMDGPU target to compile for")
     # parse the args
     args = parser.parse_args()
 
@@ -50,6 +50,13 @@ if __name__ == '__main__':
         print(module)
         exit(0)
 
+    # llvm-ir -> amdgcn
+    if args.target == 'amdgcn':
+        if not args.gfx:
+            raise argparse.ArgumentError(None, "Must specify --gfx for AMDGCN compilation")
+        module = triton.compiler.make_amdgcn(module, args.gfx)
+        print(module)
+        exit(0)
     if not args.sm:
         raise argparse.ArgumentError(None, "Must specify --sm for PTX compilation")
     if not args.ptx_version:


### PR DESCRIPTION
* This PR adds the ability to dump AMDGCN from MLIR, just like PTX, with `triton.tools.aot`.
* This allows to do FileCheck tests similar to PTX

* For example, to dump AMDGCN from MLIR for gfx906
`python3 -m triton.tools.aot /git/triton-rocm-fork/test/Target/tritongpu_to_ptx.mlir --target=amdgcn --gfx=906` 
