### PR TITLE
[WIP][DotOp][MFMA] Base for MFMA DotOp pipepine

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -131,6 +131,14 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
           llvm_unreachable("invalid operand index");
         }
 
+#ifdef USE_ROCM
+        // ---- begin MI200 ----
+        if (mmaEnc.isMI200()) {
+          // Swizzling is currently disabled for MFMA
+          return $_get(context, 1, 1, 1, order);
+        }
+#endif
+
         // ---- not implemented ----
         llvm_unreachable("unsupported swizzling for provided MMA version");
     }]>
@@ -426,6 +434,9 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
   let extraClassDeclaration = extraBaseClassDeclaration # [{
     bool isVolta() const;
     bool isAmpere() const;
+#ifdef USE_ROCM
+    bool isMI200() const;
+#endif
     // Get [isARow, isBRow, isAVec4, isBVec4, id] from versionMinor
     std::tuple<bool, bool, bool, bool, int> decodeVoltaLayoutStates() const;
     // Number of bits in versionMinor to hold the ID of the MMA encoding instance.

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -127,7 +127,7 @@ bool supportMMA(triton::DotOp op, int version) {
   // Tensor Core in
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-fragment-mma-884-f16
 #ifdef USE_ROCM
-  return false;
+  //return false;
 #endif
   auto aElemTy = op.getA().getType().cast<RankedTensorType>().getElementType();
   auto bElemTy = op.getB().getType().cast<RankedTensorType>().getElementType();
@@ -141,10 +141,13 @@ bool supportMMA(Value value, int version) {
   // Tell whether a DotOp support HMMA by the operand type(either $a or $b).
   // We cannot get both the operand types(in TypeConverter), here we assume the
   // types of both the operands are identical here.
+#ifdef USE_ROCM
+  // return false;
+  assert((version == 1 || version == 2 || version == 3) &&
+         "Unexpected MMA layout version found");
+#else
   assert((version == 1 || version == 2) &&
          "Unexpected MMA layout version found");
-#ifdef USE_ROCM
-  return false;
 #endif
   auto elemTy = value.getType().cast<RankedTensorType>().getElementType();
   return elemTy.isF16() || elemTy.isBF16() ||

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -132,7 +132,10 @@ bool supportMMA(triton::DotOp op, int version) {
   auto aElemTy = op.getA().getType().cast<RankedTensorType>().getElementType();
   auto bElemTy = op.getB().getType().cast<RankedTensorType>().getElementType();
   if (aElemTy.isF32() && bElemTy.isF32()) {
-    return op.getAllowTF32() && version >= 2;
+    return (op.getAllowTF32() && version == 2) || (!op.getAllowTF32() && version == 3);
+  }
+  if (aElemTy.isF32() && bElemTy.isF32()) {
+    
   }
   return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
 }

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -127,15 +127,19 @@ bool supportMMA(triton::DotOp op, int version) {
   // Tensor Core in
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-fragment-mma-884-f16
 #ifdef USE_ROCM
-  //return false;
+  // return false;
 #endif
   auto aElemTy = op.getA().getType().cast<RankedTensorType>().getElementType();
   auto bElemTy = op.getB().getType().cast<RankedTensorType>().getElementType();
+  auto aOrder = triton::gpu::getOrder(
+      op.getA().getType().cast<RankedTensorType>().getEncoding());
+  auto bOrder = triton::gpu::getOrder(
+      op.getB().getType().cast<RankedTensorType>().getEncoding());
+  if (aOrder[1] == 0 || bOrder[1] == 0)
+    return false;
   if (aElemTy.isF32() && bElemTy.isF32()) {
-    return (op.getAllowTF32() && version == 2) || (!op.getAllowTF32() && version == 3);
-  }
-  if (aElemTy.isF32() && bElemTy.isF32()) {
-    
+    return (op.getAllowTF32() && version == 2) ||
+           (!op.getAllowTF32() && version == 3);
   }
   return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -590,7 +590,8 @@ private:
       // so they can be consumed by tensor core operations
       unsigned vecSize;
       if (srcMmaLayout.isMI200()) {
-        vecSize = 16;
+        // recheck double-check this part
+        vecSize = 1;
         Type vecTy = vec_ty(elemTy, vecSize);
         SmallVector<Type> types(elems / vecSize, vecTy);
         SmallVector<Value> vecVals;

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
@@ -1507,7 +1507,7 @@ DotOpMFMAConversionHelper::computeOffsetsA(Value waveM, Value laneId,
   Value colOffset = mul(waveHalf, i32_val(numOfElems));
 
   for (int block = 0; block < numM; ++block) {
-    Value blockOffset = mul(i32_val(block * mfmaShape[0] * lineSize));
+    Value blockOffset = i32_val(block * mfmaShape[0] * lineSize);
     for (int tile = 0; tile < numK; ++tile) {
       Value tileOffset = i32_val(tile * mfmaShape[2]);
       for (int elem = 0; elem < numOfElems; ++elem) {
@@ -1538,7 +1538,7 @@ DotOpMFMAConversionHelper::computeOffsetsB(Value waveN, Value laneId,
   Value colOffset = urem(laneId, _32);
 
   for (int block = 0; block < numN; ++block) {
-    Value blockOffset = mul(i32_val(block * mfmaShape[1]));
+    Value blockOffset = i32_val(block * mfmaShape[1]);
     for (int tile = 0; tile < numK; ++tile) {
       Value tileOffset = i32_val(tile * mfmaShape[2] * lineSize);
       for (int elem = 0; elem < numOfElems; ++elem) {
@@ -1580,7 +1580,7 @@ Value DotOpMFMAConversionHelper::loadA(
 
   for (int m = 0; m < numRepM; ++m) {
     for (int k = 0; k < numRepK; ++k) {
-      auto vecTy = vec_ty(aTensorTy, numOfElems);
+      auto vecTy = vec_ty(aTensorTy.getElementType(), numOfElems);
       Value valVec = undef(vecTy);
       for (unsigned elem = 0; elem < numOfElems; ++elem) {
         Value elemOffset = offsets[m * numRepK + k * numOfElems + elem];
@@ -1624,7 +1624,7 @@ Value DotOpMFMAConversionHelper::loadB(
 
   for (int n = 0; n < numRepN; ++n) {
     for (int k = 0; k < numRepK; ++k) {
-      auto vecTy = vec_ty(bTensorTy, numOfElems);
+      auto vecTy = vec_ty(bTensorTy.getElementType(), numOfElems);
       Value valVec = undef(vecTy);
       for (unsigned elem = 0; elem < numOfElems; ++elem) {
         Value elemOffset = offsets[n * numRepK + k * numOfElems + elem];
@@ -1702,12 +1702,12 @@ LogicalResult DotOpMFMAConversionHelper::convertDot(
       getValuesFromDotOperandLayoutStruct(loadedB, numRepN, numRepK);
 
   SmallVector<Value> accValues;
-  auto vecTy = vec_ty(dTensorTy, 16);
+  auto vecTy = vec_ty(dTensorTy.getElementType(), 16);
   for (int m = 0; m < numRepM; ++m) {
     for (int n = 0; n < numRepN; ++n) {
       Value acc = undef(vecTy);
       for (unsigned v = 0; v < 16; ++v) {
-        Value _0 = dTensorTy.isF32() ? f32_val(0) : i32_val(0);
+        Value _0 = dTensorTy.getElementType().isF32() ? f32_val(0) : i32_val(0);
         acc = insert_element(vecTy, acc, _0, idx_val(v));
       }
       for (size_t k = 0; k < numRepK; k++) {

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
@@ -1584,7 +1584,8 @@ Value DotOpMFMAConversionHelper::loadA(
       auto vecTy = vec_ty(aTensorTy.getElementType(), numOfElems);
       Value valVec = undef(vecTy);
       for (unsigned elem = 0; elem < numOfElems; ++elem) {
-        Value elemOffset = offsets[m * numOfElems * numRepK + k * numOfElems + elem];
+        Value elemOffset =
+            offsets[m * numOfElems * numRepK + k * numOfElems + elem];
         Value elemValue = load(gep(smemPtrTy, smemBase, elemOffset));
         valVec = insert_element(vecTy, valVec, elemValue, idx_val(elem));
       }
@@ -1628,7 +1629,8 @@ Value DotOpMFMAConversionHelper::loadB(
       auto vecTy = vec_ty(bTensorTy.getElementType(), numOfElems);
       Value valVec = undef(vecTy);
       for (unsigned elem = 0; elem < numOfElems; ++elem) {
-        Value elemOffset = offsets[n * numOfElems * numRepK + k * numOfElems + elem];
+        Value elemOffset =
+            offsets[n * numOfElems * numRepK + k * numOfElems + elem];
         Value elemValue = load(gep(smemPtrTy, smemBase, elemOffset));
         valVec = insert_element(vecTy, valVec, elemValue, idx_val(elem));
       }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -678,6 +678,24 @@ struct DotOpMFMAConversionHelper {
 
   static std::tuple<int, int> getRepMN(const RankedTensorType &tensorTy);
 
+  // Get number of elements per thread for $a operand.
+  static size_t getANumElemsPerThread(RankedTensorType operand, int wpt) {
+    auto shape = operand.getShape();
+    int numOfElem = getNumOfElems(operand);
+    int repM = getNumRepM(operand, shape[0], wpt);
+    int repK = getNumRepK_(operand, shape[1]);
+    return repM * repK;
+  }
+
+  // Get number of elements per thread for $b operand.
+  static size_t getBNumElemsPerThread(RankedTensorType operand, int wpt) {
+    auto shape = operand.getShape();
+    int numOfElem = getNumOfElems(operand);
+    int repK = getNumRepK_(operand, shape[0]);
+    int repN = getNumRepN(operand, shape[1], wpt);
+    return repN * repK;
+  }
+
   Type getShemPtrTy() const;
 
   Type getLoadElemTy();
@@ -746,7 +764,7 @@ struct DotOpMFMAConversionHelper {
     return std::max<int>(K / instrK, 1);
   }
 
-  int getNumOfElems(Type operand) const {
+  static int getNumOfElems(Type operand) {
     auto matrixCoreType = getMatrixCoreTypeFromOperand(operand);
     int instrM = getMFMAInstrShape(matrixCoreType)[0];
     int instrK = getMFMAInstrShape(matrixCoreType)[2];

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -625,6 +626,186 @@ struct DotOpFMAConversionHelper {
         order[0] == 0 ? sizePerThread[order[1]] : sizePerThread[order[0]];
     return isM ? mSizePerThread : nSizePerThread;
   }
+};
+
+struct DotOpMFMAConversionHelper {
+  enum class MatrixCoreType : uint8_t {
+    // D = AB + C
+    FP32_FP16_FP16_FP32 = 0, // default
+    FP32_BF16_BF16_FP32,
+    FP32_FP32_FP32_FP32,
+    FP64_FP64_FP64_FP64,
+    INT32_INT8_INT8_INT32,
+    NOT_APPLICABLE,
+  };
+
+  MmaEncodingAttr mmaLayout;
+  ArrayRef<unsigned int> wpt;
+
+  Value thread, lane, wave;
+
+  ConversionPatternRewriter &rewriter;
+  Location loc;
+  MLIRContext *ctx{};
+
+  using ValueTable = std::map<std::pair<unsigned, unsigned>, Value>;
+  explicit DotOpMFMAConversionHelper(Type dotOperand, MmaEncodingAttr mmaLayout,
+                                     Value thread,
+                                     ConversionPatternRewriter &rewriter,
+                                     TypeConverter *typeConverter, Location loc)
+      : mmaLayout(mmaLayout), wpt(mmaLayout.getWarpsPerCTA()), thread(thread),
+        rewriter(rewriter), typeConverter(typeConverter), loc(loc),
+        ctx(mmaLayout.getContext()) {
+    deduceMFMAType(dotOperand);
+    Value waveSize = i32_val(64);
+    lane = urem(thread, waveSize);
+    wave = udiv(thread, waveSize);
+  }
+
+  void deduceMFMAType(DotOp op) const { mfmaType = getMFMAType(op); }
+  void deduceMFMAType(Type operandTy) const {
+    mfmaType = getMatrixCoreTypeFromOperand(operandTy);
+  }
+
+  ArrayRef<int> getMFMAInstrShape() const {
+    assert(mfmaType != MatrixCoreType::NOT_APPLICABLE &&
+           "Unknown MFMA type found.");
+    return mfmaInstrShape.at(mfmaType);
+  }
+
+  // Get the M and N of MFMA instruction shape.
+  static std::tuple<int, int> getInstrShapeMN() { return {32, 32}; }
+
+  static std::tuple<int, int> getRepMN(const RankedTensorType &tensorTy);
+
+  Type getShemPtrTy() const;
+
+  Type getLoadElemTy();
+
+  Type getMRetType() const;
+
+  llvm::SmallVector<Value> computeOffsetsA(Value waveM, Value laneId,
+                                           int numOfElems, int numM, int numK,
+                                           Value cSwizzleOffset) const;
+  llvm::SmallVector<Value> computeOffsetsB(Value waveN, Value laneId,
+                                           int numOfElems, int numK, int numN,
+                                           Value cSwizzleOffset) const;
+
+  Value generateMFMAOp(Value valA, Value valB, Value valC) const;
+
+  static ArrayRef<int> getMFMAInstrShape(MatrixCoreType matrixCoreType) {
+    assert(matrixCoreType != MatrixCoreType::NOT_APPLICABLE &&
+           "Unknown MFMA type found.");
+    return mfmaInstrShape.at(matrixCoreType);
+  }
+
+  // Deduce the MatrixCoreType from either $a or $b's type.
+  static MatrixCoreType getMatrixCoreTypeFromOperand(Type operandTy);
+
+  static MatrixCoreType getMFMAType(triton::DotOp op);
+
+  std::tuple<int, int, int> getMFMAInstrShape(Type operand) const {
+    deduceMFMAType(operand);
+    auto instrShape = getMFMAInstrShape();
+    int instrM = instrShape[0];
+    int instrN = instrShape[1];
+    int instrK = instrShape[2];
+    return std::make_tuple(instrM, instrN, instrK);
+  }
+
+  // \param operand is either $a or $b's type.
+  inline int getNumRepM(Type operand, int M) const {
+    return getNumRepM(operand, M, wpt[0]);
+  }
+
+  // \param operand is either $a or $b's type.
+  inline int getNumRepN(Type operand, int N) const {
+    return getNumRepN(operand, N, wpt[1]);
+  }
+
+  // \param operand is either $a or $b's type.
+  inline int getNumRepK(Type operand, int K) const {
+    return getNumRepK_(operand, K);
+  }
+
+  static int getNumRepM(Type operand, int M, int wpt) {
+    auto matrixCoreType = getMatrixCoreTypeFromOperand(operand);
+    int instrM = getMFMAInstrShape(matrixCoreType)[0];
+    return std::max<int>(M / (wpt * instrM), 1);
+  }
+
+  static int getNumRepN(Type operand, int N, int wpt) {
+    auto matrixCoreType = getMatrixCoreTypeFromOperand(operand);
+    int instrN = getMFMAInstrShape(matrixCoreType)[1];
+    return std::max<int>(N / (wpt * instrN), 1);
+  }
+
+  static int getNumRepK_(Type operand, int K) {
+    auto matrixCoreType = getMatrixCoreTypeFromOperand(operand);
+    int instrK = getMFMAInstrShape(matrixCoreType)[2];
+    return std::max<int>(K / instrK, 1);
+  }
+
+  int getNumOfElems(Type operand) const {
+    auto matrixCoreType = getMatrixCoreTypeFromOperand(operand);
+    int instrM = getMFMAInstrShape(matrixCoreType)[0];
+    int instrK = getMFMAInstrShape(matrixCoreType)[2];
+    return std::max<int>(instrM * instrK / 64, 1);
+  }
+
+  int getNumOfElems() const {
+    int instrM = getMFMAInstrShape(mfmaType)[0];
+    int instrK = getMFMAInstrShape(mfmaType)[2];
+    return std::max<int>(instrM * instrK / 64, 1);
+  }
+
+  // Get a waveId for M axis.
+  Value getWaveM(int M) const {
+    auto instrShape = getMFMAInstrShape();
+    return urem(urem(wave, i32_val(wpt[0])), i32_val(M / instrShape[0]));
+  }
+
+  // Get a waveId for N axis.
+  Value getWaveN(int N) const {
+    auto instrShape = getMFMAInstrShape();
+    Value waveMN = udiv(wave, i32_val(wpt[0]));
+    return urem(urem(waveMN, i32_val(wpt[1])), i32_val(N / instrShape[1]));
+  }
+
+  // Loading $a from lds to registers, returns a LLVM::Struct.
+  Value loadA(Value tensor, const SharedMemoryObject &smemObj) const;
+
+  // Loading $b from lds to registers, returns a LLVM::Struct.
+  Value loadB(Value tensor, const SharedMemoryObject &smemObj) const;
+
+  // Loading $c to registers, returns a Value.
+  Value loadC(Value tensor, Value llTensor) const;
+
+  // Conduct the Dot conversion.
+  // \param a, \param b, \param c and \param d are DotOp operands.
+  // \param loadedA, \param loadedB, \param loadedC, all of them are result of
+  // loading.
+  LogicalResult convertDot(Value a, Value b, Value c, Value d, Value loadedA,
+                           Value loadedB, Value loadedC, DotOp op,
+                           DotOpAdaptor adaptor) const;
+
+  ValueTable getValuesFromDotOperandLayoutStruct(Value value, int n0,
+                                                 int n1) const;
+  TypeConverter *getTypeConverter() const { return typeConverter; }
+
+private:
+  TypeConverter *typeConverter;
+  mutable MatrixCoreType mfmaType{MatrixCoreType::NOT_APPLICABLE};
+
+  // Used on AMDGPU mma layout .version == 3
+  inline static const std::map<MatrixCoreType, llvm::SmallVector<int>>
+      mfmaInstrShape = { // m, n, k
+          {MatrixCoreType::FP32_FP16_FP16_FP32, {32, 32, 8}},
+          {MatrixCoreType::FP32_BF16_BF16_FP32, {32, 32, 4}},
+          {MatrixCoreType::FP32_FP32_FP32_FP32, {32, 32, 2}},
+
+          {MatrixCoreType::INT32_INT8_INT8_INT32, {32, 32, 8}},
+          {MatrixCoreType::FP64_FP64_FP64_FP64, {16, 16, 4}}};
 };
 
 } // namespace LLVM

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -702,10 +702,10 @@ struct DotOpMFMAConversionHelper {
 
   Type getMRetType() const;
 
-  llvm::SmallVector<Value> computeOffsetsA(Value waveM, Value laneId,
+  llvm::SmallVector<Value> computeOffsetsA(Value waveM, Value laneId, int wptA,
                                            int numOfElems, int numM, int numK,
                                            Value cSwizzleOffset) const;
-  llvm::SmallVector<Value> computeOffsetsB(Value waveN, Value laneId,
+  llvm::SmallVector<Value> computeOffsetsB(Value waveN, Value laneId, int wptB,
                                            int numOfElems, int numK, int numN,
                                            Value cSwizzleOffset) const;
 

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
@@ -6,6 +6,7 @@ using namespace mlir;
 using namespace mlir::triton;
 
 using ::mlir::LLVM::DotOpFMAConversionHelper;
+using ::mlir::LLVM::DotOpMFMAConversionHelper;
 using ::mlir::LLVM::DotOpMmaV1ConversionHelper;
 using ::mlir::LLVM::getElementsFromStruct;
 using ::mlir::LLVM::getStructFromElements;
@@ -39,6 +40,11 @@ struct DotOpConversion : public ConvertTritonGPUOpToLLVMPattern<triton::DotOp> {
         return convertMMA884(op, adaptor, rewriter);
       if (mmaLayout.isAmpere())
         return convertMMA16816(op, adaptor, rewriter);
+#ifdef USE_ROCM
+      if (mmaLayout.isMI200()) {
+        return convertMFMA(op, adaptor, rewriter);
+      }
+#endif
 
       llvm::report_fatal_error(
           "Unsupported MMA kind found when converting DotOp to LLVM.");
@@ -287,6 +293,39 @@ private:
     rewriter.replaceOp(op, res);
 
     return success();
+  }
+
+  LogicalResult convertMFMA(triton::DotOp op, OpAdaptor adaptor,
+                            ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto mmaLayout = op.getResult()
+                         .getType()
+                         .cast<RankedTensorType>()
+                         .getEncoding()
+                         .cast<MmaEncodingAttr>();
+
+    Value A = op.getA();
+    Value B = op.getB();
+    Value C = op.getC();
+
+    DotOpMFMAConversionHelper helper(A.getType(), mmaLayout,
+                                     getThreadId(rewriter, loc), rewriter,
+                                     getTypeConverter(), loc);
+
+    auto ATensorTy = A.getType().cast<RankedTensorType>();
+    auto BTensorTy = B.getType().cast<RankedTensorType>();
+
+    assert(ATensorTy.getEncoding().isa<DotOperandEncodingAttr>() &&
+           BTensorTy.getEncoding().isa<DotOperandEncodingAttr>() &&
+           "Both $a and %b should be DotOperand layout.");
+
+    Value loadedA, loadedB, loadedC;
+    loadedA = adaptor.getA();
+    loadedB = adaptor.getB();
+    loadedC = helper.loadC(op.getC(), adaptor.getC());
+
+    return helper.convertDot(A, B, C, op.getD(), loadedA, loadedB, loadedC, op,
+                             adaptor);
   }
 };
 

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -518,6 +518,10 @@ public:
           result = emitBaseIndexForMmaLayoutV1(loc, rewriter, mmaLayout, shape);
         if (mmaLayout.isAmpere())
           result = emitBaseIndexForMmaLayoutV2(loc, rewriter, mmaLayout, shape);
+#ifdef USE_ROCM
+        if (mmaLayout.isMI200())
+          llvm_unreachable("if (mmaLayout.isMI200()) not implemented");
+#endif
       } else {
         llvm_unreachable("unsupported emitBaseIndexForLayout");
       }
@@ -536,6 +540,10 @@ public:
         return emitOffsetForMmaLayoutV1(mmaLayout, shape);
       if (mmaLayout.isAmpere())
         return emitOffsetForMmaLayoutV2(mmaLayout, shape);
+#ifdef USE_ROCM
+      if (mmaLayout.isMI200())
+        llvm_unreachable("if (mmaLayout.isMI200()) not implemented");
+#endif
     }
     llvm_unreachable("unsupported emitOffsetForLayout");
   }

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -145,9 +145,9 @@ public:
 #ifdef USE_ROCM
         if (mmaLayout.isMI200()) {
           const llvm::DenseMap<int, Type> targetTyMap = {
-              {32, vec_ty(elemTy, 1)},
+              {32, elemTy},
               {16, vec_ty(elemTy, 4)},
-              {8, vec_ty(elemTy, 4)},
+              {8, IntegerType::get(ctx, 32)},
           };
           Type targetTy = targetTyMap.lookup(elemTy.getIntOrFloatBitWidth());
           if (dotOpLayout.getOpIdx() == 0) { // $a

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -140,6 +140,11 @@ public:
             return struct_ty(SmallVector<Type>(elems, x2Ty));
           }
         }
+
+#ifdef USE_ROCM
+        if (mmaLayout.isMI200())
+          llvm_unreachable("if (mmaLayout.isMI200()) not implemented");
+#endif
       }
 
       llvm::errs() << "Unexpected dot operand layout detected in "

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -146,14 +146,13 @@ public:
         if (mmaLayout.isMI200()) {
           const llvm::DenseMap<int, Type> targetTyMap = {
               {32, vec_ty(elemTy, 1)},
-              {16, vec_ty(elemTy, 8)},
-              {8, vec_ty(elemTy, 8)},
+              {16, vec_ty(elemTy, 4)},
+              {8, vec_ty(elemTy, 4)},
           };
           Type targetTy = targetTyMap.lookup(elemTy.getIntOrFloatBitWidth());
           if (dotOpLayout.getOpIdx() == 0) { // $a
             auto elems =
                 DotOpMFMAConversionHelper::getANumElemsPerThread(type, wpt[0]);
-
             return struct_ty(SmallVector<Type>(elems, targetTy));
           }
           if (dotOpLayout.getOpIdx() == 1) { // $b

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -398,7 +398,8 @@ unsigned MmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape) const {
   size_t rank = shape.size();
   assert(rank == 2 && "Unexpected rank of mma layout");
 #ifdef USE_ROCM
-  assert((isVolta() || isAmpere() || isMI200()) && "Only versions 1, 2 or 3 are supported");
+  assert((isVolta() || isAmpere() || isMI200()) &&
+         "Only versions 1, 2 or 3 are supported");
 #else
   assert((isVolta() || isAmpere()) && "Only version 1 and 2 is supported");
 #endif
@@ -424,7 +425,9 @@ unsigned MmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape) const {
     res = elemsCol * elemsRow;
 #ifdef USE_ROCM
   } else if (isMI200()) {
-    llvm_unreachable("if (isMI200()) not implemented");
+    unsigned elemsCol = ceil<unsigned>(shape[0], 32 * getWarpsPerCTA()[0]) * 2;
+    unsigned elemsRow = ceil<unsigned>(shape[1], 32 * getWarpsPerCTA()[1]) * 2;
+    res = elemsCol * elemsRow;
 #endif
   } else {
     llvm_unreachable("Unexpected mma version");

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -170,7 +170,7 @@ SmallVector<unsigned>  getContigPerThread(const Attribute &layout) {
   if (auto mmaLayout = layout.dyn_cast<MmaEncodingAttr>()) {
 #ifdef USE_ROCM
     if (mmaLayout.isMI200())
-      return {4, 1};
+      return {1, 1};
       // llvm_unreachable("if (mmaLayout.isMI200()) not implemented");
 #endif
     assert(mmaLayout.isVolta() || mmaLayout.isAmpere());

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1071,15 +1071,15 @@ def dot(lhs: tl.tensor,
     # Cast operands of types f16 and i8 since only FMA implemented yet for ROCM.
     # So we always perform dot(f32,f32,f32)->f32 here with FMA.
     # TODO: remove the case for MMA/MFMA implemented cases
-    if torch.version.hip is not None:
-        ret_cast_scalar_ty = tl.float32 if lhs.type.scalar.is_int() else ret_scalar_ty
-        lhs = cast(lhs, ret_cast_scalar_ty, builder)
-        rhs = cast(rhs, ret_cast_scalar_ty, builder)
-        _0 = builder.create_splat(builder.get_fp32(0), [M, N])
-        ret_ty = tl.block_type(ret_cast_scalar_ty, [M, N])
-        ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
-                        ret_ty)
-        return cast(ret, ret_scalar_ty, builder)
+    #if torch.version.hip is not None:
+    #    ret_cast_scalar_ty = tl.float32 if lhs.type.scalar.is_int() else ret_scalar_ty
+    #    lhs = cast(lhs, ret_cast_scalar_ty, builder)
+    #    rhs = cast(rhs, ret_cast_scalar_ty, builder)
+    #    _0 = builder.create_splat(builder.get_fp32(0), [M, N])
+    #    ret_ty = tl.block_type(ret_cast_scalar_ty, [M, N])
+    #    ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
+    #                    ret_ty)
+    #    return cast(ret, ret_scalar_ty, builder)
 
     _0 = builder.create_splat(_0, [M, N])
     ret_ty = tl.block_type(ret_scalar_ty, [M, N])


### PR DESCRIPTION
This draft PR contains the basis for adding the MFMA path to the DotOp.

This draft PR contains the basis for adding the MFMA path to the DotOp.
Parts to be added here shortly:
* The `DotOpMFMAConversionHelper::convertDot` implementation, which will contain the code generation of all MFMA instructions
* Conversions from shared -> mma and mma -> blocked
