### PR TITLE
[dotOp] [rocMLIR] Generate `tensor_to_memref` to prepare LDS buffer for `blockwise_gemm_v2`

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Traits.h
+++ b/include/triton/Dialect/TritonGPU/IR/Traits.h
@@ -15,6 +15,7 @@ namespace OpTrait {
 namespace impl {
 LogicalResult verifyResultsAreSharedEncoding(Operation *op);
 LogicalResult verifyResultsAreMfmaEncoding(Operation *op);
+LogicalResult verifySameOperandsAndResultNumElements(Operation *op);
 } // namespace impl
 
 template <typename ConcreteType>
@@ -32,6 +33,15 @@ class ResultsAreMfmaEncoding
 public:
   static LogicalResult verifyTrait(Operation *op) {
     return impl::verifyResultsAreMfmaEncoding(op);
+  }
+};
+
+template <typename ConcreteType>
+class SameOperandsAndResultNumElements
+    : public TraitBase<ConcreteType, SameOperandsAndResultNumElements> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifySameOperandsAndResultNumElements(op);
   }
 };
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -14,6 +14,8 @@ def ResultsAreSharedEncoding: NativeOpTrait<"ResultsAreSharedEncoding">;
 
 def ResultsAreMfmaEncoding: NativeOpTrait<"ResultsAreMfmaEncoding">;
 
+def SameOperandsAndResultNumElements: NativeOpTrait<"SameOperandsAndResultNumElements">;
+
 class TTG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonGPU_Dialect, mnemonic, traits>;
 
@@ -209,7 +211,8 @@ def TTG_AllocTensorOp : TTG_Op<"alloc_tensor", [MemoryEffects<[MemAlloc]>,  // A
   let results = (outs TT_Tensor:$result);
 }
 
-def TTG_MemRefToTensorOp : TTG_Op<"memref_to_tensor", [ResultsAreMfmaEncoding]> {
+def TTG_MemRefToTensorOp : TTG_Op<"memref_to_tensor", [ResultsAreMfmaEncoding,
+                                                       NoMemoryEffect]> {
 
   let summary = "convert memref to tensor";
 
@@ -226,8 +229,8 @@ def TTG_MemRefToTensorOp : TTG_Op<"memref_to_tensor", [ResultsAreMfmaEncoding]> 
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 }
 
-def TTG_TensorToMemRefOp : TTG_Op<"tensor_to_memref", [SameOperandsAndResultShape,
-                                                       SameOperandsAndResultElementType,
+def TTG_TensorToMemRefOp : TTG_Op<"tensor_to_memref", [SameOperandsAndResultElementType,
+                                                       SameOperandsAndResultNumElements,
                                                        NoMemoryEffect]>{
   let summary = "tensor to memref";
 

--- a/lib/Dialect/TritonGPU/IR/Traits.cpp
+++ b/lib/Dialect/TritonGPU/IR/Traits.cpp
@@ -24,3 +24,28 @@ mlir::OpTrait::impl::verifyResultsAreMfmaEncoding(Operation *op) {
 
   return success();
 };
+
+mlir::LogicalResult
+mlir::OpTrait::impl::verifySameOperandsAndResultNumElements(Operation *op) {
+  if (op->getNumResults() != 1 || op->getNumOperands() != 1)
+    return op->emitOpError() << "requires exact 1 operand and 1 result";
+  auto src = op->getOperand(0);
+  auto dst = op->getResult(0);
+
+  auto tensorTy = src.getType().dyn_cast<RankedTensorType>();
+  auto memrefTy = dst.getType().dyn_cast<MemRefType>();
+
+  if (!tensorTy || !memrefTy)
+    return op->emitOpError() << "requires tensor operand and memref result";
+
+  auto srcShape = tensorTy.getShape();
+  auto dstShape = memrefTy.getShape();
+
+  long srcNumElements = product<long>(srcShape);
+  long dstNumElements = product<long>(dstShape);
+  if (srcNumElements != dstNumElements)
+    return op->emitOpError()
+           << "requires operand and result have same number of elements";
+
+  return success();
+};

--- a/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
+++ b/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
@@ -46,6 +46,8 @@ module attributes {"triton_gpu.num-warps" = 8 : i32} {
     %34 = tt.load %25 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked2>
     %35 = triton_gpu.convert_layout %33 : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #lds>
     %36 = triton_gpu.convert_layout %34 : (tensor<64x256xf16, #blocked2>) -> tensor<64x256xf16, #lds1>
+    // CHECK: triton_gpu.tensor_to_memref {{.*}} : tensor<128x64xf16, #lds> -> memref<8192xf16, #gpu.address_space<workgroup>>
+    // CHECK: triton_gpu.tensor_to_memref {{.*}} : tensor<64x256xf16, #lds1> -> memref<16384xf16, #gpu.address_space<workgroup>>
     // CHECK-NOT: triton_gpu.convert_layout {{.*}} : (tensor<128x64xf16, #lds{{.*}}>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
     // CHECK-NOT: triton_gpu.convert_layout {{.*}} : (tensor<64x256xf16, #lds{{.*}}>) -> tensor<64x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>
     %37 = triton_gpu.convert_layout %35 : (tensor<128x64xf16, #lds>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>}>>


### PR DESCRIPTION
This PR 
- generates `triton_gpu.tensor_to_memref` to prepare LDS buffer for `blockwise_gemm_v2`.
- adds a trait to verify that the operand and result of `triton_gpu.tensor_to_memref` have the same number of elements.
- Fixes the `tritongpu-to-rock.mlir` unit test.