### PR TITLE
[ROCM] Enable part of tl.dot operations.

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -114,6 +114,9 @@ bool supportMMA(triton::DotOp op, int version) {
   // Refer to mma section for the data type supported by Volta and Hopper
   // Tensor Core in
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-fragment-mma-884-f16
+#ifdef USE_ROCM
+  return false;
+#endif
   auto aElemTy = op.a().getType().cast<RankedTensorType>().getElementType();
   auto bElemTy = op.b().getType().cast<RankedTensorType>().getElementType();
   if (aElemTy.isF32() && bElemTy.isF32()) {
@@ -128,6 +131,9 @@ bool supportMMA(Value value, int version) {
   // types of both the operands are identical here.
   assert((version == 1 || version == 2) &&
          "Unexpected MMA layout version found");
+#ifdef USE_ROCM
+  return false;
+#endif
   auto elemTy = value.getType().cast<RankedTensorType>().getElementType();
   return elemTy.isF16() || elemTy.isBF16() ||
          (elemTy.isF32() && version >= 2) ||

--- a/lib/Dialect/TritonGPU/Transforms/Combine.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Combine.cpp
@@ -862,6 +862,9 @@ public:
 // -----------------------------------------------------------------------------
 namespace {
 int computeCapabilityToMMAVersion(int computeCapability) {
+#ifdef USE_ROCM
+  return 1;
+#endif
   if (computeCapability < 70) {
     return 0;
   } else if (computeCapability < 80) {


### PR DESCRIPTION
The change enables fall-through FMA path for the ROCM. It works for the float32 type and not all the tensors sizes. The change switches off reporting MMA and async ops support to avoid NV asm inline generation.