### PR TITLE
Fix test_convert2d

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1952,7 +1952,7 @@ if torch.version.hip is not None:
         # MmaLayout(version=(2, 0), warps_per_cta=[1, 4]),
         # MmaLayout(version=1, warps_per_cta=[4, 1]),
         # MmaLayout(version=(2, 0), warps_per_cta=[4, 1]),
-        BlockedLayout([1, 2], [2, 32], [2, 2], [1, 0]),
+        BlockedLayout([1, 4], [2, 32], [2, 2], [1, 0]),
         BlockedLayout([2, 2], [4, 16], [2, 2], [1, 0]),
         BlockedLayout([1, 1], [1, 64], [2, 2], [1, 0]),
         BlockedLayout([4, 2], [16, 4], [1, 4], [0, 1]),


### PR DESCRIPTION
In the recent IFU, the mask of store op was changed to something like 
mask = tid * elemsPerThread < numElems
where `elemsPerThread` is the total number of elements each thread needs to take care of, which is computed out of the tensor shape of the layout encoding, and `numElems` is the total number of elements in the tensor.
This is not technically correct since each thread is not storing `elemsPerThread` elements contiguously. And this is caught when the CTA coverage, obtained from `getShapePerCTA`, cannot be covered by the tensor, which is the case with layout0 in test_convert2d.