### PR TITLE
Adding wave64 support to Triton

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -229,8 +229,13 @@ for
                      "ArrayRef<unsigned>":$order,
                      "unsigned":$numWarps), [{
       int rank = sizePerThread.size();
+#ifdef USE_ROCM
+      unsigned remainingLanes = 64;
+      unsigned remainingThreads = numWarps*64;
+#else
       unsigned remainingLanes = 32;
       unsigned remainingThreads = numWarps*32;
+#endif
       unsigned remainingWarps = numWarps;
       unsigned prevLanes = 1;
       unsigned prevWarps = 1;
@@ -248,7 +253,7 @@ for
         prevWarps *= warpsPerCTA[i];
       }
       // Expand the last dimension to fill the remaining lanes and warps
-      threadsPerWarp[order[rank-1]] = 32 / prevLanes;
+      threadsPerWarp[order[rank-1]] = 64 / prevLanes;
       warpsPerCTA[order[rank-1]] = numWarps / prevWarps;
 
       return $_get(context, sizePerThread, threadsPerWarp, warpsPerCTA, order);

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -253,9 +253,12 @@ for
         prevWarps *= warpsPerCTA[i];
       }
       // Expand the last dimension to fill the remaining lanes and warps
+#ifdef USE_ROCM
       threadsPerWarp[order[rank-1]] = 64 / prevLanes;
+#else
+      threadsPerWarp[order[rank-1]] = 32 / prevLanes;
+#endif
       warpsPerCTA[order[rank-1]] = numWarps / prevWarps;
