### PR TITLE
[dotOp] [rocMLIR] Add RockToGPU Conversion pass

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,4 +1,4 @@
-#add_subdirectory(FileCheck)
+add_subdirectory(FileCheck)
 # add_llvm_executable(FileCheck FileCheck/FileCheck.cpp)
 # target_link_libraries(FileCheck PRIVATE LLVMFileCheck LLVMSupport)
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory(FileCheck)
+#add_subdirectory(FileCheck)
 # add_llvm_executable(FileCheck FileCheck/FileCheck.cpp)
 # target_link_libraries(FileCheck PRIVATE LLVMFileCheck LLVMSupport)
 

--- a/bin/triton-opt.cpp
+++ b/bin/triton-opt.cpp
@@ -1,10 +1,11 @@
+#include "mlir/Dialect/AMDGPU/AMDGPUDialect.h"
+#include "triton/Dialect/Rock/IR/Rock.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "triton/Dialect/Rock/IR/Rock.h"
 
+#include "triton/Dialect/Rock/Passes.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
-#include "triton/Dialect/Rock/Passes.h"
 
 #include "triton/Conversion/Passes.h"
 
@@ -32,14 +33,18 @@ int main(int argc, char **argv) {
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerConvertTritonGPUToRockPass();
   mlir::triton::registerConvertRockToLLVMPass();
+  mlir::triton::registerConvertRockToGPUPass();
   mlir::rock::registerPasses();
 
   // TODO: register Triton & TritonGPU passes
   mlir::DialectRegistry registry;
-  registry.insert<mlir::triton::TritonDialect, mlir::rock::RockDialect,
+  registry.insert<mlir::triton::TritonDialect,
                   mlir::triton::gpu::TritonGPUDialect, mlir::func::FuncDialect,
                   mlir::math::MathDialect, mlir::arith::ArithDialect,
                   mlir::scf::SCFDialect, mlir::gpu::GPUDialect>();
+  // Register dialects used by Rock
+  registry.insert<mlir::rock::RockDialect, mlir::memref::MemRefDialect,
+                  mlir::amdgpu::AMDGPUDialect, mlir::vector::VectorDialect>();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "Triton (GPU) optimizer driver\n", registry));

--- a/include/triton/Conversion/Passes.h
+++ b/include/triton/Conversion/Passes.h
@@ -2,8 +2,9 @@
 #define TRITON_CONVERSION_PASSES_H
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "triton/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.h"
+#include "triton/Conversion/RockToGPU/RockToGPU.h"
 #include "triton/Conversion/TritonGPUToLLVM/RockToLLVMPass.h"
+#include "triton/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.h"
 #include "triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h"
 
 namespace mlir {

--- a/include/triton/Conversion/Passes.td
+++ b/include/triton/Conversion/Passes.td
@@ -73,4 +73,29 @@ def ConvertRockToLLVM : Pass<"convert-rock-to-llvm", "mlir::ModuleOp"> {
     ];
 }
 
+//===----------------------------------------------------------------------===//
+// RockToGPU
+//===----------------------------------------------------------------------===//
+
+def ConvertRockToGPUPass : Pass<"convert-rock-to-gpu", "mlir::ModuleOp"> {
+  let summary = "Lower the operations from the Rock dialect into the GPU "
+                "dialect";
+
+  let options = [
+      Option<"kernelName", "kernel-name", "std::string",
+             "\"rock_conv2d_kcyx_nchw_nkhw\"",
+             "kernel name to be lowered">,
+      Option<"gpuModuleName", "gpu-module-name", "std::string",
+             "\"rock_kernel_module\"",
+             "GPU kernel module name to be lowered">,
+  ];
+
+  let dependentDialects = ["mlir::rock::RockDialect",
+                           "mlir::amdgpu::AMDGPUDialect",
+                           "mlir::cf::ControlFlowDialect",
+                           "mlir::func::FuncDialect",
+                           "mlir::gpu::GPUDialect",
+                           "mlir::memref::MemRefDialect"];
+}
+
 #endif

