### PR TITLE
[dotOp] [rocMLIR] Lower TritonGPU to LLVMIR in RockToLLVMPass

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -41,6 +41,8 @@ private:
 
 bool isSharedEncoding(Value value);
 
+bool isLDSEncoding(Value value);
+
 bool isMfmaEncoding(Value value);
 
 bool maybeSharedAllocationOp(Operation *op);

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -38,7 +38,7 @@ void SharedMemoryAliasAnalysis::visitOperation(
       // insert_slice %src into %dst[%offsets]
       aliasInfo = AliasInfo(operands[1]->getValue());
       pessimistic = false;
-    } else if (isSharedEncoding(result)) {
+    } else if (isSharedEncoding(result) || isLDSEncoding(result)) {
       aliasInfo.insert(result);
       pessimistic = false;
     }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -20,6 +20,7 @@ using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getSizePerThread;
 using ::mlir::triton::gpu::MmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingAttr;
+using ::mlir::triton::gpu::LDSEncodingAttr;
 using ::mlir::triton::gpu::SliceEncodingAttr;
 
 namespace mlir {
@@ -149,7 +150,7 @@ private:
     }
 
     for (Value result : op->getResults()) {
-      if (isSharedEncoding(result)) {
+      if (isSharedEncoding(result) || isLDSEncoding(result)) {
         // Bytes could be a different value once we support padding or other
         // allocation policies.
         auto tensorType = result.getType().dyn_cast<RankedTensorType>();
@@ -172,7 +173,9 @@ private:
       auto srcEncoding = srcTy.getEncoding();
       auto dstEncoding = dstTy.getEncoding();
       if (srcEncoding.isa<SharedEncodingAttr>() ||
-          dstEncoding.isa<SharedEncodingAttr>()) {
+          dstEncoding.isa<SharedEncodingAttr>() ||
+          srcEncoding.isa<LDSEncodingAttr>() ||
+          dstEncoding.isa<LDSEncodingAttr>()) {
         // Conversions from/to shared memory do not need scratch memory.
         return;
       }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -18,9 +18,9 @@ using ::mlir::triton::gpu::getContigPerThread;
 using ::mlir::triton::gpu::getOrder;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getSizePerThread;
+using ::mlir::triton::gpu::LDSEncodingAttr;
 using ::mlir::triton::gpu::MmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingAttr;
-using ::mlir::triton::gpu::LDSEncodingAttr;
 using ::mlir::triton::gpu::SliceEncodingAttr;
 
 namespace mlir {

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -103,6 +103,15 @@ bool isSharedEncoding(Value value) {
   return false;
 }
 
+bool isLDSEncoding(Value value) {
+  auto type = value.getType();
+  if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
+    auto encoding = tensorType.getEncoding();
+    return encoding && encoding.isa<triton::gpu::LDSEncodingAttr>();
+  }
+  return false;
+}
+
 bool isMfmaEncoding(Value value) {
   auto type = value.getType();
   if (auto tensorType = type.dyn_cast<RankedTensorType>()) {

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_conversion_library(TritonGPUToLLVM
     TypeConverter.cpp
     ViewOpToLLVM.cpp
     DotOpHelpers.cpp
+    TensorMemRefOpToLLVM.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/triton/Conversion/TritonGPUToLLVM

--- a/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
@@ -277,8 +277,7 @@ private:
            "Inliner pass is expected before TritonGPUToLLVM");
     b.setInsertionPointToStart(&funcs[0].getBody().front());
     smem = b.create<LLVM::AddressOfOp>(loc, global);
-    auto ptrTy =
-        LLVM::LLVMPointerType::get(typeConverter.convertType(b.getI8Type()), 3);
+    auto ptrTy = LLVM::LLVMPointerType::get(b.getContext(), 3);
     smem = b.create<LLVM::BitcastOp>(loc, ptrTy, smem);
   }
 };

--- a/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
@@ -26,6 +26,7 @@
 #include "ElementwiseOpToLLVM.h"
 #include "LoadStoreOpToLLVM.h"
 #include "ReduceOpToLLVM.h"
+#include "TensorMemRefOpToLLVM.h"
 #include "TritonGPUToLLVM.h"
 #include "TypeConverter.h"
 #include "ViewOpToLLVM.h"
@@ -209,8 +210,9 @@ public:
                    &allocation, smem, /*benefit*/ 1);
     };
     populatePatterns1(populateTritonGPUToLLVMPatterns);
+    populatePatterns1(populateTensorMemRefOpToLLVMPatterns);
     populatePatterns1(populateConvertLayoutOpToLLVMPatterns);
-    populatePatterns2(populateDotOpToLLVMPatterns);
+    // populatePatterns2(populateDotOpToLLVMPatterns);
     populatePatterns2(populateElementwiseOpToLLVMPatterns);
     populatePatterns1(populateLoadStoreOpToLLVMPatterns);
     populatePatterns1(populateReduceOpToLLVMPatterns);

--- a/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.cpp
@@ -1,62 +1,51 @@
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/TypeUtilities.h"
-#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 
 #include "TensorMemRefOpToLLVM.h"
 
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::getElementsFromStruct;
 using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
-using ::mlir::LLVM::getStructFromElements;
 using ::mlir::triton::gpu::getElemsPerThread;
 using ::mlir::triton::gpu::LDSEncodingAttr;
 
-struct TensorToMemRefOpConversion 
+struct TensorToMemRefOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<triton::gpu::TensorToMemRefOp> {
+public:
   using ConvertTritonGPUOpToLLVMPattern<
       triton::gpu::TensorToMemRefOp>::ConvertTritonGPUOpToLLVMPattern;
 
-  TensorToMemRefOpConversion(LLVMTypeConverter &converter,
-                             AxisInfoAnalysis &axisAnalysisPass, 
-                             PatternBenefit benefit)
-      : ConvertTritonGPUOpToLLVMPattern<triton::gpu::TensorToMemRefOp>(converter, benefit) {}
-  LogicalResult 
-  matchAndRewrite(triton::gpu::TensorToMemRefOp op, 
-                  OpAdaptor adaptor,
+  LogicalResult
+  matchAndRewrite(triton::gpu::TensorToMemRefOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     Value src = op.getSrc();
     auto srcTy = src.getType().dyn_cast<RankedTensorType>();
     Attribute srcEncoding = srcTy.getEncoding();
-    if (!(srcEncoding && srcEncoding.isa<LDSEncodingAttr>())) return failure();
+    if (!(srcEncoding && srcEncoding.isa<LDSEncodingAttr>()))
+      return failure();
 
     Value smemBase = getSharedMemoryBase(loc, rewriter, src);
-
     Value res = op.getResult();
     auto resTy = res.getType().dyn_cast<MemRefType>();
 
-    MemRefDescriptor desc = MemRefDescriptor::fromStaticShape(rewriter, loc,
-		                                              *getTypeConverter(), resTy,
-					                      smemBase, 
-							      smemBase);
+    MemRefDescriptor desc = MemRefDescriptor::fromStaticShape(
+        rewriter, loc, *getTypeConverter(), resTy, smemBase, smemBase);
     rewriter.replaceOp(op, {desc});
     return success();
   }
 };
 
-struct MemRefToTensorOpConversion 
+struct MemRefToTensorOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<triton::gpu::MemRefToTensorOp> {
+public:
   using ConvertTritonGPUOpToLLVMPattern<
       triton::gpu::MemRefToTensorOp>::ConvertTritonGPUOpToLLVMPattern;
-  MemRefToTensorOpConversion(LLVMTypeConverter &converter,
-                             AxisInfoAnalysis &axisAnalysisPass, 
-                             PatternBenefit benefit)
-      : ConvertTritonGPUOpToLLVMPattern<triton::gpu::MemRefToTensorOp>(converter, benefit) {}
-  LogicalResult 
-  matchAndRewrite(triton::gpu::MemRefToTensorOp op, 
-                  OpAdaptor adaptor,
+
+  LogicalResult
+  matchAndRewrite(triton::gpu::MemRefToTensorOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     Value src = op.getSrc();
@@ -65,56 +54,95 @@ struct MemRefToTensorOpConversion
     auto srcShape = srcTy.getShape();
     auto srcElemTy = srcTy.getElementType().dyn_cast<VectorType>();
     Type llSrcElemTy = typeConverter->convertType(srcElemTy);
-    auto srcElemSize  = srcElemTy.getNumElements();
+    auto srcElemSize = srcElemTy.getNumElements();
 
-    auto gpuAttr = srcTy.getMemorySpace().dyn_cast<mlir::gpu::AddressSpaceAttr>();
+    auto gpuAttr =
+        srcTy.getMemorySpace().dyn_cast<mlir::gpu::AddressSpaceAttr>();
     if (gpuAttr.getValue() != mlir::gpu::GPUDialect::getPrivateAddressSpace()) {
       llvm::errs() << "private address space is required.\n";
       return failure();
     }
-    
+
     Value res = op.getResult();
     auto resTy = res.getType().dyn_cast<RankedTensorType>();
     Type resElemTy = typeConverter->convertType(resTy.getElementType());
     auto resRank = resTy.getRank();
 
-    if (( resRank == 0) || (srcRank == 0)) {
+    if ((resRank == 0) || (srcRank == 0)) {
       llvm::errs() << "Non-scalar rank is required\n";
       return failure();
     }
 
     unsigned numElems = getElemsPerThread(resTy);
-    auto srcNumElems = product<long>(srcShape);
-    if (numElems != srcNumElems) {
-      llvm::errs() << "The number of elements is not consistent.\n";
-      return failure();
-    }
 
     MemRefDescriptor desc{adaptor.getSrc()};
     Value srcPtr = desc.alignedPtr(rewriter, loc);
 
     SmallVector<Value> valVec;
 
-    for (auto i = 0; i < numElems; i++){
+    for (auto i = 0; i < numElems; i++) {
       Value vec = extract_val(llSrcElemTy, srcPtr, i);
-      for (auto j = 0; j < srcElemSize; j++){
+      for (auto j = 0; j < srcElemSize; j++) {
         valVec.push_back(extract_val(resElemTy, vec, j));
       }
     }
 
     Type llvmResultStructTy = getTypeConverter()->convertType(resTy);
-    Value resultStruct = getStructFromElements(loc, valVec, rewriter, llvmResultStructTy);
+    Value resultStruct = getTypeConverter()->packLLElements(
+        loc, valVec, rewriter, llvmResultStructTy);
     rewriter.replaceOp(op, {resultStruct});
     return success();
   }
 };
 
+// Copied from GpuOpsLowering.h
+/// A function that maps a MemorySpace enum to a target-specific integer value.
+using MemorySpaceMapping =
+    std::function<unsigned(mlir::gpu::AddressSpace gpuAddressSpace)>;
+
+/// Copied from GpuOpsLowering.cpp
+static IntegerAttr wrapNumericMemorySpace(MLIRContext *ctx, unsigned space) {
+  return IntegerAttr::get(IntegerType::get(ctx, 64), space);
+}
+
+// Copied from GpuOpsLowering.cpp
+void populateGpuMemorySpaceAttributeConversions(
+    TypeConverter &typeConverter, const MemorySpaceMapping &mapping) {
+  typeConverter.addTypeAttributeConversion(
+      [mapping](BaseMemRefType type,
+                mlir::gpu::AddressSpaceAttr memorySpaceAttr) {
+        mlir::gpu::AddressSpace memorySpace = memorySpaceAttr.getValue();
+        unsigned addressSpace = mapping(memorySpace);
+        return wrapNumericMemorySpace(memorySpaceAttr.getContext(),
+                                      addressSpace);
+      });
+}
+
 void populateTensorMemRefOpToLLVMPatterns(
-    mlir::LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
     const Allocation *allocation, Value smem,
     ConvertTritonGPUOpToLLVMPatternBase::IndexCacheInfo &indexCacheInfo,
     PatternBenefit benefit) {
-  patterns.add<TensorToMemRefOpConversion>(typeConverter, axisInfoAnalysis, benefit);
-  patterns.add<MemRefToTensorOpConversion>(typeConverter, axisInfoAnalysis, benefit);
+  // Copied from LowerGpuOpsToROCDLOps.cpp
+  // We need this function to teach the typeConverter how to lower the
+  // enum-style gpu memory space into integers. Otherwise, fromStaticShape
+  // will complain.
+  populateGpuMemorySpaceAttributeConversions(
+      typeConverter, [](mlir::gpu::AddressSpace space) {
+        switch (space) {
+        case mlir::gpu::AddressSpace::Global:
+          return 1;
+        case mlir::gpu::AddressSpace::Workgroup:
+          return 3;
+        case mlir::gpu::AddressSpace::Private:
+          return 5;
+        }
+        llvm_unreachable("unknown address space enum value");
+        return 0;
+      });
+  patterns.add<TensorToMemRefOpConversion>(typeConverter, allocation, smem,
+                                           indexCacheInfo, benefit);
+  patterns.add<MemRefToTensorOpConversion>(typeConverter, allocation, smem,
+                                           indexCacheInfo, benefit);
 }

--- a/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.cpp
@@ -1,0 +1,120 @@
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+
+#include "TensorMemRefOpToLLVM.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+using ::mlir::LLVM::getElementsFromStruct;
+using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
+using ::mlir::LLVM::getStructFromElements;
+using ::mlir::triton::gpu::getElemsPerThread;
+using ::mlir::triton::gpu::LDSEncodingAttr;
+
+struct TensorToMemRefOpConversion 
+    : public ConvertTritonGPUOpToLLVMPattern<triton::gpu::TensorToMemRefOp> {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::gpu::TensorToMemRefOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  TensorToMemRefOpConversion(LLVMTypeConverter &converter,
+                             AxisInfoAnalysis &axisAnalysisPass, 
+                             PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::gpu::TensorToMemRefOp>(converter, benefit) {}
+  LogicalResult 
+  matchAndRewrite(triton::gpu::TensorToMemRefOp op, 
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    Value src = op.getSrc();
+    auto srcTy = src.getType().dyn_cast<RankedTensorType>();
+    Attribute srcEncoding = srcTy.getEncoding();
+    if (!(srcEncoding && srcEncoding.isa<LDSEncodingAttr>())) return failure();
+
+    Value smemBase = getSharedMemoryBase(loc, rewriter, src);
+
+    Value res = op.getResult();
+    auto resTy = res.getType().dyn_cast<MemRefType>();
+
+    MemRefDescriptor desc = MemRefDescriptor::fromStaticShape(rewriter, loc,
+		                                              *getTypeConverter(), resTy,
+					                      smemBase, 
+							      smemBase);
+    rewriter.replaceOp(op, {desc});
+    return success();
+  }
+};
+
+struct MemRefToTensorOpConversion 
+    : public ConvertTritonGPUOpToLLVMPattern<triton::gpu::MemRefToTensorOp> {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::gpu::MemRefToTensorOp>::ConvertTritonGPUOpToLLVMPattern;
+  MemRefToTensorOpConversion(LLVMTypeConverter &converter,
+                             AxisInfoAnalysis &axisAnalysisPass, 
+                             PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::gpu::MemRefToTensorOp>(converter, benefit) {}
+  LogicalResult 
+  matchAndRewrite(triton::gpu::MemRefToTensorOp op, 
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    Value src = op.getSrc();
+    auto srcTy = src.getType().dyn_cast<MemRefType>();
+    auto srcRank = srcTy.getRank();
+    auto srcShape = srcTy.getShape();
+    auto srcElemTy = srcTy.getElementType().dyn_cast<VectorType>();
+    Type llSrcElemTy = typeConverter->convertType(srcElemTy);
+    auto srcElemSize  = srcElemTy.getNumElements();
+
+    auto gpuAttr = srcTy.getMemorySpace().dyn_cast<mlir::gpu::AddressSpaceAttr>();
+    if (gpuAttr.getValue() != mlir::gpu::GPUDialect::getPrivateAddressSpace()) {
+      llvm::errs() << "private address space is required.\n";
+      return failure();
+    }
+    
+    Value res = op.getResult();
+    auto resTy = res.getType().dyn_cast<RankedTensorType>();
+    Type resElemTy = typeConverter->convertType(resTy.getElementType());
+    auto resRank = resTy.getRank();
+
+    if (( resRank == 0) || (srcRank == 0)) {
+      llvm::errs() << "Non-scalar rank is required\n";
+      return failure();
+    }
+
+    unsigned numElems = getElemsPerThread(resTy);
+    auto srcNumElems = product<long>(srcShape);
+    if (numElems != srcNumElems) {
+      llvm::errs() << "The number of elements is not consistent.\n";
+      return failure();
+    }
+
+    MemRefDescriptor desc{adaptor.getSrc()};
+    Value srcPtr = desc.alignedPtr(rewriter, loc);
+
+    SmallVector<Value> valVec;
+
+    for (auto i = 0; i < numElems; i++){
+      Value vec = extract_val(llSrcElemTy, srcPtr, i);
+      for (auto j = 0; j < srcElemSize; j++){
+        valVec.push_back(extract_val(resElemTy, vec, j));
+      }
+    }
+
+    Type llvmResultStructTy = getTypeConverter()->convertType(resTy);
+    Value resultStruct = getStructFromElements(loc, valVec, rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+void populateTensorMemRefOpToLLVMPatterns(
+    mlir::LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
+    const Allocation *allocation, Value smem,
+    ConvertTritonGPUOpToLLVMPatternBase::IndexCacheInfo &indexCacheInfo,
+    PatternBenefit benefit) {
+  patterns.add<TensorToMemRefOpConversion>(typeConverter, axisInfoAnalysis, benefit);
+  patterns.add<MemRefToTensorOpConversion>(typeConverter, axisInfoAnalysis, benefit);
+}

--- a/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.h
+++ b/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.h
@@ -7,7 +7,7 @@ using namespace mlir;
 using namespace mlir::triton;
 
 void populateTensorMemRefOpToLLVMPatterns(
-    mlir::LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
     const Allocation *allocation, Value smem,
     ConvertTritonGPUOpToLLVMPatternBase::IndexCacheInfo &indexCacheInfo,

--- a/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.h
+++ b/lib/Conversion/TritonGPUToLLVM/TensorMemRefOpToLLVM.h
@@ -1,0 +1,16 @@
+#ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_TENSOR_TO_MEMREF_OP_H
+#define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TENSOR_TO_MEMREF_OP_H
+
+#include "TritonGPUToLLVMBase.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+void populateTensorMemRefOpToLLVMPatterns(
+    mlir::LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
+    const Allocation *allocation, Value smem,
+    ConvertTritonGPUOpToLLVMPatternBase::IndexCacheInfo &indexCacheInfo,
+    PatternBenefit benefit);
+
+#endif

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -229,13 +229,13 @@ public:
   template <typename T>
   Value getSharedMemoryBase(Location loc, ConversionPatternRewriter &rewriter,
                             T value) const {
-    auto ptrTy = LLVM::LLVMPointerType::get(
-        this->getTypeConverter()->convertType(rewriter.getI8Type()), 3);
+    auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
     auto bufferId = allocation->getBufferId(value);
     assert(bufferId != Allocation::InvalidBufferId && "BufferId not found");
     size_t offset = allocation->getOffset(bufferId);
     Value offVal = i32_val(offset);
-    Value base = gep(ptrTy, smem, offVal);
+    auto elemTy = rewriter.getI8Type();
+    Value base = gep(ptrTy, elemTy, smem, offVal);
     return base;
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -60,6 +60,9 @@ struct ArithConstantSplatOpConversion
     if (!value.dyn_cast<SplatElementsAttr>())
       return failure();
 
+    if (!op.getType().isa<RankedTensorType>())
+      return failure();
+
     auto loc = op->getLoc();
 
     LLVM::ConstantOp arithConstantOp;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -54,6 +54,8 @@ unsigned getElemsPerThread(Attribute layout, ArrayRef<int64_t> shape,
     return sliceLayout.getElemsPerThread(shape, eltTy);
   } else if (auto mmaLayout = layout.dyn_cast<MmaEncodingAttr>()) {
     return mmaLayout.getElemsPerThread(shape, eltTy);
+  } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return mfmaLayout.getElemsPerThread(shape, eltTy);
   } else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>()) {
     return sharedLayout.getElemsPerThread(shape, eltTy);
   } else if (auto ldsLayout = layout.dyn_cast<LDSEncodingAttr>()) {
@@ -98,6 +100,10 @@ SmallVector<unsigned> getWarpsPerCTA(const Attribute &layout) {
     return SmallVector<unsigned>(mmaLayout.getWarpsPerCTA().begin(),
                                  mmaLayout.getWarpsPerCTA().end());
   }
+  if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return SmallVector<unsigned>(mfmaLayout.getWarpsPerCTA().begin(),
+                                 mfmaLayout.getWarpsPerCTA().end());
+  }
   assert(0 && "getWarpsPerCTA not implemented");
   return {};
 }
@@ -119,6 +125,8 @@ SmallVector<unsigned> getSizePerThread(const Attribute &layout) {
     } else {
       llvm_unreachable("Unexpected mma version");
     }
+  } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return {1, 4};
   } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
     auto parentLayout = dotLayout.getParent();
     assert(parentLayout && "DotOperandEncodingAttr must have a parent");
@@ -150,6 +158,8 @@ SmallVector<unsigned> getContigPerThread(const Attribute &layout) {
   if (auto mmaLayout = layout.dyn_cast<MmaEncodingAttr>()) {
     assert(mmaLayout.isVolta() || mmaLayout.isAmpere());
     return {1, 2};
+  } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return {1, 4};
   } else {
     return getSizePerThread(layout);
   }
@@ -168,7 +178,7 @@ SmallVector<unsigned> getThreadsPerCTA(const Attribute &layout) {
     } else
       assert(0 && "Unimplemented usage of MmaEncodingAttr");
   } else {
-    assert(0 && "Unimplemented usage of getShapePerCTA");
+    assert(0 && "Unimplemented usage of getThreadsPerCTA");
   }
 
   return threads;
@@ -203,6 +213,9 @@ SmallVector<unsigned> getShapePerCTA(const Attribute &layout,
               static_cast<unsigned>(tensorShape[1])};
     }
     assert(0 && "Unexpected MMA layout version found");
+  } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return {static_cast<unsigned>(tensorShape[0]),
+            static_cast<unsigned>(tensorShape[1])};
   } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
     auto parentLayout = dotLayout.getParent();
     assert(parentLayout && "DotOperandEncodingAttr must have a parent");
@@ -234,6 +247,8 @@ SmallVector<unsigned> getOrder(const Attribute &layout) {
                                  blockedLayout.getOrder().end());
   } else if (auto mmaLayout = layout.dyn_cast<MmaEncodingAttr>()) {
     return {1, 0};
+  } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
+    return {1, 0};
   } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
     return {1, 0};
   } else if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>()) {
@@ -263,7 +278,7 @@ SmallVector<unsigned> getOrder(const Attribute &layout) {
 
 bool isaDistributedLayout(const Attribute &layout) {
   return layout.isa<BlockedEncodingAttr>() || layout.isa<MmaEncodingAttr>() ||
-         layout.isa<SliceEncodingAttr>();
+         layout.isa<SliceEncodingAttr>() || layout.isa<MfmaEncodingAttr>();
 }
 
 } // namespace gpu
@@ -408,6 +423,20 @@ unsigned MmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape,
   }
 
   return res;
