### PR TITLE
[DO NOT MERGE] Use kernel arguments preloaded on SGPRs.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -54,13 +54,13 @@ def get_llvm_package_info():
     # download if nothing is installed
     system = platform.system()
     system_suffix = {"Linux": "linux-gnu-ubuntu-18.04", "Darwin": "apple-darwin"}[system]
-    use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
+    use_assert_enabled_llvm = False
     if use_assert_enabled_llvm:
         name = 'llvm+mlir-14.0.0-x86_64-{}-assert'.format(system_suffix)
         url = "https://github.com/shintaro-iwasaki/llvm-releases/releases/download/llvm-14.0.0-329fda39c507/{}.tar.xz".format(name)
     else:
-        name = 'clang+llvm-14.0.0-x86_64-{}'.format(system_suffix)
-        url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/{}.tar.xz".format(name)
+        name = 'LLVM-14.0.0-Linux'
+        url = "https://github.com/whchung/llvm-project/releases/download/exp-sgpr-0.2/LLVM-14.0.0-Linux.tar.gz"
     return Package("llvm", name, url, "lib", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 

--- a/python/triton/language/make_cuda2gcn.sh
+++ b/python/triton/language/make_cuda2gcn.sh
@@ -9,8 +9,8 @@ cd ROCm-Device-Libs
 git apply ../cuda2gcn.patch
 mkdir build
 cd build
-cmake .. -DCMAKE_PREFIX_PATH=$HOME/.triton/llvm/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04
-make -j4
+cmake .. -DCMAKE_PREFIX_PATH=$HOME/.triton/llvm/LLVM-14.0.0-Linux
+make -j
 
 popd
 cp ROCm-Device-Libs/build/amdgcn/bitcode/cuda2gcn.bc .


### PR DESCRIPTION
Initial commit to use kernel arguments preloaded on SGPRs.

Retrieve LLVM 14 toolchain from my personal fork.

This is a draft PR. Please do NOT merge it yet.

Perf improvements from this PR:

softmax
======
| dim1 | dim2 | execution time(us) |
|-------|-------|---------------------|
| CONFIG1 | CONFIG1 | 4.32 |
| CONFIG2 | CONFIG2 | 3.68 |
| CONFIG3 | CONFIG3 | 4.96 |

layer norm forward
=============
| dim1 | dim2 | execution time(us) |
|-------|-------|---------------------|
| CONFIG1 | CONFIG1 | 16.48 |
| CONFIG2 | CONFIG2 | 16.16 |
| CONFIG3 | CONFIG3 | 67.52 |

