### PR TITLE
Replace hard coded ROCM paths with ROCM_PATH env var.

### DIFF
--- a/lib/Target/HSACO/HSACOTranslation.cpp
+++ b/lib/Target/HSACO/HSACOTranslation.cpp
@@ -133,9 +133,10 @@ std::string generate_hsaco(llvm::Module *module, const std::string &triple,
   std::string hsaco_path = kernel_name + std::string(".hsaco");
 
   std::string error_message;
+  std::string lld_path = ::triton::tools::getenv("ROCM_PATH") + "/llvm/bin/ld.lld";
   int lld_result =
-      llvm::sys::ExecuteAndWait("/opt/rocm/llvm/bin/ld.lld",
-                                {"/opt/rocm/llvm/bin/ld.lld", "-flavor", "gnu",
+      llvm::sys::ExecuteAndWait(lld_path,
+                                {lld_path, "-flavor", "gnu",
                                  "-shared", "-o", hsaco_path, isabin_path},
                                 std::nullopt, {}, 0, 0, &error_message);
   if (lld_result) {

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1519,22 +1519,13 @@ def quiet():
         sys.stdout, sys.stderr = old_stdout, old_stderr
 
 @functools.lru_cache()
-def libhip_dir():
-    return "/opt/rocm/lib"
-
-@functools.lru_cache()
-def hip_home_dirs():
-    default_dir = "/opt/rocm"
-    return os.getenv("ROCM_HOME", default=default_dir)
-
-@functools.lru_cache()
 def rocm_path_dir():
     return os.getenv("ROCM_PATH", default="/opt/rocm")
 
 def _build(name, src, srcdir):
     if torch.version.hip is not None:
-        hip_lib_dir = libhip_dir()
-        hip_include_dir = os.path.join(hip_home_dirs(), "include")
+        hip_lib_dir = os.path.join(rocm_path_dir(), "lib")
+        hip_include_dir = os.path.join(rocm_path_dir(), "include")
     else:
         cuda_lib_dirs = libcuda_dirs()
         cuda_path = os.environ.get('CUDA_PATH', default_cuda_dir())

--- a/scripts/amd/check_llvm_src.sh
+++ b/scripts/amd/check_llvm_src.sh
@@ -1,3 +1,3 @@
 shopt -s extglob
-/opt/rocm/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*+([0-9]).ll
-# /opt/rocm/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*_before_verify.ll
+${ROCM_PATH}/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*+([0-9]).ll
+# ${ROCM_PATH}/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*_before_verify.ll

--- a/scripts/amd/lld.sh
+++ b/scripts/amd/lld.sh
@@ -1,1 +1,1 @@
-/opt/rocm/llvm/bin/ld.lld -flavor gnu -shared _empty.o -o _empty.hsaco
+${ROCM_PATH}/llvm/bin/ld.lld -flavor gnu -shared _empty.o -o _empty.hsaco

--- a/test/Target/tritongpu_to_hsaco.mlir
+++ b/test/Target/tritongpu_to_hsaco.mlir
@@ -1,3 +1,4 @@
+// RUN: export ROCM_PATH=/opt/rocm
 // RUN: HSACO_PATH=$(%PYTHON -m triton.tools.aot %s --target=amdgcn --gfx=gfx906 --triple=amdgcn-amd-amdhsa --features="+sramecc,-xnack" | head -n 1)
 // RUN: llvm-readobj -a "${HSACO_PATH}" | FileCheck %s
 


### PR DESCRIPTION
An external user reported a hard coded path error when using the Pytorch 2.0 version of triton:

https://github.com/ROCmSoftwarePlatform/triton/issues/149

This PR fixes that issue.

The fix has already landed in `triton-mlir`.
