### PR TITLE
Add if guard around policy in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.6)
 
-cmake_policy(SET CMP0116 OLD)
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
 
 include(ExternalProject)
 


### PR DESCRIPTION
This fixes error while building with old cmake versions.