### PR TITLE
[ROCM] Enable float16 and int8 types for FMA based `dot` implementation.

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1040,8 +1040,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
                           for shape in [(64, 64, 64)]
                           for epilogue in ['none', 'trans', 'add-matrix', 'add-rows', 'add-cols', 'softmax', 'chain-dot']
                           for allow_tf32 in [True, False]
-                          # for dtype in ['float16', 'float32']
-                          for dtype in ['float32']
+                          for dtype in ['float16', 'float32']
                           if not (allow_tf32 and (dtype in ['float16']))] +
 
                          [(*shape_nw, col_a, col_b, 'none', allow_tf32, dtype)
@@ -1057,8 +1056,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
                           for allow_tf32 in [True]
                           for col_a in [True, False]
                           for col_b in [True, False]
-                          #for dtype in ['int8', 'float16', 'float32']])
-                          for dtype in ['float32']])
+                          for dtype in ['int8', 'float16', 'float32']])
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, device='cuda'):
     capability = torch.cuda.get_device_capability()
     if capability[0] < 7:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -2,6 +2,8 @@ from __future__ import annotations  # remove after python 3.11
 
 from typing import List, Optional, Tuple
 
+import torch
+
 from . import core as tl
 from triton._C.libtriton.triton import ir
 
@@ -1040,6 +1042,20 @@ def dot(lhs: tl.tensor,
         ret_scalar_ty = tl.float32
     M = lhs.type.shape[0]
     N = rhs.type.shape[1]
+
+    # Cast operands of types f16 and i8 since only FMA implemented yet for ROCM.
+    # So we always perform dot(f32,f32,f32)->f32 here with FMA.
+    # TODO: remove the case for MMA/MFMA implemented cases
+    if torch.version.hip is not None:
+        ret_cast_scalar_ty = tl.float32 if lhs.type.scalar.is_int() else ret_scalar_ty
+        lhs = cast(lhs, ret_cast_scalar_ty, builder)
+        rhs = cast(rhs, ret_cast_scalar_ty, builder)
+        _0 = builder.create_splat(builder.get_fp32(0), [M, N])
+        ret_ty = tl.block_type(ret_cast_scalar_ty, [M, N])
+        ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
+                        ret_ty)
+        return cast(ret, ret_scalar_ty, builder)
+
     _0 = builder.create_splat(_0, [M, N])
     ret_ty = tl.block_type(ret_scalar_ty, [M, N])
     return tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),


### PR DESCRIPTION
By default Triton generates MLIR with f32 result of the tt.dot operation on f16 typed operands. So we have
"tt.dot(f16,f16,f32)->f32" types in .ttgir. But LLVM FMA instruction requires for the same type for all three operands. So first two operands are implicitly casted f16->f32 as "unrealized_conversion_cast struct{f16,f16,...}->struct{f32,f32}". The change fixed incorrect implicit cast generation.

As the next step to improve f16 typed FMA based dot operation "tt.dot(f16,f16,f16)->f16" could be implemented (perhaps as an option).