### PR TITLE
Eliminate the need to create environment variable for ROCm builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 
-# Default build for this branch is ROCm support
+# Enable TRITON_USE_ROCM for ROCm support
+option(TRITON_USE_ROCM "Build with ROCm/AMDGPU support" OFF)
 if(DEFINED ENV{TRITON_USE_ROCM})
 set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}" CACHE BOOL "" FORCE)
 endif()

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tarfile
 import urllib.request
+import torch
 from distutils.version import LooseVersion
 from typing import NamedTuple
 
@@ -146,6 +147,8 @@ class CMakeBuild(build_ext):
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
             "-DLLVM_EXTERNAL_LIT=" + lit_dir,
         ] + thirdparty_cmake_args
+        if torch.version.hip is not None:
+            cmake_args.append("-DTRITON_USE_ROCM=ON")
 
         # configuration
         cfg = get_build_type()


### PR DESCRIPTION
This PR eliminates the need to pollute the environment with TRITON_USE_ROCM by making it a configurable cmake parameter.

The parameter is conditionally set in setup.py if a ROCm platform is detected.