### PR TITLE
[dotOP] [rocMLIR] Add unit tests for pull requests targeting the dot-rocMLIR branch

### DIFF
--- a/.github/workflows/integration-tests-dot-rocMLIR.yml
+++ b/.github/workflows/integration-tests-dot-rocMLIR.yml
@@ -1,0 +1,32 @@
+name: dot-rocMLIR Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - dot-rocMLIR
+
+jobs:
+  Integration-Tests:
+    runs-on: Ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Clear cache
+        run: |
+          rm -rf ~/.triton/cache/
+
+      - name: Install Triton
+        run: |
+          cd python
+          TRITON_USE_ASSERT_ENABLED_LLVM=TRUE pip3 install -e '.[tests]'
+
+      - name: Run lit tests
+        run: |
+          cd python
+          LIT_TEST_DIR="build/$(ls build)/test/dot-rocMLIR"
+          if [ ! -d "$LIT_TEST_DIR" ]; then
+            echo "Not found `$LIT_TEST_DIR`.  Did you change an installation method?" ; exit -1
+          fi
+          lit -v "$LIT_TEST_DIR"

--- a/python/setup.py
+++ b/python/setup.py
@@ -172,6 +172,7 @@ class CMakeBuild(build_ext):
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DTRITON_BUILD_TUTORIALS=OFF",
+            "-DTRITON_USE_ROCM=ON",
             "-DTRITON_BUILD_PYTHON_MODULE=ON",
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
+add_subdirectory(dot-rocMLIR)
 add_subdirectory(lib)
 
+if(0)
 llvm_canonicalize_cmake_booleans(
   MLIR_ENABLE_BINDINGS_PYTHON
 )
@@ -24,3 +26,4 @@ add_lit_testsuite(check-triton-lit-tests "Running the triton regression tests"
 set_target_properties(check-triton-lit-tests PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(TRITON-LIT-TESTS ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TRITON_TEST_DEPENDS})
+endif()

--- a/test/dot-rocMLIR/CMakeLists.txt
+++ b/test/dot-rocMLIR/CMakeLists.txt
@@ -1,0 +1,20 @@
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCe_DIR}/lit.cfg.py
+)
+
+set(TRITON_TEST_DEPENDS
+  triton-opt
+  FileCheck
+)
+
+add_lit_testsuite(check-rocMLIR-lit-tests "Running the dot-rocMLIR regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TRITON_TEST_DEPENDS}
+)
+
+set_target_properties(check-rocMLIR-lit-tests PROPERTIES FOLDER "Tests")
+
+add_lit_testsuites(DOT-ROCMLIR-LIT-TESTS ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TRITON_TEST_DEPENDS})