-
       return $_get(context, sizePerThread, threadsPerWarp, warpsPerCTA, order);
 
     }]>

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -66,8 +66,11 @@ SmallVector<SmallVector<unsigned>> ReduceOpHelper::getScratchConfigsFast() {
   /// shared memory block1:
   auto mod = op.getOperation()->getParentOfType<ModuleOp>();
   unsigned numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+#ifdef USE_ROCM
+  smemShapes[1].push_back(numWarps * 64);
+#else
   smemShapes[1].push_back(numWarps * 32);
-
+#endif
   return smemShapes;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -93,7 +93,11 @@ private:
       SmallVector<Value> mmaColIdx(4);
       SmallVector<Value> mmaRowIdx(2);
       Value threadId = getThreadId(rewriter, loc);
+#ifdef USE_ROCM
+      Value warpSize = idx_val(64);
+#else
       Value warpSize = idx_val(32);
+#endif
       Value laneId = urem(threadId, warpSize);
       Value warpId = udiv(threadId, warpSize);
       // TODO: fix the bug in MMAEncodingAttr document

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
@@ -295,11 +295,14 @@ DotOpMmaV1ConversionHelper::computeOffsets(Value threadId, bool isARow,
   Value _3 = i32_val(3);
   Value _4 = i32_val(4);
   Value _16 = i32_val(16);
-  Value _32 = i32_val(32);
+#ifdef USE_ROCM
+  Value warpSize = i32_val(64);
+#else
+  Value warpSize = i32_val(32);
+#endif
 
-  Value lane = urem(threadId, _32);
-  Value warp = udiv(threadId, _32);
-
+  Value lane = urem(threadId, warpSize);
+  Value warp = udiv(threadId, warpSize);
   // warp offset
   Value warp0 = urem(warp, i32_val(wpt[0]));
   Value warp12 = udiv(warp, i32_val(wpt[0]));
@@ -377,7 +380,11 @@ DotOpMmaV1ConversionHelper::getMNCoords(Value thread,
   Value _2 = i32_val(2);
   Value _4 = i32_val(4);
   Value _16 = i32_val(16);
-  Value _32 = i32_val(32);
+#ifdef USE_ROCM
+  Value warpSize = i32_val(64);
+#else
+  Value warpSize = i32_val(32);
+#endif
   Value _fpw0 = i32_val(fpw[0]);
   Value _fpw1 = i32_val(fpw[1]);
 
@@ -388,8 +395,8 @@ DotOpMmaV1ConversionHelper::getMNCoords(Value thread,
   SmallVector<int, 2> spw({aParam.spw[0], bParam.spw[1]});
   SmallVector<unsigned, 2> shapePerCTA({spw[0] * wpt[0], spw[1] * wpt[1]});
 
-  Value lane = urem(thread, _32);
-  Value warp = udiv(thread, _32);
+  Value lane = urem(thread, warpSize);
+  Value warp = udiv(thread, warpSize);
 
   Value warp0 = urem(warp, i32_val(wpt[0]));
   Value warp12 = udiv(warp, i32_val(wpt[0]));

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -425,10 +425,13 @@ struct MMA16816ConversionHelper {
         helper(mmaLayout), rewriter(rewriter), typeConverter(typeConverter),
         loc(loc), ctx(mmaLayout.getContext()) {
     helper.deduceMmaType(dotOperand);
-
-    Value _32 = i32_val(32);
-    lane = urem(thread, _32);
-    warp = udiv(thread, _32);
+#ifdef USE_ROCM
+  Value warpSize = i32_val(64);
+#else
+  Value warpSize = i32_val(32);
+#endif
+    lane = urem(thread, warpSize);
+    warp = udiv(thread, warpSize);
   }
 
   // Get a warpId for M axis.

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -426,9 +426,9 @@ struct MMA16816ConversionHelper {
         loc(loc), ctx(mmaLayout.getContext()) {
     helper.deduceMmaType(dotOperand);
 #ifdef USE_ROCM
-  Value warpSize = i32_val(64);
+    Value warpSize = i32_val(64);
 #else
-  Value warpSize = i32_val(32);
+    Value warpSize = i32_val(32);
 #endif
     lane = urem(thread, warpSize);
     warp = udiv(thread, warpSize);

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -597,7 +597,11 @@ private:
                                 const BlockedEncodingAttr &blocked_layout,
                                 ArrayRef<int64_t> shape) const {
     Value threadId = getThreadId(rewriter, loc);
+#ifdef USE_ROCM
+    Value warpSize = idx_val(64);
+#else
     Value warpSize = idx_val(32);
+#endif
     Value laneId = urem(threadId, warpSize);
     Value warpId = udiv(threadId, warpSize);
     auto sizePerThread = blocked_layout.getSizePerThread();
@@ -706,6 +710,7 @@ private:
     Value _4 = i32_val(4);
     Value _16 = i32_val(16);
     Value _32 = i32_val(32);
+    Value _64 = i32_val(64);
     Value _fpw0 = i32_val(fpw[0]);
     Value _fpw1 = i32_val(fpw[1]);
 
@@ -716,8 +721,8 @@ private:
     SmallVector<int, 2> spw({aParam.spw[0], bParam.spw[1]});
     SmallVector<unsigned, 2> shapePerCTA({spw[0] * wpt[0], spw[1] * wpt[1]});
 
-    Value lane = urem(thread, _32);
-    Value warp = udiv(thread, _32);
+    Value lane = urem(thread, _64);
+    Value warp = udiv(thread, _64);
 
     Value warp0 = urem(warp, i32_val(wpt[0]));
     Value warp12 = udiv(warp, i32_val(wpt[0]));
@@ -802,7 +807,7 @@ private:
     SmallVector<Value> warpsPerCTA = {idx_val(_warpsPerCTA[0]),
                                       idx_val(_warpsPerCTA[1])};
     Value threadId = getThreadId(rewriter, loc);
-    Value warpSize = idx_val(32);
+    Value warpSize = idx_val(64);
     Value laneId = urem(threadId, warpSize);
     Value warpId = udiv(threadId, warpSize);
     Value warpId0 = urem(urem(warpId, warpsPerCTA[0]), idx_val(shape[0] / 16));

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -709,8 +709,11 @@ private:
     Value _2 = i32_val(2);
     Value _4 = i32_val(4);
     Value _16 = i32_val(16);
-    Value _32 = i32_val(32);
-    Value _64 = i32_val(64);
+#ifdef USE_ROCM
+    Value warpSize = i32_val(64);
+#else
+    Value warpSize = i32_val(32);
+#endif
     Value _fpw0 = i32_val(fpw[0]);
     Value _fpw1 = i32_val(fpw[1]);
 
@@ -721,8 +724,8 @@ private:
     SmallVector<int, 2> spw({aParam.spw[0], bParam.spw[1]});
     SmallVector<unsigned, 2> shapePerCTA({spw[0] * wpt[0], spw[1] * wpt[1]});
 
-    Value lane = urem(thread, _64);
-    Value warp = udiv(thread, _64);
+    Value lane = urem(thread, warpSize);
+    Value warp = udiv(thread, warpSize);
 
     Value warp0 = urem(warp, i32_val(wpt[0]));
     Value warp12 = udiv(warp, i32_val(wpt[0]));
@@ -807,7 +810,11 @@ private:
     SmallVector<Value> warpsPerCTA = {idx_val(_warpsPerCTA[0]),
                                       idx_val(_warpsPerCTA[1])};
     Value threadId = getThreadId(rewriter, loc);
+#ifdef USE_ROCM
     Value warpSize = idx_val(64);
+#else
+    Value warpSize = idx_val(32);
+#endif
     Value laneId = urem(threadId, warpSize);
     Value warpId = udiv(threadId, warpSize);
     Value warpId0 = urem(urem(warpId, warpsPerCTA[0]), idx_val(shape[0] / 16));

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -239,9 +239,15 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
     int numWarps = typeConverter->getNumWarps();
 
     SmallVector<unsigned> retSizePerThread = {1, 1};
-    if (origShape[0] * origShape[1] / (numWarps * 32) >= 4)
+#ifdef USE_ROCM
+    int warpSize = 64;
+#else
+    int warpSize = 32;
+#endif
+
+    if (origShape[0] * origShape[1] / (numWarps * warpSize) >= 4)
       retSizePerThread = {2, 2};
-    if (origShape[0] * origShape[1] / (numWarps * 32) >= 16)
+    if (origShape[0] * origShape[1] / (numWarps * warpSize) >= 16)
       retSizePerThread = {4, 4};
     SmallVector<unsigned> retOrder = {1, 0};
     Attribute dEncoding = triton::gpu::BlockedEncodingAttr::get(

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -49,7 +49,11 @@ struct CoalescePass : public TritonGPUCoalesceBase<CoalescePass> {
         }
       }
     int numElems = product(origType.getShape());
+#ifdef USE_ROCM
+    int numThreads = numWarps * 64;
+#else
     int numThreads = numWarps * 32;
+#endif
     int numElemsPerThread = std::max(numElems / numThreads, 1);
     // Thread tile size depends on memory alignment
     SmallVector<unsigned, 4> sizePerThread(rank, 1);

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1840,8 +1840,22 @@ class BlockedLayout:
     def __str__(self):
         return f"#triton_gpu.blocked<{{sizePerThread={self.sz_per_thread}, threadsPerWarp={self.threads_per_warp}, warpsPerCTA={self.warps_per_cta}, order={self.order}}}>"
 
-
-layouts = [
+if torch.version.hip is not None:
+    layouts = [
+        # MmaLayout(version=1, warps_per_cta=[1, 4]),
+        # MmaLayout(version=(2, 0), warps_per_cta=[1, 4]),
+        # MmaLayout(version=1, warps_per_cta=[4, 1]),
+        # MmaLayout(version=(2, 0), warps_per_cta=[4, 1]),
+        BlockedLayout([1, 4], [2, 32], [2, 2], [1, 0]),
+        BlockedLayout([2, 2], [4, 16], [2, 2], [1, 0]),
+        BlockedLayout([1, 1], [1, 64], [2, 2], [1, 0]),
+        BlockedLayout([4, 2], [16, 4], [1, 4], [0, 1]),
+        BlockedLayout([4, 2], [8, 8], [2, 2], [0, 1]),
+        BlockedLayout([1, 1], [32, 2], [2, 2], [0, 1]),
+        BlockedLayout([4, 2], [1, 64], [4, 1], [1, 0])
+    ]
+else:
+    layouts = [
     # MmaLayout(version=1, warps_per_cta=[1, 4]),
     MmaLayout(version=(2, 0), warps_per_cta=[1, 4]),
     # MmaLayout(version=1, warps_per_cta=[4, 1]),
@@ -1854,7 +1868,6 @@ layouts = [
     BlockedLayout([1, 1], [32, 1], [2, 2], [0, 1]),
     BlockedLayout([4, 4], [1, 32], [4, 1], [1, 0])
 ]
-
 
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", ['float16'])

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1856,18 +1856,18 @@ if torch.version.hip is not None:
     ]
 else:
     layouts = [
-    # MmaLayout(version=1, warps_per_cta=[1, 4]),
-    MmaLayout(version=(2, 0), warps_per_cta=[1, 4]),
-    # MmaLayout(version=1, warps_per_cta=[4, 1]),
-    MmaLayout(version=(2, 0), warps_per_cta=[4, 1]),
-    BlockedLayout([1, 8], [2, 16], [4, 1], [1, 0]),
-    BlockedLayout([1, 4], [4, 8], [2, 2], [1, 0]),
-    BlockedLayout([1, 1], [1, 32], [2, 2], [1, 0]),
-#    BlockedLayout([8, 1], [16, 2], [1, 4], [0, 1]),
-    BlockedLayout([4, 1], [8, 4], [2, 2], [0, 1]),
-    BlockedLayout([1, 1], [32, 1], [2, 2], [0, 1]),
-    BlockedLayout([4, 4], [1, 32], [4, 1], [1, 0])
-]
+        # MmaLayout(version=1, warps_per_cta=[1, 4]),
+        MmaLayout(version=(2, 0), warps_per_cta=[1, 4]),
+        # MmaLayout(version=1, warps_per_cta=[4, 1]),
+        MmaLayout(version=(2, 0), warps_per_cta=[4, 1]),
+        BlockedLayout([1, 8], [2, 16], [4, 1], [1, 0]),
+        BlockedLayout([1, 4], [4, 8], [2, 2], [1, 0]),
+        BlockedLayout([1, 1], [1, 32], [2, 2], [1, 0]),
+    #    BlockedLayout([8, 1], [16, 2], [1, 4], [0, 1]),
+        BlockedLayout([4, 1], [8, 4], [2, 2], [0, 1]),
+        BlockedLayout([1, 1], [32, 1], [2, 2], [0, 1]),
+        BlockedLayout([4, 4], [1, 32], [4, 1], [1, 0])
+    ]
 
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", ['float16'])

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1212,7 +1212,7 @@ def generate_launcher(constants, signature):
     static void _launch(int gridX, int gridY, int gridZ, int num_warps, int shared_memory, hipStream_t stream, hipFunction_t function, {arg_decls}) {{
       void *params[] = {{ {', '.join(f"&arg{i}" for i in signature.keys() if i not in constants)} }};
       if(gridX*gridY*gridZ > 0){{
-          HIP_CHECK(hipModuleLaunchKernel(function, gridX, gridY, gridZ, 32*num_warps, 1, 1, shared_memory, stream, params, 0));
+          HIP_CHECK(hipModuleLaunchKernel(function, gridX, gridY, gridZ, 64*num_warps, 1, 1, shared_memory, stream, params, 0));
       }}
     }}
     typedef struct _DevicePtrInfo {{

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -31,11 +31,11 @@ func.func @load_ops(%ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
 // -----
 
 func.func @reduce_ops(%ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
-  // Test if the total number of threadsPerWarp is 32
+  // Test if the total number of threadsPerWarp is 64
   // Test if the total number of warps is 2
-  // CHECK: #[[blocked0:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 2], order = [0, 1]}>
-  // CHECK: #[[blocked1:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
-  // CHECK: #[[blocked2:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 2], order = [0, 1]}>
+  // CHECK: #[[blocked0:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 16], warpsPerCTA = [1, 2], order = [0, 1]}>
+  // CHECK: #[[blocked1:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 2], order = [0, 1]}>
+  // CHECK: #[[blocked2:.*]] = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 2], order = [0, 1]}>
   // CHECK: module attributes {"triton_gpu.num-warps" = 2 : i32} {{.*}}
   %c0 = arith.constant dense<1.00e+00> : tensor<4x4xf32>
   %c1 = arith.constant dense<2.00e+00> : tensor<8x2xf32>

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -9,8 +9,8 @@
 module attributes {"triton_gpu.num-warps" = 4 : i32} {
 
 
-// CHECK: [[row_layout:#.*]] = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK: [[col_layout:#.*]] = #triton_gpu.blocked<{sizePerThread = [4, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK: [[row_layout:#.*]] = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK: [[col_layout:#.*]] = #triton_gpu.blocked<{sizePerThread = [4, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
 // CHECK: [[load_ptr:%.*]] = triton_gpu.convert_layout {{.*}} -> tensor<64x64x!tt.ptr<f32>, [[row_layout]]>
 // CHECK: [[load_mask:%.*]] = triton_gpu.convert_layout {{.*}} -> tensor<64x64xi1, [[row_layout]]>
 // CHECK: [[load_other:%.*]] = triton_gpu.convert_layout {{.*}} -> tensor<64x64xf32, [[row_layout]]>


### PR DESCRIPTION
This PR adds support for warpSize = 64 for AMDGPU to Triton:
* Changing warpSize = 32 to warpSize = 64
* Adding wave64 support for ReduceOp
* Fixing layouts in `test_convert2d` to work with wave64

The current solution with ifdef is temporary and should be improved in the future so that wavefront size can be determined with  `rocminfo`