### PR TITLE
Fix warning on some amdgpu arch (i.e., navi21)

### DIFF
--- a/bin/triton-translate.cpp
+++ b/bin/triton-translate.cpp
@@ -87,6 +87,14 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
       "gfx", llvm::cl::desc("AMDGCN target. e.g. '90a'"),
       llvm::cl::value_desc("architecture"), llvm::cl::init("90a"));
 
+  static llvm::cl::opt<std::string> GCNTriple(
+      "amdgcn", llvm::cl::desc("AMDGCN triple. e.g. '-amd-amdhsa'"),
+      llvm::cl::value_desc("target triple"), llvm::cl::init("-amd-amdhsa"));
+
+  static llvm::cl::opt<std::string> GCNFeatures(
+      "", llvm::cl::desc("AMDGCN features. e.g. '+sramecc,-xnack'"),
+      llvm::cl::value_desc("features"), llvm::cl::init("+sramecc,-xnack"));
+
   llvm::InitLLVM y(argc, argv);
 
   registerAsmPrinterCLOptions();
@@ -120,7 +128,9 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
                                                    ptxVersion.getValue());
   else if (targetKind == "hsaco") {
     auto [module, hsaco] =
-        ::triton::translateLLVMIRToHSACO(*llvmir, GCNArch.getValue());
+        ::triton::translateLLVMIRToHSACO(*llvmir, GCNArch.getValue(),
+                                                  GCNTriple.getValue(),
+                                                  GCNFeatures.getValue());
     llvm::outs() << hsaco;
   } else {
     llvm::errs() << "Error: Unknown target specified: " << targetKind << "\n";

--- a/include/triton/Target/HSACO/HSACOTranslation.h
+++ b/include/triton/Target/HSACO/HSACOTranslation.h
@@ -13,7 +13,9 @@ namespace triton {
 
 // Translate TritonGPU IR to HSACO code.
 std::tuple<std::string, std::string> translateLLVMIRToHSACO(llvm::Module& module,
-                                                            std::string cc);
+                                                            std::string gfx_arch,
+                                                            std::string gfx_triple,
+                                                            std::string gfx_features);
 
 } // namespace triton
 

--- a/lib/Target/HSACO/HSACOTranslation.cpp
+++ b/lib/Target/HSACO/HSACOTranslation.cpp
@@ -141,18 +141,16 @@ std::string generate_hsaco(llvm::Module* module,
 }
 
 std::tuple<std::string, std::string> llir_to_amdgcn_and_hsaco(llvm::Module* module,
-                                                   std::string cc) {
-  // create
-  std::string triple = "amdgcn-amd-amdhsa";
-  std::string proc = cc;
-  std::string features = "+sramecc,-xnack";
+                                                   std::string gfx_arch,
+                                                   std::string gfx_triple,
+                                                   std::string gfx_features) {
 
   init_llvm();
 
   // verify and store llvm
   auto module_obj = llvm::CloneModule(*module);
-  auto amdgcn = generate_amdgcn_assembly(module, triple, proc, features);
-  auto hsaco_path = generate_hsaco(module_obj.get(), triple, proc, features);
+  auto amdgcn = generate_amdgcn_assembly(module, gfx_triple, gfx_arch, gfx_features);
+  auto hsaco_path = generate_hsaco(module_obj.get(), gfx_triple, gfx_arch, gfx_features);
 
   return std::make_tuple(amdgcn, hsaco_path);
 }
@@ -162,8 +160,10 @@ std::tuple<std::string, std::string> llir_to_amdgcn_and_hsaco(llvm::Module* modu
 namespace triton {
 
 std::tuple<std::string, std::string> translateLLVMIRToHSACO(llvm::Module& module,
-                                                            std::string cc) {
-  auto hsacoCode = llir_to_amdgcn_and_hsaco(&module, cc);
+                                                            std::string gfx_arch,
+                                                            std::string gfx_triple,
+                                                            std::string gfx_features) {
+  auto hsacoCode = llir_to_amdgcn_and_hsaco(&module, gfx_arch, gfx_triple, gfx_features);
   return hsacoCode;
 }
 

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1596,7 +1596,8 @@ void init_triton_translation(py::module &m) {
 
   m.def(
       "translate_llvmir_to_hsaco",
-      [](const std::string llvmIR, std::string cc) -> std::tuple<std::string, std::string> {
+      [](const std::string llvmIR, std::string gfx_arch, std::string gfx_triple, 
+          std::string gfx_features) -> std::tuple<std::string, std::string> {
         // create LLVM module from C++
         llvm::LLVMContext context;
         std::unique_ptr<llvm::MemoryBuffer> buffer =
@@ -1605,8 +1606,7 @@ void init_triton_translation(py::module &m) {
         std::unique_ptr<llvm::Module> module =
             llvm::parseIR(buffer->getMemBufferRef(), error, context);
         // translate module to HSACO
-        auto hsacoCode =
-            triton::translateLLVMIRToHSACO(*module, cc);
+        auto hsacoCode = triton::translateLLVMIRToHSACO(*module, gfx_arch, gfx_triple, gfx_features);
         return hsacoCode;
       },
       ret::take_ownership);


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3516

now triton can compile LLVMIR based on the full ISA details instead of manual hardcoding.

I have tested it on gfx90a and gfx1030 (without sramecc and xnack features), and warnings are gone.