### PR TITLE
Remove FDIVOpConversion MLIR pipe stage for ROCm.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -4996,7 +4996,9 @@ void populateTritonToLLVMPatterns(mlir::LLVMTypeConverter &typeConverter,
   POPULATE_UNARY_OP(triton::PtrToIntOp, LLVM::PtrToIntOp)
 #undef POPULATE_UNARY_OP
 
+#ifndef USE_ROCM
   patterns.add<FDivOpConversion>(typeConverter, benefit);
+#endif
 
   patterns.add<ExtElemwiseOpConversion>(typeConverter, benefit);
 


### PR DESCRIPTION
This change fixes the following unit tests:

- one of the subtests in test_elementwise.py
- all the test_bin_op division failures in test_core.py/test_core_amd.py