--- a/include/triton/Conversion/RockToGPU/RockToGPU.h
+++ b/include/triton/Conversion/RockToGPU/RockToGPU.h
@@ -1,0 +1,32 @@
+//===- RockToGPU.h - Conversion from Rock to GPU ----------------*- C++ -*-===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CONVERSION_ROCKTOGPU_ROCKTOGPU_H_
+#define MLIR_CONVERSION_ROCKTOGPU_ROCKTOGPU_H_
+
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace mlir {
+class LLVMTypeConverter;
+class TypeConverter;
+class Pass;
+
+template <typename T> class OperationPass;
+
+#define GEN_PASS_DECL_CONVERTROCKTOGPUPASS
+#include "triton/Conversion/Passes.h.inc"
+
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_ROCKTOGPU_ROCKTOGPU_H_

--- a/include/triton/Conversion/TritonGPUToLLVM/RockToLLVMPass.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/RockToLLVMPass.h
@@ -7,6 +7,9 @@
 
 namespace mlir {
 
+#define GEN_PASS_DECL_CONVERTROCKTOLLVM
+#include "triton/Conversion/Passes.h.inc"
+
 class ModuleOp;
 template <typename T> class OperationPass;
 

--- a/include/triton/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.h
@@ -7,6 +7,9 @@
 
 namespace mlir {
 
+#define GEN_PASS_DECL_CONVERTTRITONGPUTOROCK
+#include "triton/Conversion/Passes.h.inc"
+
 class ModuleOp;
 template <typename T> class OperationPass;
 

--- a/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -5,6 +5,9 @@
 
 namespace mlir {
 
+#define GEN_PASS_DECL_CONVERTTRITONTOTRITONGPU
+#include "triton/Conversion/Passes.h.inc"
+
 class ModuleOp;
 template <typename T> class OperationPass;
 

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(TritonToTritonGPU)
 add_subdirectory(TritonGPUToLLVM)
+add_subdirectory(RockToGPU)

--- a/lib/Conversion/RockToGPU/CMakeLists.txt
+++ b/lib/Conversion/RockToGPU/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_mlir_conversion_library(MLIRRockToGPU
+  RockToGPU.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/RockToGPU
+
+  DEPENDS
+  #MLIRConversionPassIncGen
+  TritonConversionPassIncGen
+  MLIRRockPassIncGen
+)
+target_link_libraries(MLIRRockToGPU
+  PUBLIC
+  MLIRAffineToStandard
+  MLIRRockTransforms
+  MLIRLLVMDialect
+  MLIRIR
+  MLIRPass
+  MLIRSCFToControlFlow
+  MLIRFuncToLLVM
+  MLIRSupport
+  MLIRTransforms
+  MLIRVectorDialect
+  LLVMCore
+  LLVMSupport
+  )

--- a/lib/Conversion/RockToGPU/RockToGPU.cpp
+++ b/lib/Conversion/RockToGPU/RockToGPU.cpp
@@ -1,0 +1,291 @@
+//===- RockToGPU.cpp - MLIR Rock ops lowering passes ---------------===//
+//
+// Copyright 2020 The MLIR Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+//
+// This pass converts rock ops to std dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Conversion/RockToGPU/RockToGPU.h"
+
+#include "mlir/Dialect/AMDGPU/AMDGPUDialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "triton/Dialect/Rock/IR/Rock.h"
+#include "triton/Dialect/Rock/Passes.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTROCKTOGPUPASS
+#include "triton/Conversion/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+struct LowerRockOpsToGPUPass
+    : public impl::ConvertRockToGPUPassBase<LowerRockOpsToGPUPass> {
+public:
+  using impl::ConvertRockToGPUPassBase<
+      LowerRockOpsToGPUPass>::ConvertRockToGPUPassBase;
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Rock Operation pattern lowering.
+//===----------------------------------------------------------------------===//
+
+struct MIGPUAllocRewritePattern : public OpRewritePattern<rock::GpuAllocOp> {
+  using OpRewritePattern<rock::GpuAllocOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(rock::GpuAllocOp op,
+                                PatternRewriter &b) const override {
+    auto type = op.getOutput().getType();
+    auto gpuAttr = type.getMemorySpace().dyn_cast<gpu::AddressSpaceAttr>();
+    auto func = op->getParentOfType<gpu::GPUFuncOp>();
+    Location loc = op->getLoc();
+
+    if (gpuAttr.getValue() == gpu::GPUDialect::getWorkgroupAddressSpace()) {
+      Value attribution = func.addWorkgroupAttribution(type, loc);
+      op.replaceAllUsesWith(attribution);
+    } else if (gpuAttr.getValue() ==
+               gpu::GPUDialect::getPrivateAddressSpace()) {
+      Value attribution = func.addPrivateAttribution(type, loc);
+      op.replaceAllUsesWith(attribution);
+    } else {
+      // TBD: return failure.
+      llvm::errs() << "unsupported addrspace!\n";
+    }
+    op.erase();
+    return success();
+  }
+};
+
+template <typename Tmi, typename Tgpu>
+struct MIOpRewritePattern : public OpRewritePattern<Tmi> {
+  using OpRewritePattern<Tmi>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Tmi op, PatternRewriter &b) const override {
+    b.create<Tgpu>(op.getLoc());
+    op.erase();
+    return success();
+  }
+};
+
+template <typename Tmi, typename Tgpu>
+struct MIIdRewritePattern : public OpRewritePattern<Tmi> {
+  using OpRewritePattern<Tmi>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Tmi op, PatternRewriter &b) const override {
+    Value nop =
+        b.create<Tgpu>(op.getLoc(), b.getIndexType(), gpu::Dimension::x);
+    op.replaceAllUsesWith(nop);
+    op.erase();
+    return success();
+  }
+};
+} // namespace
+
+void LowerRockOpsToGPUPass::runOnOperation() {
+  ModuleOp op = getOperation();
+  MLIRContext *ctx = op.getContext();
+  OpBuilder b(ctx);
+  Location loc = op.getLoc();
+
+  // Annotate this module as a container module.
+  op->setAttr(gpu::GPUDialect::getContainerModuleAttrName(),
+              UnitAttr::get(ctx));
+
+  auto makeGpuModule = [&](StringRef name) {
+    // create a GPUModuleOp in case the GPU module specified does not exist.
+    auto gpuModule = b.create<gpu::GPUModuleOp>(loc, name);
+
+    // add the GPUModuleOp into the symbol table.
+    SymbolTable symbolTable(op);
+    symbolTable.insert(gpuModule);
+
+    return gpuModule;
+  };
+
+  auto processGpuKernelFunc = [&](gpu::GPUModuleOp &gpuMod,
+                                  func::FuncOp &theFunc) -> LogicalResult {
+    // Set up the symbol table for the GPU ModuleOp.
+    SymbolTable gpuModuleSymbolTable(gpuMod);
+    // Reset builder insertion point to the beginning of the GPU module,
+    // as it would be modified inside the lambda.
+    OpBuilder b(gpuMod.getContext());
+
+    // create a GPUFuncOp.
+    FunctionType gpuFuncType = theFunc.getFunctionType();
+    auto gpuFunc =
+        b.create<gpu::GPUFuncOp>(loc, theFunc.getName(), gpuFuncType);
+
+    // insert the GPUFuncOp into GPUModuleOp.
+    gpuModuleSymbolTable.insert(gpuFunc);
+
+    // Set kernel attribute.
+    int32_t gridSize = 0;
+    int32_t blockSize = 0;
+    gpuFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(), b.getUnitAttr());
+    if (auto attr = theFunc->getAttr("block_size")) {
+      gpuFunc->setAttr("block_size", attr);
+      blockSize = attr.template cast<IntegerAttr>().getInt();
+      gpuFunc->setAttr(gpu::GPUFuncOp::getKnownBlockSizeAttrName(),
+                       b.getDenseI32ArrayAttr({blockSize, 1, 1}));
+    }
+    if (auto attr = theFunc->getAttr("grid_size")) {
+      gpuFunc->setAttr("grid_size", attr);
+      gridSize = attr.template cast<IntegerAttr>().getInt();
+      gpuFunc->setAttr(gpu::GPUFuncOp::getKnownGridSizeAttrName(),
+                       b.getDenseI32ArrayAttr({gridSize, 1, 1}));
+    }
+
+    // associate arguments for newly created GPUFuncOp.
+    IRMapping map;
+    for (auto pair : llvm::zip(theFunc.getArguments(), gpuFunc.getArguments()))
+      map.map(std::get<0>(pair), std::get<1>(pair));
+
+    // clone function body into newly created GPUFuncOp.
+    Region &gpuFuncBody = gpuFunc.getBody();
+    Region &funcBody = theFunc.getBody();
+    funcBody.cloneInto(&gpuFuncBody, map);
+
+    // add a branch op to the cloned region.
+    Block &funcEntry = funcBody.front();
+    Block *clonedFuncEntry = map.lookup(&funcEntry);
+    Block &gpuFuncEntry = gpuFuncBody.front();
+    b.setInsertionPointToEnd(&gpuFuncEntry);
+    b.create<cf::BranchOp>(loc, clonedFuncEntry);
+
+    // Clone in global constants
+    llvm::SmallDenseMap<SymbolRefAttr, FlatSymbolRefAttr> clonedConsts;
+    WalkResult result = funcBody.walk([&](memref::GetGlobalOp op)
+                                          -> WalkResult {
+      SymbolRefAttr globalSym = op.getNameAttr();
+      auto toClone = dyn_cast_or_null<memref::GlobalOp>(
+          SymbolTable::lookupNearestSymbolFrom(op, globalSym));
+      if (!toClone)
+        return WalkResult::interrupt();
+      if (toClone->getParentOfType<gpu::GPUModuleOp>() == gpuMod)
+        // Already cloned, continue
+        return WalkResult::advance();
+      auto maybeMapped = clonedConsts.find(globalSym);
+      if (maybeMapped == clonedConsts.end()) {
+        OpBuilder::InsertionGuard guard(b);
+        Operation *cloned = toClone.clone();
+        // There probably shouldn't be any renames, but let's be careful.
+        StringAttr newNameAttr = gpuModuleSymbolTable.insert(cloned);
+        clonedConsts.insert({globalSym, FlatSymbolRefAttr::get(newNameAttr)});
+      }
+      op.setNameAttr(clonedConsts.find(globalSym)->second);
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted())
+      return theFunc.emitOpError("failed to clone referenced global constants");
+    // copy original_func attribute
+    const char *attrName = "original_func";
+    if (auto attr = theFunc->getAttrOfType<SymbolRefAttr>(attrName)) {
+      gpuFunc->setAttr(attrName, attr);
+    }
+
+    // convert all calls to gpu.launch_func
+    SmallVector<func::CallOp, 4> calls;
+    op.walk([&](func::CallOp call) {
+      if (auto callable = call.getCallableForCallee()) {
+        if (FlatSymbolRefAttr symRef = callable.dyn_cast<SymbolRefAttr>()
+                                           .dyn_cast<FlatSymbolRefAttr>()) {
+          if (symRef.getValue() == theFunc.getName()) {
+            OpBuilder b(call);
+            auto gridVal = b.create<arith::ConstantIndexOp>(loc, gridSize);
+            auto blockVal = b.create<arith::ConstantIndexOp>(loc, blockSize);
+            auto cst1 = b.create<arith::ConstantIndexOp>(loc, 1);
+            auto dynamicSharedMemSize =
+                b.create<arith::ConstantIntOp>(loc, 0, b.getI32Type());
+            gpu::KernelDim3 gridDims{gridVal, cst1, cst1};
+            gpu::KernelDim3 blockDims{blockVal, cst1, cst1};
+            b.create<gpu::LaunchFuncOp>(loc, gpuFunc, gridDims, blockDims,
+                                        dynamicSharedMemSize,
+                                        call.getOperands());
+            calls.push_back(call);
+          }
+        }
+      }
+    });
+
+    for (auto &call : calls) {
+      call.erase();
+    }
+
+    return success();
+  };
+
+  SmallVector<func::FuncOp, 1> processedFuncs;
+  // Check parameters and populate default values if necessary.
+  for (auto func : op.getOps<func::FuncOp>()) {
+    if (func->hasAttr("kernel")) {
+      std::string gfname = func.getName().str();
+      gfname += "_module";
+      auto gpuMod = makeGpuModule(gfname);
+      if (failed(processGpuKernelFunc(gpuMod, func)))
+        signalPassFailure();
+
+      processedFuncs.push_back(func);
+    }
+  }
+
+  // Remove all processed FuncOp instances.
+  for (auto func : processedFuncs) {
+    func.erase();
+  }
+
+  // Convert Rock ops to GPU Ops
+  int gpuModCount = 0;
+  op.walk([this, &gpuModCount](gpu::GPUModuleOp gpuMod) {
+    gpuModCount++;
+    auto *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+
+    // rock-lowering
+    patterns.add<MIGPUAllocRewritePattern,
+                 MIOpRewritePattern<rock::WorkgroupBarrierOp, gpu::BarrierOp>,
+                 MIOpRewritePattern<rock::LDSBarrierOp, amdgpu::LDSBarrierOp>,
+                 MIIdRewritePattern<rock::WorkgroupIdOp, gpu::BlockIdOp>,
+                 MIIdRewritePattern<rock::WorkitemIdOp, gpu::ThreadIdOp>,
+                 MIOpRewritePattern<func::ReturnOp, gpu::ReturnOp>>(ctx);
+
+    if (failed(applyPatternsAndFoldGreedily(gpuMod, std::move(patterns))))
+      signalPassFailure();
+  });
+
+  if (gpuModCount == 0) {
+    // Must have at least 1 gpu.module for rocm-runner
+    makeGpuModule("rock_gpu_module");
+  }
+}

--- a/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
@@ -30,8 +30,10 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTROCKTOLLVM
 #include "triton/Conversion/Passes.h.inc"
+} // namespace mlir
 
 namespace mlir {
 
@@ -106,9 +108,11 @@ private:
   int numWarps{0};
 };
 
-class ConvertRockToLLVM : public ConvertRockToLLVMBase<ConvertRockToLLVM> {
+class ConvertRockToLLVM
+    : public impl::ConvertRockToLLVMBase<ConvertRockToLLVM> {
 
 public:
+  using impl::ConvertRockToLLVMBase<ConvertRockToLLVM>::ConvertRockToLLVMBase;
   explicit ConvertRockToLLVM(int computeCapability)
       : computeCapability(computeCapability) {}
 

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.cpp
@@ -43,9 +43,11 @@ using namespace mlir::triton::gpu;
 using namespace mlir::arith;
 using namespace mlir::rock;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTTRITONGPUTOROCK
 #include "triton/Conversion/Passes.h.inc"
 #include "triton/Dialect/Rock/Passes.h.inc"
+} // namespace mlir
 
 static bool isConvertLDSToDotOp(Operation *op) {
   bool result = false;
@@ -313,9 +315,11 @@ struct DotOpRewritePattern : public OpRewritePattern<triton::DotOp> {
 namespace {
 
 class ConvertTritonGPUToRock
-    : public ConvertTritonGPUToRockBase<ConvertTritonGPUToRock> {
+    : public impl::ConvertTritonGPUToRockBase<ConvertTritonGPUToRock> {
 
 public:
+  using impl::ConvertTritonGPUToRockBase<
+      ConvertTritonGPUToRock>::ConvertTritonGPUToRockBase;
   explicit ConvertTritonGPUToRock(int computeCapability)
       : computeCapability(computeCapability) {}
 

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -18,8 +18,10 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTTRITONTOTRITONGPU
 #include "triton/Conversion/Passes.h.inc"
+} // namespace mlir
 
 namespace {
 
@@ -673,8 +675,10 @@ void populateCFPatterns(TritonGPUTypeConverter &typeConverter,
 //
 
 class ConvertTritonToTritonGPU
-    : public ConvertTritonToTritonGPUBase<ConvertTritonToTritonGPU> {
+    : public impl::ConvertTritonToTritonGPUBase<ConvertTritonToTritonGPU> {
 public:
+  using impl::ConvertTritonToTritonGPUBase<
+      ConvertTritonToTritonGPU>::ConvertTritonToTritonGPUBase;
   ConvertTritonToTritonGPU() = default;
   // constructor with some parameters set explicitly.
   ConvertTritonToTritonGPU(int numWarps) { this->numWarps = numWarps; }

--- a/test/dot-rocMLIR/Conversion/RockToGPU/alloc.mlir
+++ b/test/dot-rocMLIR/Conversion/RockToGPU/alloc.mlir
@@ -1,0 +1,16 @@
+// RUN: triton-opt -convert-rock-to-gpu %s | FileCheck %s
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: gpu.module @allockernel_module
+// CHECK-NEXT: gpu.func @allockernel(%{{.*}}: memref<?x?x?x?xf32>) workgroup(%{{.*}}: memref<16xf32, #gpu.address_space<workgroup>>) private(%{{.*}}: memref<16xf32, #gpu.address_space<private>>) kernel
+module {
+  func.func @allockernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32} {
+    %cst = arith.constant 0.0 : f32
+    %c0 = arith.constant 0 : index
+    %buffer_lds = rock.alloc() : memref<16xf32, #gpu.address_space<workgroup>>
+    %buffer_vgpr = rock.alloc() : memref<16xf32, #gpu.address_space<private>>
+    memref.store %cst, %buffer_lds[%c0] : memref<16xf32, #gpu.address_space<workgroup>>
+    memref.store %cst, %buffer_vgpr[%c0] : memref<16xf32, #gpu.address_space<private>>
+    return
+  }
+}

--- a/test/dot-rocMLIR/Conversion/RockToGPU/emptykernel.mlir
+++ b/test/dot-rocMLIR/Conversion/RockToGPU/emptykernel.mlir
@@ -1,0 +1,11 @@
+// RUN: triton-opt -convert-rock-to-gpu %s | FileCheck %s
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: gpu.module @emptykernel_module
+// CHECK-NEXT: gpu.func @emptykernel(%{{.*}}: memref<?x?x?x?xf32>) kernel
+
+module {
+  func.func @emptykernel(%arg0: memref<?x?x?x?xf32>) attributes {kernel = 0 : i32} {
+    return
+  }
+}

--- a/test/dot-rocMLIR/Conversion/RockToGPU/memref_global.mlir
+++ b/test/dot-rocMLIR/Conversion/RockToGPU/memref_global.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt -convert-rock-to-gpu %s | FileCheck %s
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: memref.global "private" constant @const : memref<2xi32> = dense<[[VALUE:.*]]>
+memref.global "private" constant @const : memref<2xi32> = dense<"0xDEADBEEFBEEFDEAD">
+// CHECK-NEXT: memref.global "private" constant @kern2_module : memref<2xi32> = dense<[[VALUE2:.*]]>
+memref.global "private" constant @kern2_module : memref<2xi32> = dense<"0xC01DF00D">
+// CHECK: gpu.module @kern_module
+// CHECK-NEXT: gpu.func @kern
+func.func @kern(%arg0 : memref<2xi32>) attributes {kernel, block_size = 64 : i32, grid_size = 1 : i32 } {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = memref.get_global @const : memref<2xi32>
+  %1 = memref.load %0[%c0] : memref<2xi32>
+  %2 = memref.load %0[%c1] : memref<2xi32>
+  memref.store %1, %arg0[%c1] : memref<2xi32>
+  memref.store %2, %arg0[%c0] : memref<2xi32>
+  func.return
+}
+// CHECK: memref.global "private" constant @const : memref<2xi32> = dense<[[VALUE]]>
+// CHECK-NEXT: }
+
+// CHECK: gpu.module @kern2_module_0
+// CHECK-NEXT: gpu.func @kern2
+func.func @kern2(%arg0 : memref<2xi32>) attributes {kernel, block_size = 64 : i32, grid_size = 1 : i32 } {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = memref.get_global @kern2_module : memref<2xi32>
+  %1 = memref.get_global @kern2_module : memref<2xi32>
+  %2 = memref.load %0[%c0] : memref<2xi32>
+  %3 = memref.load %1[%c1] : memref<2xi32>
+  memref.store %2, %arg0[%c1] : memref<2xi32>
+  memref.store %3, %arg0[%c0] : memref<2xi32>
+  func.return
+}
+// CHECK: memref.global "private" constant @kern2_module : memref<2xi32> = dense<[[VALUE2]]>
+// CHECK-NOT: memref.global
+// CHECK-NEXT: }
+// CHECK-NEXT: }

--- a/test/dot-rocMLIR/Conversion/RockToGPU/misc_ops.mlir
+++ b/test/dot-rocMLIR/Conversion/RockToGPU/misc_ops.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-opt -convert-rock-to-gpu %s | FileCheck %s
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-NEXT: gpu.module @misckernel_module
+// CHECK-NEXT: gpu.func @misckernel(%{{.*}}: memref<?xf32>, %{{.*}}: memref<?xf32>) kernel
+// CHECK-SAME: block_size = 64 : i32
+// CHECK-SAME: gpu.known_block_size = array<i32: 64, 1, 1>
+// CHECK-SAME: gpu.known_grid_size = array<i32: 900, 1, 1>
+// CHECK-SAME: grid_size = 900 : i32
+module {
+  func.func @misckernel(%arg0: memref<?xf32>, %arg1: memref<?xf32>)
+      attributes {kernel = 0 : i32, block_size = 64 : i32, grid_size = 900 : i32} {
+    // CHECK: gpu.barrier
+    rock.workgroup_barrier
+
+    // CHECK: gpu.lds_barrier
+    rock.lds_barrier
+
+    // CHECK: %{{.*}} = gpu.block_id x
+    %bid = rock.workgroup_id : index
+
+    // CHECK: %{{.*}} = gpu.thread_id x
+    %tid = rock.workitem_id : index
+
+    %idx = arith.muli %bid, %tid : index
+
+    %val = memref.load %arg0[%idx] : memref<?xf32>
+
+    memref.store %val, %arg1[%idx] : memref<?xf32>
+    return
+  }
+}

--- a/test/dot-rocMLIR/Rock/sanity.mlir
+++ b/test/dot-rocMLIR/Rock/sanity.mlir
@@ -16,7 +16,7 @@
 #lds1 = #triton_gpu.lds<{kpack = 4, order = [0, 1]}>
 #xdlops_gemm_params = #rock.xdlops_gemm_params<kPerBlock = 16, mPerBlock = 128, nPerBlock = 256, kpack = 4, mPerWave = 64, nPerWave = 64, forceUnroll = true>
 module attributes {"triton_gpu.num-warps" = 8 : i32} {
-  func.func public @kernel_0d1c2d3d4c5d6d7d8c9d10d11c(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) {
+  func.func public @test_dot(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) attributes {kernel = 0 : i32} {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>
     %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
     %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>


### PR DESCRIPTION
This PR adds the RockToGPU conversion pass from the rocMLIR repo.
- Modify the existing conversion passes to use the per-pass autogenerated macros ([reference](https://discourse.llvm.org/t/psa-deprecation-warning-per-pass-autogenerated-macros-and-pass-options/64998)).
- Add {kernel = 0} as an attribute of the `mlir::func::FuncOp`. This is required by the RockToGPU pass to convert the `func.func` into a `gpu.func`
- Add unit test for the RockToGPU pass

This pass will
1. Convert the `func.func` into `gpu.func`
2. Create a `gpu.module` inside the top level `Module` to wrap the `gpu.func`
3. Add a `gpu.container_module` attribute to the top level `Module`
4. Lower `rock.alloc`