### PR TITLE
[Test] Fix ctest tests

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
@@ -134,8 +134,6 @@ struct Modifier {
 
   Operand *newAddrOperand(mlir::Value addr, StringRef constraint);
 
-  Operand *newEmptyOperand(std::string arg);
-
   Modifier *newModifier(StringRef modifier, StringRef arg);
 
   llvm::SmallVector<Operand *, 4> getAllArgs() const;

--- a/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
@@ -134,6 +134,8 @@ struct Modifier {
 
   Operand *newAddrOperand(mlir::Value addr, StringRef constraint);
 
+  Operand *newEmptyOperand(std::string arg);
+
   Modifier *newModifier(StringRef modifier, StringRef arg);
 
   llvm::SmallVector<Operand *, 4> getAllArgs() const;

--- a/lib/Conversion/TritonGPUToLLVM/GCNAsmFormat.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GCNAsmFormat.cpp
@@ -125,17 +125,6 @@ GCNInstr::Operand *GCNBuilder::newAddrOperand(mlir::Value addr,
   return opr;
 }
 
-GCNInstr::Operand *GCNBuilder::newEmptyOperand(std::string arg) {
-  auto *opr = newOperand();
-  opr->repr = [arg](int idx) -> std::string {
-    std::stringstream ss;
-    ss << arg;
-    return ss.str();
-  };
-
-  return opr;
-}
-
 std::string GCNBuilder::dump() const {
   llvm::SmallVector<std::string> lines;
   for (auto &exec : executions) {
@@ -179,7 +168,6 @@ std::string GCNInstrExecution::dump() const {
   } else {
     os << instrRepr << " " << argsRepr;
   }
-  os << ";";
   os.flush();
   return osStr;
 }

--- a/lib/Conversion/TritonGPUToLLVM/GCNAsmFormat.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GCNAsmFormat.cpp
@@ -125,6 +125,17 @@ GCNInstr::Operand *GCNBuilder::newAddrOperand(mlir::Value addr,
   return opr;
 }
 
+GCNInstr::Operand *GCNBuilder::newEmptyOperand(std::string arg) {
+  auto *opr = newOperand();
+  opr->repr = [arg](int idx) -> std::string {
+    std::stringstream ss;
+    ss << arg;
+    return ss.str();
+  };
+
+  return opr;
+}
+
 std::string GCNBuilder::dump() const {
   llvm::SmallVector<std::string> lines;
   for (auto &exec : executions) {
@@ -164,10 +175,11 @@ std::string GCNInstrExecution::dump() const {
 
   std::string modsRepr = strJoin(modReprs, " ");
   if (!modsRepr.empty()) {
-    os << instrRepr << " " << argsRepr << ", " << modsRepr;
+    os << instrRepr << " " << argsRepr << " " << modsRepr;
   } else {
     os << instrRepr << " " << argsRepr;
   }
+  os << ";";
   os.flush();
   return osStr;
 }

--- a/unittest/Conversion/TritonGPUToLLVM/GcnAsmFormatTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/GcnAsmFormatTest.cpp
@@ -45,7 +45,7 @@ TEST_F(GcnAsmFormatTest, basic) {
   auto &mov = *builder.create("v_mov_b32");
 
   mov(val, cst);
-  ASSERT_EQ(builder.dump(), "v_mov_b32 $0, 0x1;");
+  ASSERT_EQ(builder.dump(), "v_mov_b32 $0, 0x1");
 
   auto constraints = builder.getConstraints();
   ASSERT_EQ(constraints, "=v");
@@ -59,7 +59,7 @@ TEST_F(GcnAsmFormatTest, complexInstruction) {
   Value addrVal = v[0];
   auto dst = builder.newOperand("=v");
   auto addr = builder.newAddrOperand(addrVal, "v");
-  auto offOpr = builder.newEmptyOperand("off");
+  auto offOpr = builder.newConstantOperand("off");
 
   auto offsetMod = builder.newModifier("offset", std::to_string(offset));
 
@@ -68,7 +68,7 @@ TEST_F(GcnAsmFormatTest, complexInstruction) {
   // Link the instruction to operands
   ld({addr, dst, offOpr}, {offsetMod});
 
-  EXPECT_EQ(builder.dump(), "global_load_ushort $1, $0, off offset:128;");
+  EXPECT_EQ(builder.dump(), "global_load_ushort $1, $0, off offset:128");
 
   auto constraints = builder.getConstraints();
   ASSERT_EQ(constraints, "=v,v");

--- a/unittest/Conversion/TritonGPUToLLVM/GcnAsmFormatTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/GcnAsmFormatTest.cpp
@@ -45,7 +45,7 @@ TEST_F(GcnAsmFormatTest, basic) {
   auto &mov = *builder.create("v_mov_b32");
 
   mov(val, cst);
-  ASSERT_EQ(builder.dump(), "v_mov_b32 $0, 0x1 ;");
+  ASSERT_EQ(builder.dump(), "v_mov_b32 $0, 0x1;");
 
   auto constraints = builder.getConstraints();
   ASSERT_EQ(constraints, "=v");
@@ -59,12 +59,14 @@ TEST_F(GcnAsmFormatTest, complexInstruction) {
   Value addrVal = v[0];
   auto dst = builder.newOperand("=v");
   auto addr = builder.newAddrOperand(addrVal, "v");
+  auto offOpr = builder.newEmptyOperand("off");
+
   auto offsetMod = builder.newModifier("offset", std::to_string(offset));
 
   auto &ld = builder.create<GCNMemInstr>("global_load")->load_type(width);
 
   // Link the instruction to operands
-  ld({addr, dst}, {offsetMod});
+  ld({addr, dst, offOpr}, {offsetMod});
 
   EXPECT_EQ(builder.dump(), "global_load_ushort $1, $0, off offset:128;");
 


### PR DESCRIPTION
Fixed GcnAsmFormatTest.basic and GcnAsmFormatTest.complexInstruction tests
- Added lost "off" operand
- Removed semicolon after instructions
- Removed redundant comma between args and modifiers