### PR TITLE
[dotOp] [rocMLIR] Add LDSEncodingAttr

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -141,6 +141,51 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
 }
 
 //===----------------------------------------------------------------------===//
+// LDS Layout Encoding
+//===----------------------------------------------------------------------===//
+
+def LDSEncodingAttr : TritonGPU_Attr<"LDSEncoding"> {
+  let mnemonic = "lds";
+
+  let description = [{
+A data layout in LDS required by `rock.blockwise_gemm` from the Rock dialect.
+It breaks the k dimension into kpacksPerK and kpack. And tile A and tile B
+are required to have the following data layout:
+tile A: kpacksPerK x m x kpack
+tile B: kpacksPerK x n x kpack
+$order refers to the order of axes by the rate of changing. It is used to
+indicate which dim of the tensor refers to the k dimension.
+tile A: order = [1,0]
+tile B: order = [0,1]
+Therefore, shape[order[0]] will always refer to the k dimension.
+  }];
+
+  let parameters = (
+    ins
+    "unsigned":$kpack,
+    ArrayRefParameter<"unsigned", "order of axes by the rate of changing">:$order
+  );
+
+  let builders = [
+    AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
+                     "unsigned":$kpack), [{
+        int opIdx = dotOpEnc.getOpIdx();
+        SmallVector<unsigned, 2> order{0,0};
+
+        if (opIdx == 0) // tile A order = [1,0]
+           order[0] = 1;
+        else            // tile B order = [0,1]
+           order[1] = 1;
+
+        return $_get(context, kpack, order);
+    }]>
+  ];
+
+  let extraClassDeclaration = extraBaseClassDeclaration;
+  let hasCustomAssemblyFormat = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // Distributed Layout Encoding
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -48,11 +48,13 @@ public:
              dstDotOp.getParent() == srcMmaEncoding))
           return;
       }
+      // TODO: Make kpack one of the tuning parameters and pass it from
+      // kernel launch
+      uint32_t kpack = 4;
       auto tmpType = RankedTensorType::get(
           dstType.getShape(), dstType.getElementType(),
-          triton::gpu::SharedEncodingAttr::get(
-              mod.getContext(), dstDotOp, srcType.getShape(),
-              triton::gpu::getOrder(srcEncoding), srcType.getElementType()));
+          triton::gpu::LDSEncodingAttr::get(
+              mod.getContext(), dstDotOp, kpack));
       auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
           cvtOp.getLoc(), tmpType, cvtOp.getOperand());
       auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(


### PR DESCRIPTION
Add LDSEncodingAttr and replace `#shared` with `#lds`.
The ir now looks like follows for the test_dot kernel
``` llvm
#lds = #triton_gpu.lds<{kpack = 4, order = [1, 0]}>
#lds1 = #triton_gpu.lds<{kpack = 4, order = [0, 1]}>
%33 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked1>
%34 = tt.load %25 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked3>
%35 = triton_gpu.convert_layout %33 : (tensor<128x64xf16, #blocked1>) -> tensor<128x64xf16, #lds>
 %36 = triton_gpu.convert_layout %34 : (tensor<64x256xf16, #blocked3>) -> tensor<64x256xf16, #lds1>
// rock ops
```