### PR TITLE
Remove str conversion on bytes for llir compile stage

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1715,7 +1715,7 @@ def compile(fn, **kwargs):
                 fn_cache_manager.put(next_module, f"{name}.{ir}")
         if os.path.exists(path):
             metadata["ctime"][ir] = os.path.getctime(path)
-        asm[ir] = next_module if ir == "cubin" else str(next_module)
+        asm[ir] = next_module if ir in ("cubin", "llir") else str(next_module)
         if ir == "llir" and "shared" not in metadata:
             metadata["shared"] = _triton.get_shared_memory_size(module)
         if ir == "ptx":


### PR DESCRIPTION
Pytorch CI makes use of the `-bb` flag in `run_test.py` this will throw errors when comparing bytes/bytesarray to string.

This resulted in many errors in the torchinductor unit tests:
```
_______ TestInductorOpInfoCUDA.test_comprehensive_logical_or_cuda_int64 ________
concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/_inductor/codecache.py", line 533, in _worker_compile
    kernel.precompile(warm_cache_only_with_cc=cc)
  File "/opt/conda/lib/python3.8/site-packages/torch/_inductor/triton_ops/autotune.py", line 58, in precompile
    self.launchers = [
  File "/opt/conda/lib/python3.8/site-packages/torch/_inductor/triton_ops/autotune.py", line 59, in <listcomp>
    self._precompile_config(c, warm_cache_only_with_cc)
  File "/opt/conda/lib/python3.8/site-packages/torch/_inductor/triton_ops/autotune.py", line 72, in _precompile_config
    triton.compile(
  File "/var/lib/jenkins/triton/python/triton/compiler.py", line 1718, in compile
    asm[ir] = next_module if ir == "cubin" else str(next_module)
BytesWarning: str() on a bytes instance
"""
```

After some triaging it was found that `next_module` in `compiler.py` is of type bytes in the llir stage and is the source of the error.

The change suggested will ignore the bytes to str conversion if the compile stage is llir, this is identical to how cubin stage is already handled.