### PR TITLE
[Triton-MLIR] Always link in AMDGCN bitcode libraries.

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -559,7 +559,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
 # # test extern
 # # -------------
 if torch.version.hip is not None:
-  e_libs = triton.get_amdgcn_bitcode_paths()
+  e_libs = None
 else:
   e_libs = {"libdevice": '/usr/local/cuda/nvvm/libdevice/libdevice.10.bc'}
 

--- a/python/test/unit/language/test_elementwise.py
+++ b/python/test/unit/language/test_elementwise.py
@@ -33,7 +33,7 @@ torch_ops = {
 }
 
 if torch.version.hip is not None:
-  e_libs = triton.get_amdgcn_bitcode_paths()
+  e_libs = None
 else:
   e_libs = {"libdevice": '/usr/local/cuda/nvvm/libdevice/libdevice.10.bc'}
 

--- a/python/test/unit/language/test_ext_elemwise.py
+++ b/python/test/unit/language/test_ext_elemwise.py
@@ -6,9 +6,6 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
-if torch.version.hip is not None:
-    e_libs = triton.get_amdgcn_bitcode_paths()
-
 @pytest.mark.parametrize('num_warps, block_size, iter_size', [
     [4, 256, 1],
     [4, 1024, 256],
@@ -35,12 +32,8 @@ def test_sin_no_mask(num_warps, block_size, iter_size):
     y = torch.empty((block_size,), device=x.device, dtype=x.dtype)
 
     grid = lambda EA: (x.shape.numel() // (block_size),)
-    if torch.version.hip is not None:
-        kernel[grid](x_ptr=x, y_ptr=y,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps, extern_libs=e_libs)
-    else:
-        kernel[grid](x_ptr=x, y_ptr=y,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
+    kernel[grid](x_ptr=x, y_ptr=y,
+                 block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
 
     golden_y = torch.sin(x)
     assert_close(y, golden_y, rtol=1e-7, atol=1e-7)
@@ -78,12 +71,8 @@ def test_fmin_no_mask(num_warps, block_size, iter_size):
     z = torch.empty((block_size,), device=x.device, dtype=x.dtype)
 
     grid = lambda EA: (x.shape.numel() // (block_size),)
-    if torch.version.hip is not None:
-        kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps, extern_libs=e_libs)
-    else:
-        kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
+    kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z,
+                 block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
 
     golden_z = torch.minimum(x, y)
     assert_close(z, golden_z, rtol=1e-7, atol=1e-7)
@@ -127,12 +116,8 @@ def test_fmad_rn_no_mask(num_warps, block_size, iter_size):
     w = torch.empty((block_size,), device=x.device, dtype=x.dtype)
 
     grid = lambda EA: (x.shape.numel() // (block_size),)
-    if torch.version.hip is not None:
-        kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z, w_ptr=w,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps, extern_libs=e_libs)
-    else:
-        kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z, w_ptr=w,
-                     block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
+    kernel[grid](x_ptr=x, y_ptr=y, z_ptr=z, w_ptr=w,
+                 block_size=x.shape[0], iter_size=iter_size, num_warps=num_warps)
 
     golden_w = x * y + z
     assert_close(w, golden_w, rtol=1e-7, atol=1e-7)
@@ -188,7 +173,7 @@ def kernel(X, Y, BLOCK: tl.constexpr):
     # triton result
     y = torch.zeros(shape, dtype=x.dtype, device="cuda")
     if torch.version.hip is not None:
-      kernel[(1,)](x, y, BLOCK=shape[0], extern_libs=e_libs)
+      kernel[(1,)](x, y, BLOCK=shape[0], extern_libs=None)
     else:
       kernel[(1,)](x, y, BLOCK=shape[0], extern_libs={"libdevice": lib_path})
     # compare

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -25,7 +25,7 @@ from .runtime import (
     KernelInterface,
 )
 from .runtime.jit import jit
-from .compiler import compile, CompilationError, get_amdgcn_bitcode_paths
+from .compiler import compile, CompilationError
 from . import language
 from . import testing
 from . import ops

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1609,6 +1609,10 @@ def compile(fn, **kwargs):
     extern_libs = kwargs.get("extern_libs", dict())
     # build compilation stages
     if torch.version.hip is not None:
+        if extern_libs is None:
+            extern_libs = get_amdgcn_bitcode_paths()
+        else:
+            extern_libs.update(get_amdgcn_bitcode_paths())
         gfx_arch = os.environ.get('MI_GPU_ARCH', compile.discovered_gfx_arch)
         if gfx_arch is None:
             raise RuntimeError('gfx_arch is None (not specified)')
@@ -1738,9 +1742,9 @@ def _get_amdgcn_bitcode_paths():
   amdgcn_bitcode_paths = {}
   i = 1
   for bc_lib in gpu_arch_agnostic_bitcode_libraries:
-    amdgcn_bitcode_paths['library' + str(i)] = bitcode_path_dir + bc_lib
+    amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + bc_lib
     i += 1
-  amdgcn_bitcode_paths['library' + str(i)] = bitcode_path_dir + gpu_arch_specific_bitcode_library
+  amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + gpu_arch_specific_bitcode_library
   return amdgcn_bitcode_paths
 
 @static_vars(amdgcn_bitcode_paths = _get_amdgcn_bitcode_paths())


### PR DESCRIPTION
This fixes the modulus (%) operator and many other issues (now and in the future).

The CUDA bitcode libraries are linked in here:

https://github.com/ROCmSoftwarePlatform/triton/blob/triton-mlir-IFU/lib/Target/PTX/PTXTranslation.cpp#L34-L70

The net effect is that they are *always* linked in.

So we do the same for AMDGCN (in Python).

This PR along with the cuda2gcn wrapper will enable many of the advanced math functions to work without intervention from the user.