### PR TITLE
Implement triton::LoadOp and triton::StoreOp using LLVM load and store

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/GcnAsmFormat.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/GcnAsmFormat.h
@@ -277,7 +277,7 @@ struct GCNMemInstr : public GCNInstrBase<GCNMemInstr> {
   GCNMemInstr &load_type(int width) {
     switch (width) {
     case Byte:
-      o("byte");
+      o("ubyte");
       break;
     case Short:
       o("ushort");


### PR DESCRIPTION
ops.

This avoids using GCNBuilder which has the following issues:

1. Performance problems with emitting too many barriers
2. Impossibility of supporting int8 and uint8 because the minimum AMDGPU register width is 16 bits.

More unit tests were included in test_core_amd.py.