### PR TITLE
Add support for AMDGCN bitcode (.bc) files.

### DIFF
--- a/python/tests/test_ext_elemwise.py
+++ b/python/tests/test_ext_elemwise.py
@@ -173,6 +173,9 @@ def kernel(X, Y, BLOCK: tl.constexpr):
 
     # triton result
     y = torch.zeros(shape, dtype=x.dtype, device="cuda")
-    kernel[(1,)](x, y, BLOCK=shape[0], extern_libs={"libdevice": lib_path})
+    if torch.version.hip is not None:
+      kernel[(1,)](x, y, BLOCK=shape[0], extern_libs=triton.get_amdgcn_bitcode_paths())
+    else:
+      kernel[(1,)](x, y, BLOCK=shape[0], extern_libs={"libdevice": lib_path})
     # compare
     assert_close(y, y_ref)

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -9,7 +9,7 @@ import torch
 from .utils import *
 from .runtime import Config, autotune, heuristics, JITFunction, KernelInterface
 from .runtime.jit import jit
-from .compiler import compile, CompilationError
+from .compiler import compile, CompilationError, get_amdgcn_bitcode_paths
 from . import language
 from . import testing
 from . import ops

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1550,6 +1550,30 @@ def compile(fn, signature: str, device: int = -1, constants=dict(), num_warps: i
       asm = {"ttir": ttir, "ttgir": ttgir, "llir": llir, "ptx": ptx, "cubin": cubin}
     return CompiledKernel(so_path, metadata, asm)
 
+@static_vars(discovered_gfx_arch = _get_amdgpu_arch())
+def _get_amdgcn_bitcode_paths():
+  gpu_arch_agnostic_bitcode_libraries = ["opencl.bc",
+                                         "ocml.bc",
+                                         "ockl.bc",
+                                         "oclc_finite_only_off.bc",
+                                         "oclc_daz_opt_off.bc",
+                                         "oclc_correctly_rounded_sqrt_on.bc",
+                                         "oclc_unsafe_math_off.bc",
+                                         "oclc_wavefrontsize64_on.bc"]
+  gfx_arch_id = re.search('gfx(\\d+)', _get_amdgcn_bitcode_paths.discovered_gfx_arch).group(1).strip()
+  gpu_arch_specific_bitcode_library = 'oclc_isa_version_' + gfx_arch_id + ".bc"
+  bitcode_path_dir = rocm_path_dir() + '/amdgcn/bitcode/'
+  amdgcn_bitcode_paths = {}
+  i = 1
+  for bc_lib in gpu_arch_agnostic_bitcode_libraries:
+    amdgcn_bitcode_paths['library' + str(i)] = bitcode_path_dir + bc_lib
+    i += 1
+  amdgcn_bitcode_paths['library' + str(i)] = bitcode_path_dir + gpu_arch_specific_bitcode_library
+  return amdgcn_bitcode_paths
+
+@static_vars(amdgcn_bitcode_paths = _get_amdgcn_bitcode_paths())
+def get_amdgcn_bitcode_paths():
+  return get_amdgcn_bitcode_paths.amdgcn_bitcode_paths
 
 class CompiledKernel:
 


### PR DESCRIPTION
This PR implements support for linking to AMDGCN bitcode files.

Some unit tests will link directly to this to use the contained math functions.

There is however another item that this PR does not cover: namely specifying the AMDGCN math counterparts in:

https://github.com/ROCmSoftwarePlatform/triton/blob/triton-mlir-phase-2/python/triton/language/libdevice.py

Other unit tests use the functionality in this file and this will be updated to include AMDGCN support in a forthcoming PR.