+}
+
+unsigned MfmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape,
+                                             Type eltTy) const {
+  size_t rank = shape.size();
+  assert(rank == 2 && "Unexpected rank of mfma layout");
+
+  unsigned warpSize = 64;
+  unsigned elemsInTensor = static_cast<unsigned>(product<int64_t>(shape));
+  unsigned threadsInCTA = product<unsigned>(getWarpsPerCTA()) * warpSize;
+  if (elemsInTensor % threadsInCTA != 0) {
+    llvm_unreachable("Unexpected tensor shape");
+  }
+  return elemsInTensor / threadsInCTA;
 }
 
 unsigned SharedEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -159,7 +159,7 @@ SmallVector<unsigned> getContigPerThread(const Attribute &layout) {
     assert(mmaLayout.isVolta() || mmaLayout.isAmpere());
     return {1, 2};
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    return {1, 4};
+    return {4, 1};
   } else {
     return getSizePerThread(layout);
   }

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1076,19 +1076,6 @@ def dot(lhs: tl.tensor,
     M = lhs.type.shape[0]
     N = rhs.type.shape[1]
 
-    # Cast operands of types f16 and i8 since only FMA implemented yet for ROCM.
-    # So we always perform dot(f32,f32,f32)->f32 here with FMA.
-    # TODO: remove the case for MMA/MFMA implemented cases
-    if torch.version.hip is not None:
-        ret_cast_scalar_ty = tl.float32 if lhs.type.scalar.is_int() else ret_scalar_ty
-        lhs = cast(lhs, ret_cast_scalar_ty, builder)
-        rhs = cast(rhs, ret_cast_scalar_ty, builder)
-        _0 = builder.create_splat(builder.get_fp32(0), [M, N])
-        ret_ty = tl.block_type(ret_cast_scalar_ty, [M, N])
-        ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
-                        ret_ty)
-        return cast(ret, ret_scalar_ty, builder)
-
     _0 = builder.create_splat(_0, [M, N])
     ret_ty = tl.block_type(ret_scalar_ty, [M, N])
     return tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),

