### PR TITLE
[ROCM] Implement next part of atomics.

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -892,6 +892,7 @@ def atomic_max(ptr: tl.tensor,
                                                        val.handle,
                                                        mask.handle),
                              val.type)
+    # ROCM TODO: implement atomic_max/min for f32 as they are supported by MI cards.
     # for float
     # return atomic_smax(i_ptr, i_val) if val >= 0
     # return atomic_umin(i_ptr, i_val) if val < 0


### PR DESCRIPTION
- fixed scalar atomic_rmw implementation for fmin/fmax for f32
- fixed tensor atomic_rmw
- added atomic_cas implementation.

TODO:
- fix atomic_rmw for f16
- implement fmin/fmax for f32 with native instructions (asm inline in case of LLVM 14) instead of tweak used as for NV (added comment in python/triton/language/semantic.py).