--- a/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
+++ b/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
@@ -1,0 +1,63 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-rock | FileCheck --check-prefixes=CHECK %s
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#lds = #triton_gpu.lds<{kpack = 4, order = [1, 0]}>
+#lds1 = #triton_gpu.lds<{kpack = 4, order = [0, 1]}>
+module attributes {"triton_gpu.num-warps" = 8 : i32} {
+  func.func public @test_dot(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) {
+  // CHECK: arith.constant dense<0.000000e+00> : tensor<128x256xf32, [[$mfmaEnc:#triton_gpu.mfma<.*>]]>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %2 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<128x1xi32, #blocked>
+    %3 = tt.expand_dims %1 {axis = 1 : i32} : (tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>) -> tensor<128x1xi32, #blocked1>
+    %4 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %4, %2 : tensor<128x1x!tt.ptr<f16>, #blocked>, tensor<128x1xi32, #blocked>
+    %6 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %7 = tt.expand_dims %6 {axis = 0 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x64xi32, #blocked>
+    %8 = tt.splat %arg1 : (i32) -> tensor<1x64xi32, #blocked>
+    %9 = arith.muli %7, %8 : tensor<1x64xi32, #blocked>
+    %10 = tt.broadcast %5 : (tensor<128x1x!tt.ptr<f16>, #blocked>) -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %11 = tt.broadcast %9 : (tensor<1x64xi32, #blocked>) -> tensor<128x64xi32, #blocked>
+    %12 = tt.addptr %10, %11 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+    %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %14 = tt.expand_dims %13 {axis = 1 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>) -> tensor<64x1xi32, #blocked2>
+    %15 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<64x1x!tt.ptr<f16>, #blocked2>
+    %16 = tt.addptr %15, %14 : tensor<64x1x!tt.ptr<f16>, #blocked2>, tensor<64x1xi32, #blocked2>
+    %17 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked2}>>
+    %18 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %19 = tt.expand_dims %17 {axis = 0 : i32} : (tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked2}>>) -> tensor<1x256xi32, #blocked2>
+    %20 = tt.expand_dims %18 {axis = 0 : i32} : (tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>) -> tensor<1x256xi32, #blocked1>
+    %21 = tt.splat %arg3 : (i32) -> tensor<1x256xi32, #blocked2>
+    %22 = arith.muli %19, %21 : tensor<1x256xi32, #blocked2>
+    %23 = tt.broadcast %16 : (tensor<64x1x!tt.ptr<f16>, #blocked2>) -> tensor<64x256x!tt.ptr<f16>, #blocked2>
+    %24 = tt.broadcast %22 : (tensor<1x256xi32, #blocked2>) -> tensor<64x256xi32, #blocked2>
+    %25 = tt.addptr %23, %24 : tensor<64x256x!tt.ptr<f16>, #blocked2>, tensor<64x256xi32, #blocked2>
+    %26 = tt.splat %arg7 : (i32) -> tensor<128x1xi32, #blocked1>
+    %27 = arith.muli %3, %26 : tensor<128x1xi32, #blocked1>
+    %28 = tt.splat %arg6 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>, #blocked1>
+    %29 = tt.addptr %28, %27 : tensor<128x1x!tt.ptr<f16>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %30 = tt.broadcast %29 : (tensor<128x1x!tt.ptr<f16>, #blocked1>) -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+    %31 = tt.broadcast %20 : (tensor<1x256xi32, #blocked1>) -> tensor<128x256xi32, #blocked1>
+    %32 = tt.addptr %30, %31 : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<128x256xi32, #blocked1>
+    %33 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked>
+    %34 = tt.load %25 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked2>
+    %35 = triton_gpu.convert_layout %33 : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #lds>
+    %36 = triton_gpu.convert_layout %34 : (tensor<64x256xf16, #blocked2>) -> tensor<64x256xf16, #lds1>
+    // CHECK-NOT: triton_gpu.convert_layout {{.*}} : (tensor<128x64xf16, #lds{{.*}}>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    // CHECK-NOT: triton_gpu.convert_layout {{.*}} : (tensor<64x256xf16, #lds{{.*}}>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    %37 = triton_gpu.convert_layout %35 : (tensor<128x64xf16, #lds>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    %38 = triton_gpu.convert_layout %36 : (tensor<64x256xf16, #lds1>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    // CHECK-NOT: tt.dot
+    // CHECK: rock.fill([[$bufferC:.*]], {{.*}}) : memref<[[$bufferCType:.*]], #gpu.address_space<private>>, vector<{{.*}}>
+    // CHECK-NEXT: blockwise_gemm_v2 [[$bufferC]]
+    // CHECK-NEXT: triton_gpu.memref_to_tensor [[$bufferC]] : memref<[[$bufferCType]], #gpu.address_space<private>> -> tensor<128x256xf32, [[$mfmaEnc]]>
+    %39 = tt.dot %37, %38, %cst {allowTF32 = true} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>> * tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>> -> tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>
+    %40 = triton_gpu.convert_layout %39 : (tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>) -> tensor<128x256xf32, #blocked1>
+    %41 = arith.truncf %40 : tensor<128x256xf32, #blocked1> to tensor<128x256xf16, #blocked1>
+    tt.store %32, %41 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf16, #blocked1>
+    return
+  }
+}

--- a/test/dot-rocMLIR/TritonGPU/combine.mlir
+++ b/test/dot-rocMLIR/TritonGPU/combine.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-combine 2>&1 | FileCheck %s
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked4 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 4], order = [0, 1]}>
+#blocked5 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked6 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked7 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked8 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"triton_gpu.num-warps" = 8 : i32} {
+  func.func public @kernel_intro_mfma(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) {
+    // CHECK: arith.constant dense<0.000000e+00> : tensor<128x256xf32, [[$mfmaEnc:#triton_gpu.mfma<.*>]]>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked1>
+    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked1>
+    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked1>
+    %3 = triton_gpu.convert_layout %0 : (tensor<128xi32, #blocked1>) -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %4 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>) -> tensor<128x1xi32, #blocked2>
+    %5 = triton_gpu.convert_layout %4 : (tensor<128x1xi32, #blocked2>) -> tensor<128x1xi32, #blocked>
+    %6 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>, #blocked>
+    %7 = tt.addptr %6, %5 : tensor<128x1x!tt.ptr<f16>, #blocked>, tensor<128x1xi32, #blocked>
+    %8 = triton_gpu.convert_layout %2 : (tensor<64xi32, #blocked1>) -> tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked3}>>
+    %9 = tt.expand_dims %8 {axis = 0 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked3}>>) -> tensor<1x64xi32, #blocked3>
+    %10 = tt.splat %arg1 : (i32) -> tensor<1x64xi32, #blocked3>
+    %11 = arith.muli %9, %10 : tensor<1x64xi32, #blocked3>
+    %12 = tt.broadcast %7 : (tensor<128x1x!tt.ptr<f16>, #blocked>) -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %13 = tt.broadcast %11 : (tensor<1x64xi32, #blocked3>) -> tensor<128x64xi32, #blocked3>
+    %14 = triton_gpu.convert_layout %13 : (tensor<128x64xi32, #blocked3>) -> tensor<128x64xi32, #blocked>
+    %15 = tt.addptr %12, %14 : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+    %16 = triton_gpu.convert_layout %2 : (tensor<64xi32, #blocked1>) -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %17 = tt.expand_dims %16 {axis = 1 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>) -> tensor<64x1xi32, #blocked2>
+    %18 = triton_gpu.convert_layout %17 : (tensor<64x1xi32, #blocked2>) -> tensor<64x1xi32, #blocked4>
+    %19 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<64x1x!tt.ptr<f16>, #blocked4>
+    %20 = tt.addptr %19, %18 : tensor<64x1x!tt.ptr<f16>, #blocked4>, tensor<64x1xi32, #blocked4>
+    %21 = triton_gpu.convert_layout %1 : (tensor<256xi32, #blocked1>) -> tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked3}>>
+    %22 = tt.expand_dims %21 {axis = 0 : i32} : (tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked3}>>) -> tensor<1x256xi32, #blocked3>
+    %23 = tt.splat %arg3 : (i32) -> tensor<1x256xi32, #blocked3>
+    %24 = arith.muli %22, %23 : tensor<1x256xi32, #blocked3>
+    %25 = tt.broadcast %20 : (tensor<64x1x!tt.ptr<f16>, #blocked4>) -> tensor<64x256x!tt.ptr<f16>, #blocked4>
+    %26 = tt.broadcast %24 : (tensor<1x256xi32, #blocked3>) -> tensor<64x256xi32, #blocked3>
+    %27 = triton_gpu.convert_layout %26 : (tensor<64x256xi32, #blocked3>) -> tensor<64x256xi32, #blocked4>
+    %28 = tt.addptr %25, %27 : tensor<64x256x!tt.ptr<f16>, #blocked4>, tensor<64x256xi32, #blocked4>
+    %29 = tt.splat %arg7 : (i32) -> tensor<128x1xi32, #blocked>
+    %30 = arith.muli %5, %29 : tensor<128x1xi32, #blocked>
+    %31 = tt.splat %arg6 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>, #blocked>
+    %32 = tt.addptr %31, %30 : tensor<128x1x!tt.ptr<f16>, #blocked>, tensor<128x1xi32, #blocked>
+    %33 = tt.broadcast %32 : (tensor<128x1x!tt.ptr<f16>, #blocked>) -> tensor<128x256x!tt.ptr<f16>, #blocked>
+    %34 = tt.broadcast %22 : (tensor<1x256xi32, #blocked3>) -> tensor<128x256xi32, #blocked3>
+    %35 = triton_gpu.convert_layout %34 : (tensor<128x256xi32, #blocked3>) -> tensor<128x256xi32, #blocked>
+    %36 = tt.addptr %33, %35 : tensor<128x256x!tt.ptr<f16>, #blocked>, tensor<128x256xi32, #blocked>
+    %37 = triton_gpu.convert_layout %15 : (tensor<128x64x!tt.ptr<f16>, #blocked>) -> tensor<128x64x!tt.ptr<f16>, #blocked5>
+    %38 = tt.load %37 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked5>
+    %39 = triton_gpu.convert_layout %38 : (tensor<128x64xf16, #blocked5>) -> tensor<128x64xf16, #blocked>
+    %40 = triton_gpu.convert_layout %28 : (tensor<64x256x!tt.ptr<f16>, #blocked4>) -> tensor<64x256x!tt.ptr<f16>, #blocked6>
+    %41 = tt.load %40 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked6>
+    %42 = triton_gpu.convert_layout %41 : (tensor<64x256xf16, #blocked6>) -> tensor<64x256xf16, #blocked4>
+    %43 = triton_gpu.convert_layout %39 : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked7}>>
+    %44 = triton_gpu.convert_layout %42 : (tensor<64x256xf16, #blocked4>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked7}>>
+    %45 = triton_gpu.convert_layout %cst : (tensor<128x256xf32, #blocked>) -> tensor<128x256xf32, #blocked7>
+    // CHECK: tt.dot {{.*}}, {{.*}}, {{.*}} {allowTF32 = true} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = [[$mfmaEnc]]}>> * tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = [[$mfmaEnc]]}>> -> tensor<128x256xf32, [[$mfmaEnc]]>
+    %46 = tt.dot %43, %44, %45 {allowTF32 = true} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked7}>> * tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked7}>> -> tensor<128x256xf32, #blocked7>
+    // CHECK-NEXT: triton_gpu.convert_layout {{.*}} : (tensor<128x256xf32, [[$mfmaEnc]]>) -> tensor<128x256xf32, #blocked{{.*}}>
+    %47 = triton_gpu.convert_layout %46 : (tensor<128x256xf32, #blocked7>) -> tensor<128x256xf32, #blocked>
+    %48 = arith.truncf %47 : tensor<128x256xf32, #blocked> to tensor<128x256xf16, #blocked>
+    %49 = triton_gpu.convert_layout %36 : (tensor<128x256x!tt.ptr<f16>, #blocked>) -> tensor<128x256x!tt.ptr<f16>, #blocked8>
+    %50 = triton_gpu.convert_layout %48 : (tensor<128x256xf16, #blocked>) -> tensor<128x256xf16, #blocked8>
+    tt.store %49, %50 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf16, #blocked8>
+    return
+  }
+}

--- a/test/dot-rocMLIR/TritonGPU/decompose-conversions.mlir
+++ b/test/dot-rocMLIR/TritonGPU/decompose-conversions.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-decompose-conversions 2>&1 | FileCheck %s
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+// CHECK: #lds{{.*}} = #triton_gpu.lds{{.*}}
+// CHECK: #lds{{.*}} = #triton_gpu.lds{{.*}}
+module attributes {"triton_gpu.num-warps" = 8 : i32} {
+  func.func public @kernel_decompose(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) {
+    %cst_a = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #blocked>
+    %cst_b = arith.constant dense<0.000000e+00> : tensor<64x256xf16, #blocked1>
+    // CHECK: triton_gpu.convert_layout {{.*}} : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, [[$lds_layout1:#lds.*]]>
+    // CHECK-NEXT: triton_gpu.convert_layout {{.*}} : (tensor<128x64xf16, [[$lds_layout1]]>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    %1 = triton_gpu.convert_layout %cst_a : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    // CHECK: triton_gpu.convert_layout {{.*}} : (tensor<64x256xf16, #blocked1>) -> tensor<64x256xf16, [[$lds_layout2:#lds.*]]>
+    // CHECK-NEXT: triton_gpu.convert_layout {{.*}} : (tensor<64x256xf16, [[$lds_layout2]]>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    %2 = triton_gpu.convert_layout %cst_b : (tensor<64x256xf16, #blocked1>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
+    return
+  }
+}

--- a/test/dot-rocMLIR/lit.cfg.py
+++ b/test/dot-rocMLIR/lit.cfg.py
@@ -1,0 +1,67 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner
+
+# name: The name of this test suite
+config.name  = 'dot-rocMLIR'
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.mlir']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.triton_obj_root, 'test')
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
+
+llvm_config.with_system_environment(
+    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+# llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.triton_obj_root, 'test')
+config.triton_tools_dir = os.path.join(config.triton_obj_root, 'bin')
+config.filecheck_dir = os.path.join(config.triton_obj_root, 'bin', 'FileCheck')
+tool_dirs = [config.triton_tools_dir, config.llvm_tools_dir, config.filecheck_dir]
+
+# Tweak the PATH to include the tools dir.
+for d in tool_dirs:
+    llvm_config.with_environment('PATH', d, append_path=True)
+tools = [
+    'triton-opt',
+    ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
+]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+# TODO: what's this?
+llvm_config.with_environment('PYTHONPATH', [
+    os.path.join(config.mlir_binary_dir, 'python_packages', 'triton'),
+], append_path=True)

--- a/test/dot-rocMLIR/lit.site.cfg.py.in
+++ b/test/dot-rocMLIR/lit.site.cfg.py.in
@@ -1,0 +1,23 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.triton_obj_root = "@TRITON_BINARY_DIR@"
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_lib_dir = "@LLVM_LIBS_DIR@"
+config.llvm_shlib_dir = "@SHLIBDIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.llvm_exe_ext = "@EXEEXT@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.mlir_binary_dir = "@MLIR_BINARY_DIR@"
+config.python_executable = "@Python3_EXECUTABLE@"
+config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
+
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work
+lit_config.load_config(config, "@TRITON_SOURCE_DIR@/test/dot-rocMLIR/lit.cfg.py")


### PR DESCRIPTION
This PR adds a github workflow for each PR targeting the `dot-rocMLIR` branch. It includes the following three unit tests:
1. `TritonGPU/combine.mlir`: the result and acc of `tt.dot` should be converted to have `#mfma` encoding.
    - This pass was changed to `remove-layout-conversions` here: https://github.com/ROCmSoftwarePlatform/triton/commit/0ec277efc5c6f6b2e20d2cd087339f55b2bdb6a1.
3. `TritonGPU/decompose-conversions.mlir`: the conversion from `#blocked` to `#dot_op` should be decomposed to conversion from `#blocked` to `#lds` and conversion from `#lds` to `#dot_op`.
4. `Conversion/tritongpu_to_rock.mlir`: here we introduced `blockwise_gemm_v2`  and `triton_gpu.memref_to_tensor` and related ops from the rock dialect. 