### PR TITLE
Fix AMDGPU gfx autodetect logic.

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1455,7 +1455,7 @@ def read_or_execute_2(cache_manager, force_compile, file_name_1, file_name_2,
 def _get_amdgpu_arch():
     try:
         rocminfo = subprocess.check_output(rocm_path_dir() + '/bin/rocminfo').decode()
-        gfx_arch = re.search('Name:\\s+.*(gfx\\d+)', rocminfo)
+        gfx_arch = re.search('Name:\\s+.*(gfx\\w+)', rocminfo)
         return gfx_arch.group(1).strip()
     except:
         return None


### PR DESCRIPTION
This fix is needed because the previous autodetect logic failed for gfx90a.