### PR TITLE
Add fixes for cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 
-# Default build for this branch is ROCm support
+# Enable TRITON_USE_ROCM for ROCm support
+option(TRITON_USE_ROCM "Build with ROCm/AMDGPU support" OFF)
 if(DEFINED ENV{TRITON_USE_ROCM})
 set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}" CACHE BOOL "" FORCE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 
 # Default build for this branch is ROCm support
-option(TRITON_USE_ROCM "Build with ROCm/AMDGPU support" ON)
 if(DEFINED ENV{TRITON_USE_ROCM})
 set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}" CACHE BOOL "" FORCE)
 endif()

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tarfile
 import urllib.request
+import torch
 from distutils.version import LooseVersion
 from typing import NamedTuple
 
@@ -146,6 +147,8 @@ class CMakeBuild(build_ext):
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
             "-DLLVM_EXTERNAL_LIT=" + lit_dir,
         ] + thirdparty_cmake_args
+        if torch.version.hip is not None:
+            cmake_args.append("-DTRITON_USE_ROCM=ON")
 
         # configuration
         cfg = get_build_type()

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1731,24 +1731,27 @@ def compile(fn, **kwargs):
 
 @static_vars(discovered_gfx_arch = _get_amdgpu_arch())
 def _get_amdgcn_bitcode_paths():
-  gpu_arch_agnostic_bitcode_libraries = ["opencl.bc",
-                                         "ocml.bc",
-                                         "ockl.bc",
-                                         "oclc_finite_only_off.bc",
-                                         "oclc_daz_opt_off.bc",
-                                         "oclc_correctly_rounded_sqrt_on.bc",
-                                         "oclc_unsafe_math_off.bc",
-                                         "oclc_wavefrontsize64_on.bc"]
-  gfx_arch_id = re.search('gfx(\\w+)', _get_amdgcn_bitcode_paths.discovered_gfx_arch).group(1).strip()
-  gpu_arch_specific_bitcode_library = 'oclc_isa_version_' + gfx_arch_id + ".bc"
-  bitcode_path_dir = rocm_path_dir() + '/amdgcn/bitcode/'
-  amdgcn_bitcode_paths = {}
-  i = 1
-  for bc_lib in gpu_arch_agnostic_bitcode_libraries:
-    amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + bc_lib
-    i += 1
-  amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + gpu_arch_specific_bitcode_library
-  return amdgcn_bitcode_paths
+  if torch.version.hip is not None:
+      gpu_arch_agnostic_bitcode_libraries = ["opencl.bc",
+                                             "ocml.bc",
+                                             "ockl.bc",
+                                             "oclc_finite_only_off.bc",
+                                             "oclc_daz_opt_off.bc",
+                                             "oclc_correctly_rounded_sqrt_on.bc",
+                                             "oclc_unsafe_math_off.bc",
+                                             "oclc_wavefrontsize64_on.bc"]
+      gfx_arch_id = re.search('gfx(\\w+)', _get_amdgcn_bitcode_paths.discovered_gfx_arch).group(1).strip()
+      gpu_arch_specific_bitcode_library = 'oclc_isa_version_' + gfx_arch_id + ".bc"
+      bitcode_path_dir = rocm_path_dir() + '/amdgcn/bitcode/'
+      amdgcn_bitcode_paths = {}
+      i = 1
+      for bc_lib in gpu_arch_agnostic_bitcode_libraries:
+        amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + bc_lib
+        i += 1
+      amdgcn_bitcode_paths['library_' + str(i)] = bitcode_path_dir + gpu_arch_specific_bitcode_library
+      return amdgcn_bitcode_paths
+  else:
+      return {}
 
 @static_vars(amdgcn_bitcode_paths = _get_amdgcn_bitcode_paths())
 def get_amdgcn_bitcode_paths():


### PR DESCRIPTION
Add changes to build `triton-mlir-pyt20` on cuda and also to eliminate the need for the TRITON_USE_ROCM env var.