--- a/test/dot-rocMLIR/Conversion/rock_to_llvm.mlir
+++ b/test/dot-rocMLIR/Conversion/rock_to_llvm.mlir
@@ -1,0 +1,33 @@
+// RUN: (triton-opt %s -split-input-file --convert-rock-to-llvm --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null; true) | FileCheck %s
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#lds = #triton_gpu.lds<{kpack = 4, order = [1, 0]}>
+module attributes {"triton_gpu.num-warps" = 1 : i32} {
+  // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
+  // CHECK-LABEL: convert_layout_blocked_lds_diff_order
+  func.func @convert_layout_blocked_lds_diff_order(%arg0: tensor<128x64xf32, #blocked>) {
+    // CHECK: llvm.store
+    // CHECK-SAME: !llvm.ptr<vector<1xf32>, 3>
+    // CHECK: llvm.store
+    // CHECK-SAME: !llvm.ptr<vector<1xf32>, 3>
+    %0 = triton_gpu.convert_layout %arg0 : (tensor<128x64xf32, #blocked>) -> tensor<128x64xf32, #lds>
+    return
+  }
+}
+
+// -----
+
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#lds1 = #triton_gpu.lds<{kpack = 4, order = [0, 1]}>
+module attributes {"triton_gpu.num-warps" = 1 : i32} {
+  // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
+  // CHECK-LABEL: convert_layout_blocked_lds_same_order
+  func.func @convert_layout_blocked_lds_same_order(%arg1: tensor<64x256xf32, #blocked1>) {
+    // CHECK: llvm.store
+    // CHECK-SAME: !llvm.ptr<vector<4xf32>, 3>
+    // CHECK: llvm.store
+    // CHECK-SAME: !llvm.ptr<vector<4xf32>, 3>
+    %1 = triton_gpu.convert_layout %arg1 : (tensor<64x256xf32, #blocked1>) -> tensor<64x256xf32, #lds1>
+    return
+  }
+}

--- a/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
+++ b/test/dot-rocMLIR/Conversion/tritongpu_to_rock.mlir
@@ -1,8 +1,8 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-rock | FileCheck --check-prefixes=CHECK %s
 
-#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
-#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
-#blocked2 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
 #lds = #triton_gpu.lds<{kpack = 4, order = [1, 0]}>
 #lds1 = #triton_gpu.lds<{kpack = 4, order = [0, 1]}>
 module attributes {"triton_gpu.num-warps" = 8 : i32} {

--- a/test/dot-rocMLIR/Rock/sanity.mlir
+++ b/test/dot-rocMLIR/Rock/sanity.mlir
@@ -53,32 +53,30 @@ module attributes {"triton_gpu.num-warps" = 8 : i32} {
     %32 = tt.addptr %30, %31 : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<128x256xi32, #blocked1>
     %33 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked>
     %34 = tt.load %25 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xf16, #blocked2>
-    %35 = arith.extf %33 : tensor<128x64xf16, #blocked> to tensor<128x64xf32, #blocked>
-    %36 = arith.extf %34 : tensor<64x256xf16, #blocked2> to tensor<64x256xf32, #blocked2>
-    %37 = triton_gpu.convert_layout %35 : (tensor<128x64xf32, #blocked>) -> tensor<128x64xf32, #lds>
-    %38 = triton_gpu.convert_layout %36 : (tensor<64x256xf32, #blocked2>) -> tensor<64x256xf32, #lds1>
-    %39 = triton_gpu.tensor_to_memref %37 : tensor<128x64xf32, #lds> -> memref<8192xf32, #gpu.address_space<workgroup>>
-    %40 = triton_gpu.tensor_to_memref %38 : tensor<64x256xf32, #lds1> -> memref<16384xf32, #gpu.address_space<workgroup>>
+    %35 = triton_gpu.convert_layout %33 : (tensor<128x64xf16, #blocked>) -> tensor<128x64xf16, #lds>
+    %36 = triton_gpu.convert_layout %34 : (tensor<64x256xf16, #blocked2>) -> tensor<64x256xf16, #lds1>
+    %37 = triton_gpu.tensor_to_memref %35 : tensor<128x64xf16, #lds> -> memref<8192xf16, #gpu.address_space<workgroup>>
+    %38 = triton_gpu.tensor_to_memref %36 : tensor<64x256xf16, #lds1> -> memref<16384xf16, #gpu.address_space<workgroup>>
     %c64 = arith.constant 64 : index
     %c64_0 = arith.constant 64 : index
     %c64_1 = arith.constant 64 : index
     %c4 = arith.constant 4 : index
-    %41 = rock.workitem_id : index
-    %42 = arith.divui %41, %c64 : index
-    %43 = arith.divui %42, %c4 : index
-    %44 = arith.remui %42, %c4 : index
-    %45 = arith.muli %43, %c64_0 : index
-    %46 = arith.muli %44, %c64_1 : index
-    %47 = rock.alloc() : memref<16xvector<4xf32>, #gpu.address_space<private>>
-    %48 = rock.alloc() : memref<16xvector<4xf32>, #gpu.address_space<private>>
-    %49 = rock.alloc() : memref<4xvector<16xf32>, #gpu.address_space<private>>
+    %39 = rock.workitem_id : index
+    %40 = arith.divui %39, %c64 : index
+    %41 = arith.divui %40, %c4 : index
+    %42 = arith.remui %40, %c4 : index
+    %43 = arith.muli %41, %c64_0 : index
+    %44 = arith.muli %42, %c64_1 : index
+    %45 = rock.alloc() : memref<16xvector<4xf16>, #gpu.address_space<private>>
+    %46 = rock.alloc() : memref<16xvector<4xf16>, #gpu.address_space<private>>
+    %47 = rock.alloc() : memref<4xvector<16xf32>, #gpu.address_space<private>>
     %cst_2 = arith.constant dense<0.000000e+00> : vector<16xf32>
-    rock.fill(%49, %cst_2) : memref<4xvector<16xf32>, #gpu.address_space<private>>, vector<16xf32>
-    rock.blockwise_gemm_v2 %49 += %47 from %39[%45] * %48 from %40[%46] {blockSize = 512 : i32, ldsBufferOffsetA = 0 : index, ldsBufferOffsetB = 0 : index, params = #xdlops_gemm_params} : memref<4xvector<16xf32>, #gpu.address_space<private>> += memref<16xvector<4xf32>, #gpu.address_space<private>> from memref<8192xf32, #gpu.address_space<workgroup>> * memref<16xvector<4xf32>, #gpu.address_space<private>> from memref<16384xf32, #gpu.address_space<workgroup>>
-    %50 = triton_gpu.memref_to_tensor %49 : memref<4xvector<16xf32>, #gpu.address_space<private>> -> tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>
-    %51 = triton_gpu.convert_layout %50 : (tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>) -> tensor<128x256xf32, #blocked1>
-    %52 = arith.truncf %51 : tensor<128x256xf32, #blocked1> to tensor<128x256xf16, #blocked1>
-    tt.store %32, %52 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf16, #blocked1>
+    rock.fill(%47, %cst_2) : memref<4xvector<16xf32>, #gpu.address_space<private>>, vector<16xf32>
+    rock.blockwise_gemm_v2 %47 += %45 from %37[%43] * %46 from %38[%44] {blockSize = 512 : i32, ldsBufferOffsetA = 0 : index, ldsBufferOffsetB = 0 : index, params = #xdlops_gemm_params} : memref<4xvector<16xf32>, #gpu.address_space<private>> += memref<16xvector<4xf16>, #gpu.address_space<private>> from memref<8192xf16, #gpu.address_space<workgroup>> * memref<16xvector<4xf16>, #gpu.address_space<private>> from memref<16384xf16, #gpu.address_space<workgroup>>
+    %48 = triton_gpu.memref_to_tensor %47 : memref<4xvector<16xf32>, #gpu.address_space<private>> -> tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>
+    %49 = triton_gpu.convert_layout %48 : (tensor<128x256xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 4], xdlopsPerWarp = [2, 2]}>>) -> tensor<128x256xf32, #blocked1>
+    %50 = arith.truncf %49 : tensor<128x256xf32, #blocked1> to tensor<128x256xf16, #blocked1>
+    tt.store %32, %50 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf16, #blocked1>
     return
   }
 }

--- a/test/dot-rocMLIR/TritonGPU/combine.mlir
+++ b/test/dot-rocMLIR/TritonGPU/combine.mlir
@@ -1,14 +1,14 @@
 // RUN: triton-opt %s -split-input-file  -tritongpu-remove-layout-conversions -tritongpu-accelerate-matmul  -tritongpu-remove-layout-conversions 2>&1 | FileCheck %s
 
-#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
-#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
-#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
-#blocked3 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [0, 1]}>
-#blocked4 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 4], order = [0, 1]}>
-#blocked5 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
-#blocked6 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
-#blocked7 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
-#blocked8 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [2, 4], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [8], order = [0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked4 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked5 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked6 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked7 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 64], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked8 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
 module attributes {"triton_gpu.num-warps" = 8 : i32} {
   func.func public @kernel_intro_mfma(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}) {
     // CHECK: arith.constant dense<0.000000e+00> : tensor<128x256xf32, [[$mfmaEnc:#triton_gpu.mfma<.*>]]>

--- a/test/dot-rocMLIR/TritonGPU/decompose-conversions.mlir
+++ b/test/dot-rocMLIR/TritonGPU/decompose-conversions.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --tritongpu-decompose-conversions 2>&1 | FileCheck %s
 
-#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
-#blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 4], warpsPerCTA = [1, 8], order = [0, 1]}>
 // CHECK: #lds{{.*}} = #triton_gpu.lds{{.*}}
 // CHECK: #lds{{.*}} = #triton_gpu.lds{{.*}}
 module attributes {"triton_gpu.num-warps" = 8 : i32} {


### PR DESCRIPTION
This PR lowers every left op in the TritonGPU dialect into LLVMIR.
- Add support of `LDSEncodingAttr` in AllocationAnalysis
- `convert_layout` from #blocked to #lds
- `convert_layout` from #mfma to #blocked
- Integrate `tensor_to_memref` and `memref_to_tensor` from #161 
  - For `tensor_to_memref` lowering
    - Add a GPU memory space attribute conversion to the LLVMTypeConverter
    - Use opaque pointer for the base ptr of allocation shared memory
  - For `memref_to_tensor` lower, fix the logic in the original PR
- Some misc changes
  - Revert #127 to allow dot(f16, f16, f32) -> f32
  - Ignore vector type in `ArithConstantSplatOpConversion`  