### PR TITLE
enable masked load / store

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -1003,15 +1003,14 @@ struct LoadOpConversion
       const size_t width = std::min(totalWidth, maxWordWidth);
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
       const size_t wordNElems = width / valueElemNbits;
-      size_t size = width / valueElemNbits;
       assert(wordNElems * nWords * numVecs == numElems);
 
 #ifdef USE_ROCM
 
       Value pred = mask ? maskElems[vecStart] : int_val(1, 1);
-      for (size_t ii = 0; ii < nWords; ++ii) {
-        for (size_t s = 0; s < size; ++s) {
-          size_t elemOffset = vecStart + ii * size + s;
+      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
+        for (size_t wordElem = 0; wordElem < wordNElems; ++wordElem) {
+          size_t elemOffset = vecStart + wordIdx * wordNElems + wordElem;
 
           // get values
           Value trueVal = load(ptrElems[elemOffset]);


### PR DESCRIPTION
This PR enable masked load for Triton on ROCM.  We use the llvm Select op which takes the mask value and picks loaded Values or a false Value(either 0 or a val provided by the user).

This also fully enables vector add. 

``` 
python/tests/test_vecadd.py::test_vecadd_scf_no_mask[4-256-1] PASSED     [  5%]
python/tests/test_vecadd.py::test_vecadd_scf_no_mask[4-1024-256] PASSED  [ 10%]
python/tests/test_vecadd.py::test_vecadd_scf_mask[shape0-2-128-1] PASSED [ 15%]
python/tests/test_vecadd.py::test_vecadd_scf_mask[shape1-2-128-32] PASSED [ 21%]
python/tests/test_vecadd.py::test_vecadd_no_scf[4-256-shape0] PASSED     [ 26%]
python/tests/test_vecadd.py::test_vecadd_no_scf[2-256-shape1] PASSED     [ 31%]
python/tests/test_vecadd.py::test_vecadd_no_scf[1-256-shape2] PASSED     [ 36%]
python/tests/test_vecadd.py::test_vecadd_no_scf[4-16-shape3] PASSED      [ 42%]
python/tests/test_vecadd.py::test_vecadd_no_scf[2-64-shape4] PASSED      [ 47%]
python/tests/test_vecadd.py::test_vecadd_no_scf[1-128-shape5] PASSED     [ 52%]
python/tests/test_vecadd.py::test_vecadd_no_scf_masked[1-128-shape0] PASSED [ 57%]
python/tests/test_vecadd.py::test_vecadd_no_scf_masked[1-256-shape1] PASSED [ 63%]
python/tests/test_vecadd.py::test_vecadd_no_scf_masked[2-256-shape2] PASSED [ 68%]
python/tests/test_vecadd.py::test_vecadd_no_scf_masked[4-256-shape3] PASSED [ 73%]
python/tests/test_vecadd.py::test_vecadd_no_scf_masked_randomly PASSED   [ 78%]
python/tests/test_vecadd.py::test_vecadd_fcmp_no_scf_masked[1-128-shape0] PASSED [ 84%]
python/tests/test_vecadd.py::test_vecadd_fcmp_no_scf_masked[1-256-shape1] PASSED [ 89%]
python/tests/test_vecadd.py::test_vecadd_fcmp_no_scf_masked[2-256-shape2] PASSED [ 94%]
python/tests/test_vecadd.py::test_vecadd_fcmp_no_scf_masked[4-256-shape3] PASSED [100%]

============================== 19 passed in 8.04s ==============================
```