### PR TITLE
[dotOp] [rocMLIR] Add MfmaEncodingAttr

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -547,6 +547,58 @@ section 9.7.13.4.1 for more details.
   let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
+//===----------------------------------------------------------------------===//
+// MFMA Layout Encoding
+//===----------------------------------------------------------------------===//
+
+def MfmaEncodingAttr : DistributedEncoding<"MfmaEncoding"> {
+  let mnemonic = "mfma";
+
+  let description = [{
+An encoding for tensors that have been produced by AMD Matrix Cores.
+It is characterized by three parameters:
+- `warpsPerCTA` describes the layout of warps within the CTA
+- `xdlopsPerWarp` describes the partition within the warp.
+   Each partition invokes one `mfma` instruction (xdlops)
+- `nonKDim` describes the size of the output block
+   (not to be confused with CUDA thread block) from the
+   chosen `mfma` instruction.
+
+Here is an example layout with `warpsPerCTA=[1,2]`, `xdlopsPerWarps=[1,2]`,
+and `nonKDim=32`. The chosen instruction is `mfma_32x32xkxf16`.
+            warp0                    warp1 = warp0 + 64
+ ------------/\-------------  -------------/\--------------
+    xdlops0        xdlops1       xdlops0         xdlops1
+ -----/\------ ------/\-----  -----/\------   -----/\-----
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[............ | ............  ............. | .............]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[0  1  ... 31 | 0  1  ... 31  64 65 ... 95  | 64 65 ... 95 ]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+[32 33 ... 63 | 32 33 ... 63  96 97 ... 127 | 96 97 ... 127]
+
+}];
+
+  let parameters = (
+    ins
+    "unsigned":$nonKDim,
+    ArrayRefParameter<"unsigned">:$warpsPerCTA,
+    ArrayRefParameter<"unsigned">:$xdlopsPerWarp
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
 
 
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -33,4 +33,5 @@ add_mlir_conversion_library(TritonGPUToLLVM
     TritonIR
     TritonGPUIR
     TritonGPUTransforms
+    MLIRRockUtility
 )

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -645,6 +645,50 @@ void LDSEncodingAttr::print(AsmPrinter &printer) const {
 }
 
 //===----------------------------------------------------------------------===//
+// MFMA encoding
+//===----------------------------------------------------------------------===//
+
+Attribute MfmaEncodingAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess().failed())
+    return {};
+  DictionaryAttr dict;
+  if (parser.parseAttribute(dict).failed())
+    return {};
+  if (parser.parseGreater().failed())
+    return {};
+
+  unsigned nonKDim = 0;
+  SmallVector<unsigned, 2> warpsPerCTA;
+  SmallVector<unsigned, 2> xdlopsPerWarp;
+
+  for (const NamedAttribute &attr : dict) {
+    if (attr.getName() == "nonKDim") {
+      if (parseUInt(parser, attr, nonKDim, "nonKDim").failed())
+        return {};
+    }
+    if (attr.getName() == "warpsPerCTA") {
+      if (parseIntArrayAttr(parser, attr, warpsPerCTA, "warpsPerCTA").failed())
+        return {};
+    }
+    if (attr.getName() == "xdlopsPerWarp") {
+        if (parseIntArrayAttr(parser, attr, xdlopsPerWarp, "xdlopsPerWarp").failed())
+        return {};
+    }
+  }
+
+  return parser.getChecked<MfmaEncodingAttr>(parser.getContext(), nonKDim,
+                                             warpsPerCTA, xdlopsPerWarp);
+}
+
+void MfmaEncodingAttr::print(AsmPrinter &printer) const {
+  printer << "<{"
+          << "nonKDim = " << getNonKDim() << ", "
+          << "warpsPerCTA = [" << getWarpsPerCTA() << "], "
+          << "xdlopsPerWarp0 = [" << getXdlopsPerWarp() << "]"
+          << "}>";
+}
+
+//===----------------------------------------------------------------------===//
 // Mma encoding
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Add the MfmaEncodingAttr to describe the result of mfma instructions.
Introduce it in BlockedToMFMA() from the tritongpu-combineops pass.
Now the IR looks like the follows:
```llvm
    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp0 = [2, 2]}>>
    %33 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked>
    %34 = tt.load %25 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked2>
    %35 = triton_gpu.convert_layout %33 : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #lds>
    %36 = triton_gpu.convert_layout %34 : (tensor<64x256xf16, #blocked2>) -> tensor<64x256xf16, #lds1>
    %37 = rock.alloc() : memref<24576xf16, #gpu.address_space<workgroup>>
    %c64 = arith.constant 64 : index
    %c64_0 = arith.constant 64 : index
    %c64_1 = arith.constant 64 : index
    %c4 = arith.constant 4 : index
    %38 = rock.workgroup_id : index
    %39 = rock.workitem_id : index
    %40 = arith.divui %39, %c64 : index
    %41 = arith.divui %40, %c4 : index
    %42 = arith.remui %40, %c4 : index
    %43 = arith.muli %41, %c64_0 : index
    %44 = arith.muli %42, %c64_1 : index
    %45 = rock.alloc() : memref<16xvector<4xf16>, #gpu.address_space<private>>
    %46 = rock.alloc() : memref<16xvector<4xf16>, #gpu.address_space<private>>
    %47 = rock.alloc() : memref<4xvector<16xf32>, #gpu.address_space<private>>
    %cst_2 = arith.constant dense<0.000000e+00> : vector<16xf32>
    rock.fill(%47, %cst_2) : memref<4xvector<16xf32>, #gpu.address_space<private>>, vector<16xf32>
    rock.blockwise_gemm_v2 %47 += %45 from %37[%43] * %46 from %37[%44] {blockSize = 512 : i32, ldsBufferOffsetA = 0 : index, ldsBufferOffsetB = 8192 : index, params = #xdlops_gemm_params} : memref<4xvector<16xf32>, #gpu.address_space<private>> += memref<16xvector<4xf16>, #gpu.address_space<private>> from memref<24576xf16, #gpu.address_space<workgroup>> * memref<16xvector<4xf16>, #gpu.address_space<private>> from memref<24576xf16, #gpu.address_space<workgroup>>
    %48 = triton_gpu.convert_layout %cst : (tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp0 = [2, 2]}>>) -> tensor<128x256xf32, #blocked1>
    %49 = arith.truncf %48 : tensor<128x256xf32, #blocked1> to tensor<128x256xf16, #blocked1>
    tt.store %32, %49 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf16, #blocked1>
``` 