### PR TITLE
Update LLVM 17 URL to updated package.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ def get_llvm_package_info():
     use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
     release_suffix = "assert" if use_assert_enabled_llvm else "release"
     name = f'llvm+mlir-17.0.0-x86_64-{system_suffix}-{release_suffix}'
-    url = f"https://github.com/ptillet/triton-llvm-releases/releases/download/llvm-17.0.0-37b7a60cd74b/{name}.tar.xz"
+    url = f"https://github.com/ptillet/triton-llvm-releases/releases/download/llvm-17.0.0-8e5a41e8271f/{name}.tar.xz"
     return Package("llvm", name, url, "lib", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 


### PR DESCRIPTION
This new LLVM distribution advances the LLVM commit pointer to include an AMDGCN specific fix for a compiler hang.

This hang was exposed by a Pytorch 2.0 unit test.