### PR TITLE
[Triton-MLIR] Fix test_math_op from test_core.py for AMDGPU.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -866,5 +866,7 @@ void populateElementwiseOpToLLVMPatterns(mlir::LLVMTypeConverter &typeConverter,
   // For FP64 input type, ExpOpConversionApprox will return failure and
   // ElementwiseOpConversion<math::ExpOp, math::ExpOp> defined below will call
   // __nv_expf for higher-precision calculation
+#ifndef USE_ROCM
   patterns.add<ExpOpConversionApprox>(typeConverter, benefit);
+#endif
 }


### PR DESCRIPTION
The only test_math_op function that does not work was `exp` so this commit fixes that.