### PR TITLE
[Test] Enable triton-translate build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.6)
+
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 include(ExternalProject)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -26,35 +26,37 @@ target_link_libraries(triton-opt PRIVATE
 mlir_check_all_link_libraries(triton-opt)
 
 
-# add_llvm_executable(triton-translate triton-translate.cpp PARTIAL_SOURCES_INTENDED)
-#llvm_update_compile_flags(triton-translate)
-# target_link_libraries(triton-translate PRIVATE
-#         TritonAnalysis
-#         TritonTransforms
-#         TritonGPUTransforms
-#         TritonLLVMIR
-#         TritonDriver
-#         ${dialect_libs}
-#         ${conversion_libs}
+add_llvm_executable(triton-translate triton-translate.cpp PARTIAL_SOURCES_INTENDED)
+llvm_update_compile_flags(triton-translate)
+target_link_libraries(triton-translate PRIVATE
+         TritonAnalysis
+         TritonTransforms
+         TritonGPUTransforms
+         TritonLLVMIR
+         TritonPTX
+         TritonHSACO
+         ${dialect_libs}
+         ${conversion_libs}
 #         # tests
 #         TritonTestAnalysis
 
-#         LLVMCore
-#         LLVMSupport
-#         LLVMOption
-#         LLVMCodeGen
-#         LLVMAsmParser
+         LLVMCore
+         LLVMSupport
+         LLVMOption
+         LLVMCodeGen
+         LLVMAsmParser
 
-#         # MLIR core
-#         MLIROptLib
-#         MLIRIR
-#         MLIRPass
-#         MLIRSupport
-#         MLIRTransforms
-#         MLIRExecutionEngine
-#         MLIRMathToLLVM
-#         MLIRTransformUtils
-#         MLIRLLVMToLLVMIRTranslation
-#         MLIRNVVMToLLVMIRTranslation
-#         )
-# mlir_check_all_link_libraries(triton-translate)
+         # MLIR core
+         MLIROptLib
+         MLIRIR
+         MLIRPass
+         MLIRSupport
+         MLIRTransforms
+         MLIRExecutionEngine
+         MLIRMathToLLVM
+         MLIRTransformUtils
+         MLIRLLVMToLLVMIRTranslation
+         MLIRNVVMToLLVMIRTranslation
+         MLIRROCDLToLLVMIRTranslation
+         MLIRSCFToStandard
+         )

--- a/test/Target/tritongpu_to_llvmir.mlir
+++ b/test/Target/tritongpu_to_llvmir.mlir
@@ -1,4 +1,4 @@
-// RUN: %PYTHON -m triton.tools.aot %s --target=llvm-ir --sm=80 | FileCheck %s
+// RUN: triton-translate --target=llvmir --sm=80 %s | FileCheck %s
 
 // == LLVM IR check begin ==
 // CHECK-LABEL: ; ModuleID = 'LLVMDialectModule'


### PR DESCRIPTION
... and use it in tests instead of python module triton.tools.aot.

The tool is more useful to test/debug at least for LLVM IR generation.

If the patch is ok, the next patch is to update the `triton-translate` util functionality to dump HSACO object file and AMDGCN assembler.