### PR TITLE
Performance enhancements for AMDGPU atomics.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -460,7 +460,7 @@ struct AtomicCASOpConversion
     auto failureOrdering = LLVM::AtomicOrdering::monotonic;
     auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
         loc, casPtr, casCmp, casVal, successOrdering,
-        failureOrdering);
+        failureOrdering, StringRef("agent"));
     // Extract the new_loaded value from the pair.
     Value newLoaded = extract_val(valueElemTy, cmpxchg, 0);
 
@@ -662,7 +662,7 @@ struct AtomicRMWOpConversion
       // since it supports memref indexes (after moving triton to use memrefs).
       auto atom = rewriter.create<LLVM::AtomicRMWOp>(
           loc, *maybeKind, rmwPtr, valElements[i],
-          LLVM::AtomicOrdering::monotonic);
+          LLVM::AtomicOrdering::monotonic, StringRef("agent"));
       rewriter.create<LLVM::BrOp>(loc, atom.getResult(), endBlock);
 
       rewriter.setInsertionPointToStart(endBlock);

--- a/lib/Target/LLVMIR/LLVMIRTranslation.cpp
+++ b/lib/Target/LLVMIR/LLVMIRTranslation.cpp
@@ -81,6 +81,8 @@ static void amendLLVMFunc(llvm::Function *func, const NVVMMetadata &metadata) {
 #else // AMDGCN
     func->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
     func->addFnAttr("amdgpu-flat-work-group-size", "1, 1024");
+    func->addFnAttr("denormal-fp-math-f32", "preserve-sign");
+    func->addFnAttr("amdgpu-unsafe-fp-atomics", "true");
 #endif
   }
 }


### PR DESCRIPTION
Add "agent" syncscope specification to prevent large performance loss for gfx90a.

Add LLVM function attributes to enable fp32 atomic adds for archs that support it (e.g. gfx90a).

This change increases layernorm backward pass performance from 7 GB/sec to 245 gb/sec. on MI200.

Note that this change was not possible with the previous LLVM 14.0 because the AtomicRMWOp builder API did not allow the specification of the syncscope in that LLVM version.