### PR TITLE
add inital div op impl

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/GcnAsmFormat.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/GcnAsmFormat.h
@@ -218,8 +218,35 @@ template <class ConcreteT> struct GCNInstrBase : public GCNInstrCommon {
   }
 };
 
+enum VectorWidth {
+  Byte = 8,
+  Short = 16,
+  Dword = 32,
+  Qword = 64
+};
+
 struct GCNInstr : public GCNInstrBase<GCNInstr> {
   using GCNInstrBase<GCNInstr>::GCNInstrBase;
+
+   GCNInstr &float_op_type(int width) {
+    switch (width) {
+    case Byte:
+      assert(Byte != width);
+      break;
+    case Short:
+      o("f16");
+      break;
+    case Dword:
+      o("f32");
+      break;
+    case Qword:
+      o("f64");
+      break;
+    default:
+      break;
+    }
+    return *this;
+  }
 };
 
 struct GCNInstrExecution {
@@ -246,13 +273,6 @@ struct GCNInstrExecution {
 struct GCNMemInstr : public GCNInstrBase<GCNMemInstr> {
   using GCNInstrBase<GCNMemInstr>::GCNInstrBase;
   // Add specific type suffix to instruction
-
-  enum VectorWidth {
-    Byte = 8,
-    Short = 16,
-    Dword = 32,
-    Qword = 64
-  };
 
   GCNMemInstr &load_type(int width) {
     switch (width) {

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -4951,13 +4951,10 @@ struct FDivOpConversion
     // create inst
     auto &rcp = gcnBuilder.create<GCNInstr>("v_rcp")->float_op_type(bitwidth);
     auto &mul_inst = gcnBuilder.create<GCNInstr>("v_mul")->float_op_type(bitwidth);
-    // auto &div_inst = gcnBuilder.create<GCNInstr>("v_div_fixup")->float_op_type(bitwidth); // TODO: fix mismatches
-    
 
     // launch insts
     rcp(res, rhs);
     mul_inst(res, lhs, res);
-    // div_inst(res, lhs, rhs, res); // TODO: fix mismatches
 
     // return result
     Value ret = gcnBuilder.launch(rewriter, loc, elemTy, false);

--- a/python/tests/test_core_amd.py
+++ b/python/tests/test_core_amd.py
@@ -244,7 +244,7 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
 
 @pytest.mark.parametrize("dtype_x, dtype_y, op", [
     (dtype_x, dtype_y, op)
-    for op in ['+', '-', '*']  # , '%'] #TODO: handle remainder
+    for op in ['+', '-', '*', '/']  # , '%'] #TODO: handle remainder
     for dtype_x in dtypes
     for dtype_y in dtypes
 ])


### PR DESCRIPTION
PR adds an intial div implementaiton.

If you run the test_binop with the only division you get the following result, most of them seem to be mismatch issues. 
``` 
=========================== short test summary info ============================
FAILED python/tests/test_core_amd.py::test_bin_op[int16-float32-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[int16-float64-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[int32-float64-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[int64-int16-/] - AssertionE...
FAILED python/tests/test_core_amd.py::test_bin_op[int64-int32-/] - AssertionE...
FAILED python/tests/test_core_amd.py::test_bin_op[int64-float16-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[int64-float64-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[uint16-float32-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[uint16-float64-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[uint32-float64-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[uint64-uint16-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[uint64-uint32-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[uint64-float16-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[uint64-float64-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[float16-float32-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float16-float64-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float32-float32-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float32-float64-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-int16-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-int32-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-int64-/] - Assertio...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-uint16-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-uint32-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-uint64-/] - Asserti...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-float16-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-float32-/] - Assert...
FAILED python/tests/test_core_amd.py::test_bin_op[float64-float64-/] - Assert...
======================== 27 failed, 54 passed in 11.44s ========================
```

A second PR later on that uses the actual div assembly instructions might solve this. Something like the snippet below.
```
auto &div_inst = gcnBuilder.create<GCNInstr>("v_div_fixup")->float_op_type(bitwidth); // TODO: fix mismatches
div_inst(res, lhs, rhs, res); 
```