### PR TITLE
[ROCM] First part of atomicrmw implementation.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1,3 +1,4 @@
+#include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
 
@@ -471,6 +472,155 @@ struct AtomicRMWOpConversion
             converter, allocation, smem, benefit),
         LoadStoreConversionBase(axisAnalysisPass) {}
 
+#ifdef USE_ROCM
+  /// Try to match the mlir::triton::RMWOp to LLVM::AtomicBinOp.
+  static Optional<LLVM::AtomicBinOp> matchAtomicOp(RMWOp atomicOp) {
+    switch (atomicOp) {
+    case RMWOp::AND:
+      return LLVM::AtomicBinOp::_and;
+    case RMWOp::OR:
+      return LLVM::AtomicBinOp::_or;
+    case RMWOp::XOR:
+      return LLVM::AtomicBinOp::_xor;
+    case RMWOp::ADD:
+      return LLVM::AtomicBinOp::add;
+    case RMWOp::FADD:
+      return LLVM::AtomicBinOp::fadd;
+    case RMWOp::MAX:
+      return LLVM::AtomicBinOp::max;
+    case RMWOp::MIN:
+      return LLVM::AtomicBinOp::min;
+    case RMWOp::UMAX:
+      return LLVM::AtomicBinOp::umax;
+    case RMWOp::UMIN:
+      return LLVM::AtomicBinOp::umin;
+    case RMWOp::XCHG:
+      return LLVM::AtomicBinOp::xchg;
+    default:
+      return llvm::None;
+    }
+    llvm_unreachable("Invalid RMWOp");
+  }
+
+  /// Clones a segment of ops [start, end) and erases the original.
+  static void moveOpsRange(ValueRange oldResult, ValueRange newResult,
+                           Block::iterator start, Block::iterator end,
+                           ConversionPatternRewriter &rewriter) {
+    BlockAndValueMapping mapping;
+    mapping.map(oldResult, newResult);
+    SmallVector<Operation *, 2> opsToErase;
+    for (auto it = start; it != end; ++it) {
+      rewriter.clone(*it, mapping);
+      opsToErase.push_back(&*it);
+    }
+    for (auto *it : opsToErase)
+      rewriter.eraseOp(it);
+  }
+
+  LogicalResult
+  matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    MLIRContext *ctx = rewriter.getContext();
+
+    auto atomicRmwAttr = op.atomic_rmw_op();
+    Value ptr = op.ptr();
+    Value val = op.val();
+
+    Value llPtr = adaptor.ptr();
+    Value llVal = adaptor.val();
+    Value llMask = adaptor.mask();
+
+    auto valElements = getElementsFromStruct(loc, llVal, rewriter);
+    auto ptrElements = getElementsFromStruct(loc, llPtr, rewriter);
+    auto maskElements = getElementsFromStruct(loc, llMask, rewriter);
+
+    Value opResult = op.getResult();
+    auto valueTy = opResult.getType().dyn_cast<RankedTensorType>();
+    Type valueElemTy =
+        valueTy ? getTypeConverter()->convertType(valueTy.getElementType())
+                : opResult.getType();
+    const size_t valueElemNbits = valueElemTy.getIntOrFloatBitWidth();
+    auto elemsPerThread = getElemsPerThread(val.getType());
+    // vec = 1 for scalar
+    auto vec = getVectorSize(ptr);
+    Value mask = int_val(1, 1);
+    auto tid = tid_val();
+    // tensor
+    if (valueTy) {
+      auto valTy = val.getType().cast<RankedTensorType>();
+      vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
+      // mask
+      auto shape = valueTy.getShape();
+      auto numElements = product(shape);
+      mask = and_(mask, icmp_slt(mul(tid, i32_val(elemsPerThread)),
+                                 i32_val(numElements)));
+    }
+
+    auto vecTy = vec_ty(valueElemTy, vec);
+    SmallVector<Value> resultVals(elemsPerThread);
+    for (size_t i = 0; i < elemsPerThread; i += vec) {
+      Value rmwVal = undef(vecTy);
+      for (int ii = 0; ii < vec; ++ii) {
+        Value iiVal = createIndexAttrConstant(
+            rewriter, loc, getTypeConverter()->getIndexType(), ii);
+        rmwVal = insert_element(vecTy, rmwVal, valElements[i + ii], iiVal);
+      }
+
+      Value rmwPtr = ptrElements[i];
+      Value rmwMask = maskElements[i];
+      rmwMask = and_(rmwMask, mask);
+      if (!valueTy) {
+        rmwMask = and_(rmwMask, icmp_eq(tid, i32_val(0)));
+      }
+
+      // Build blocks to bypass the atomic instruction for ~rmwMask.
+      auto *curBlock = rewriter.getInsertionBlock();
+      auto *atomicBlock = rewriter.createBlock(
+          curBlock->getParent(), std::next(Region::iterator(curBlock)));
+      auto *endBlock = rewriter.createBlock(
+          atomicBlock->getParent(), std::next(Region::iterator(atomicBlock)));
+
+      // Operations range to be moved to `endBlock`.
+      auto opsToMoveStart = op->getIterator();
+      auto opsToMoveEnd = curBlock->back().getIterator();
+      rewriter.setInsertionPointToEnd(curBlock);
+
+      rewriter.create<LLVM::CondBrOp>(loc, rmwMask, atomicBlock, endBlock);
+      rewriter.setInsertionPointToEnd(atomicBlock);
+
+      auto maybeKind = matchAtomicOp(atomicRmwAttr);
+      auto atom = rewriter.create<LLVM::AtomicRMWOp>(
+          loc, valueElemTy, *maybeKind, rmwPtr, valElements[i],
+          LLVM::AtomicOrdering::monotonic);
+      rewriter.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
+
+      rewriter.setInsertionPointToEnd(endBlock);
+      Value ret = atom.getResult();
+      if (valueTy) {
+        for (int ii = 0; ii < vec; ++ii) {
+          resultVals[i + ii] =
+              vec == 1 ? ret : extract_element(valueElemTy, ret, idx_val(ii));
+        }
+      } else {
+        rewriter.replaceOp(op, {atom});
+      }
+
+      // Move the all the instructions after tt.atomic to `endBlock`.
+      moveOpsRange(opResult, ret, std::next(opsToMoveStart),
+                   std::next(opsToMoveEnd), rewriter);
+    }
+    if (valueTy) {
+      Type structTy = getTypeConverter()->convertType(valueTy);
+      Value resultStruct =
+          getStructFromElements(loc, resultVals, rewriter, structTy);
+      rewriter.replaceOp(op, {resultStruct});
+    }
+    return success();
+  }
+
+#else  // USE_ROCM
+
   LogicalResult
   matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -609,6 +759,7 @@ struct AtomicRMWOpConversion
     }
     return success();
   }
+#endif // USE_ROCM
 };
 
 struct InsertSliceOpConversion


### PR DESCRIPTION
Added implementation for scalar atomics:
- atomic_add - uint, int and float types
- atomic_min/max - uint and int

atomic_min/max for float is not supported in LLVM 14. We can wait to moving in upstream to latest LLVM or have to implement these atomics with inline asm.

Tensor variants and atomic_cas, as well as rest of scalar atomics will be introduced with next PR(s).