### PR TITLE
[BACKEND] Support int64 constant (#1050)

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -476,11 +476,14 @@ void init_triton_ir(py::module &&m) {
              return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
                  loc, v, self.getI32Type()));
            })
+      .def("get_int64",
+           [](mlir::OpBuilder &self, int64_t v) -> mlir::Value {
+             auto loc = self.getUnknownLoc();
+             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+                 loc, v, self.getI64Type()));
+           })
       // .def("get_uint32", &ir::builder::get_int32, ret::reference)
-      // .def("get_int64", [](ir::builder *self, int64_t v) { return
-      // self->get_int64((uint64_t)v); }, ret::reference) .def("get_uint64",
-      // &ir::builder::get_int64, ret::reference) .def("get_float16",
-      // &ir::builder::get_float16, ret::reference)
+      // .def("get_float16", &ir::builder::get_float16, ret::reference)
       .def("get_float32",
            [](mlir::OpBuilder &self, float v) -> mlir::Value {
              auto loc = self.getUnknownLoc();


### PR DESCRIPTION
Code snippet from a case in torchbench.

```Python
@triton.jit
def kernel(in_ptr0, out_ptr0, xnumel, rnumel, XBLOCK : tl.constexpr, RBLOCK : tl.constexpr):
    xnumel = 2
    rnumel = 77
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
    xmask = xindex < xnumel
    rbase = tl.arange(0, RBLOCK)[None, :]
    _tmp1 = tl.zeros([XBLOCK, RBLOCK], tl.int64) + -9223372036854775808
```