### PR TITLE
[ROCM] Fix incorrect llvm.bitcast creation.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -128,7 +128,7 @@ struct LoadOpConversion
 
           // get values
           Value trueVal = load(ptrElems[elemOffset]);
-          Value zeroVal = bitcast(i32_val(0), valueElemTy);
+          Value zeroVal = bitcast(int_val(valueElemNbits, 0), valueElemTy);
           Value falseVal = other ? otherElems[elemOffset] : zeroVal;
 
           // select value based on mask
@@ -340,7 +340,8 @@ struct StoreOpConversion
           elem = bitcast(elem, valueElemTy);
 #ifdef USE_ROCM
           Value maskVal = llMask ? maskElems[vecStart] : int_val(1, 1);
-          Value ret = select(maskVal, elem , bitcast(i32_val(0), valueElemTy));
+          Value ret = select(maskVal, elem,
+                             bitcast(int_val(valueElemNbits, 0), valueElemTy));
           store(ret, ptrElems[elemOffset]);
         }
       }

--- a/test/Conversion/AMDGPU/load_store.mlir
+++ b/test/Conversion/AMDGPU/load_store.mlir
@@ -1,0 +1,16 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm | FileCheck --check-prefixes=CHECK,GCN %s
+
+// Check load instructin doesn't generate incorrect bitcast.
+module attributes {"triton_gpu.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @test_float16_bitcast
+  func public @test_float16_bitcast(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %true = arith.constant true
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = tt.addptr %arg0, %0 : !tt.ptr<f16>, i32
+    %2 = tt.load %1 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : f16
+    // GCN: llvm.bitcast {{.*}} : i16 to f16
+    tt.store %1, %2 : f16
+    // GCN: llvm.bitcast {{.*}} : i16 to f16
+    return
+  }
+}


### PR DESCRIPTION
Before the patch tt.load and tt.store generated incorrect bitcasts like `%f = llvm.bitcast %i : i32 to f16` (source and destination bitcast' types should have same bitwidth).