### PR TITLE
[Triton-MLIR] Triton compile fix signature

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1603,7 +1603,6 @@ def compile(fn, **kwargs):
     # has to be a path to a file
     context = _triton.ir.context()
     asm = dict()
-    signature = kwargs.get("signature", "")
     constants = kwargs.get("constants", dict())
     num_warps = kwargs.get("num_warps", 4)
     num_stages = kwargs.get("num_stages", 3 if capability >= 75 else 2)


### PR DESCRIPTION
The parsing of the signature args is unnecessary here as that is done later in the function.

The signature argument is specified in the call to triton.compile.  For example:

kernel = triton.compile(empty_kernel,
                        **signature**="*fp32,i32,i32",
                        constants={"BLOCK": 256})


