### PR TITLE
Remove torch import in setup.py to check for ROCm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,9 @@ option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 
 # Enable TRITON_USE_ROCM for ROCm support
-option(TRITON_USE_ROCM "Build with ROCm/AMDGPU support" OFF)
-if(DEFINED ENV{TRITON_USE_ROCM})
-set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}" CACHE BOOL "" FORCE)
+find_package(HIP)
+if(HIP_FOUND)
+  set(TRITON_USE_ROCM ON)
 endif()
 
 # Ensure Python3 vars are set correctly

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 import tarfile
 import urllib.request
-import torch
 from distutils.version import LooseVersion
 from typing import NamedTuple
 
@@ -147,8 +146,6 @@ class CMakeBuild(build_ext):
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
             "-DLLVM_EXTERNAL_LIT=" + lit_dir,
         ] + thirdparty_cmake_args
-        if torch.version.hip is not None:
-            cmake_args.append("-DTRITON_USE_ROCM=ON")
 
         # configuration
         cfg = get_build_type()


### PR DESCRIPTION
Remove the Triton-Pytorch (weak) circular dependency by eliminating the torch import in setup.py.