### PR TITLE
[FRONTEND] Fix triton-translate default options

### DIFF
--- a/bin/triton-translate.cpp
+++ b/bin/triton-translate.cpp
@@ -92,7 +92,7 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
       llvm::cl::value_desc("architecture"), llvm::cl::init("90a"));
 
   static llvm::cl::opt<std::string> GCNTriple(
-      "amdgcn", llvm::cl::desc("AMDGCN triple. e.g. '-amd-amdhsa'"),
+      "amdgcn", llvm::cl::desc("AMDGCN triple vendor and platfom. e.g. '-amd-amdhsa'"),
       llvm::cl::value_desc("target triple"), llvm::cl::init("-amd-amdhsa"));
 
   static llvm::cl::opt<std::string> GCNFeatures(
@@ -131,10 +131,11 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
     llvm::outs() << ::triton::translateLLVMIRToPTX(*llvmir, SMArch.getValue(),
                                                    ptxVersion.getValue());
   else if (targetKind == "hsaco") {
+    const std::string arch = "gfx" + GCNArch.getValue();
+    const std::string triple = "amdgcn" + GCNTriple.getValue();
+    const std::string features = GCNFeatures.getValue();
     auto [module, hsaco] =
-        ::triton::translateLLVMIRToHSACO(*llvmir, GCNArch.getValue(),
-                                                  GCNTriple.getValue(),
-                                                  GCNFeatures.getValue());
+        ::triton::translateLLVMIRToHSACO(*llvmir, arch, triple, features);
     llvm::outs() << hsaco;
   } else {
     llvm::errs() << "Error: Unknown target specified: " << targetKind << "\n";

--- a/lib/Target/HSACO/HSACOTranslation.cpp
+++ b/lib/Target/HSACO/HSACOTranslation.cpp
@@ -67,6 +67,10 @@ initialize_module(llvm::Module *module, const std::string &triple,
   std::string error;
   auto target =
       llvm::TargetRegistry::lookupTarget(module->getTargetTriple(), error);
+  if (target == nullptr) {
+    std::cout << "LookupTarget fail: " << error << std::endl;
+    return nullptr;
+  }
   llvm::TargetOptions opt;
   opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
   opt.UnsafeFPMath = false;
@@ -89,6 +93,10 @@ std::string generate_amdgcn_assembly(llvm::Module *module,
                                      const std::string &proc,
                                      const std::string &features) {
   auto machine = initialize_module(module, triple, proc, features);
+
+  if (machine == nullptr)
+    return "";
+
   llvm::SmallVector<char, 0> buffer;
   llvm::legacy::PassManager pass;
   llvm::raw_svector_ostream stream(buffer);
@@ -110,6 +118,9 @@ std::string generate_hsaco(llvm::Module *module, const std::string &triple,
                            const std::string &proc,
                            const std::string &features) {
   auto machine = initialize_module(module, triple, proc, features);
+
+  if (machine == nullptr)
+    return "";
 
   std::string kernel_name = "/tmp/" + std::to_string(New64());
 


### PR DESCRIPTION
This PR fixes option behavior in triton-translate utility and adds additional error reporting message for unsupported triple value.