### PR TITLE
tags must start with 'pytorch-triton-rocm-v'

### DIFF
--- a/.github/workflows/wheels-rocm.yml
+++ b/.github/workflows/wheels-rocm.yml
@@ -1,7 +1,7 @@
 name: PyTorch Triton ROCm Wheels
 
-# Build on every branch push, tag push, and pull request change:
-on: [push, pull_request]
+# Build on every branch push or tag push:
+on: push
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels-rocm.yml
+++ b/.github/workflows/wheels-rocm.yml
@@ -25,10 +25,10 @@ jobs:
 
       - name: Patch setup.py version if tagged
         # patch setup.py version for any tag starting with 'v'
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/pytorch-triton-rocm-v')
         run: |
-          # strip off initial 'v'
-          VERSION=${GITHUB_REF_NAME#v}
+          # strip off initial 'pytorch-triton-rocm-v'
+          VERSION=${GITHUB_REF_NAME#pytorch-triton-rocm-v}
           echo Version: $VERSION
           sed -i -r "s/version\=\"(.*)\"/version=\"$VERSION\"/g" python/setup.py
 


### PR DESCRIPTION
Instead of starting tags with simply 'v', this will help disambiguate future tagging of other branches.