### PR TITLE
[dotOp] [rocMLIR] Lower rock.alloc() to LLVMIR

### DIFF
--- a/bin/triton-translate.cpp
+++ b/bin/triton-translate.cpp
@@ -1,8 +1,3 @@
-#include "triton/Dialect/Triton/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "triton/Target/LLVMIR/LLVMIRTranslation.h"
-#include "triton/Target/PTX/PTXTranslation.h"
-#include "triton/Target/HSACO/HSACOTranslation.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
@@ -14,6 +9,11 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Target/HSACO/HSACOTranslation.h"
+#include "triton/Target/LLVMIR/LLVMIRTranslation.h"
+#include "triton/Target/PTX/PTXTranslation.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -77,7 +77,8 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
       llvm::cl::init("-"));
 
   static llvm::cl::opt<std::string> targetKind(
-      "target", llvm::cl::desc("<translation target, options: llvmir/ptx/hsaco>"),
+      "target",
+      llvm::cl::desc("<translation target, options: llvmir/ptx/hsaco>"),
       llvm::cl::value_desc("target"), llvm::cl::init("llvmir"));
 
   static llvm::cl::opt<int> SMArch("sm", llvm::cl::desc("sm arch"),
@@ -91,7 +92,8 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
       llvm::cl::value_desc("architecture"), llvm::cl::init("90a"));
 
   static llvm::cl::opt<std::string> GCNTriple(
-      "amdgcn", llvm::cl::desc("AMDGCN triple vendor and platfom. e.g. '-amd-amdhsa'"),
+      "amdgcn",
+      llvm::cl::desc("AMDGCN triple vendor and platfom. e.g. '-amd-amdhsa'"),
       llvm::cl::value_desc("target triple"), llvm::cl::init("-amd-amdhsa"));
 
   static llvm::cl::opt<std::string> GCNFeatures(

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_conversion_library(TritonGPUToLLVM
     ViewOpToLLVM.cpp
     DotOpHelpers.cpp
     TensorMemRefOpToLLVM.cpp
+    GpuAllocOpToLLVM.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/triton/Conversion/TritonGPUToLLVM

--- a/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.cpp
@@ -1,0 +1,70 @@
+#include "GpuAllocOpToLLVM.h"
+
+#include "mlir/Dialect/AMDGPU/AMDGPUDialect.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "triton/Dialect/Rock/IR/Rock.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+struct MIGPUAllocRewritePattern
+    : public ConvertTritonGPUOpToLLVMPattern<mlir::rock::GpuAllocOp> {
+  using ConvertTritonGPUOpToLLVMPattern<
+      mlir::rock::GpuAllocOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  LogicalResult matchAndRewrite(rock::GpuAllocOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const {
+    auto type = op.getOutput().getType();
+    assert(type && type.hasStaticShape() && "unexpected type in rock.alloc()");
+    auto gpuAttr =
+        type.getMemorySpace().dyn_cast<mlir::gpu::AddressSpaceAttr>();
+    Location loc = op->getLoc();
+
+    if (gpuAttr.getValue() ==
+        mlir::gpu::GPUDialect::getWorkgroupAddressSpace()) {
+      llvm::errs() << "rock.alloc() for LDS is not supported!\n";
+    } else if (gpuAttr.getValue() ==
+               mlir::gpu::GPUDialect::getPrivateAddressSpace()) {
+      Type elementType = getTypeConverter()->convertType(type.getElementType());
+      auto ptrType =
+          ptr_ty(op.getContext(),
+                 mlir::ROCDL::ROCDLDialect::kPrivateMemoryAddressSpace);
+      Value numElements =
+          rewriter.create<LLVM::ConstantOp>(loc, i64_ty, type.getNumElements());
+      Value allocated = rewriter.create<LLVM::AllocaOp>(
+          loc, ptrType, elementType, numElements, /*alignment=*/0);
+      auto descr = MemRefDescriptor::fromStaticShape(
+          rewriter, loc, *getTypeConverter(), type, allocated);
+      rewriter.replaceOp(op, {descr});
+    } else {
+      // TBD: return failure.
+      llvm::errs() << "unsupported addrspace!\n";
+    }
+    return success();
+  }
+};
+
+template <typename Tmi, typename Tgpu>
+struct MIIdRewritePattern : public OpRewritePattern<Tmi> {
+  using OpRewritePattern<Tmi>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Tmi op, PatternRewriter &b) const override {
+    Value nop =
+        b.create<Tgpu>(op.getLoc(), b.getIndexType(), mlir::gpu::Dimension::x);
+    b.replaceOp(op, nop);
+    return success();
+  }
+};
+
+void populateGpuAllocOpToLLVMPatterns(
+    TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
+    const Allocation *allocation, Value smem, PatternBenefit benefit,
+    MLIRContext *ctx) {
+  patterns.add<MIGPUAllocRewritePattern>(typeConverter, benefit);
+  // patterns.add<WorkitemIdRewritePattern>(typeConverter, benefit);
+  patterns
+      .add<MIIdRewritePattern<mlir::rock::WorkitemIdOp, mlir::gpu::ThreadIdOp>>(
+          ctx);
+}

--- a/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.h
+++ b/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.h
@@ -1,0 +1,15 @@
+#ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_GPUALLOC_OP_H
+#define TRITON_CONVERSION_TRITONGPU_TO_LLVM_GPUALLOC_OP_H
+
+#include "TritonGPUToLLVMBase.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+void populateGpuAllocOpToLLVMPatterns(
+    TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    int numWarps, AxisInfoAnalysis &axisInfoAnalysis,
+    const Allocation *allocation, Value smem, PatternBenefit benefit,
+    MLIRContext *ctx);
+
+#endif

--- a/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/RockToLLVMPass.cpp
@@ -24,6 +24,7 @@
 #include "ConvertLayoutOpToLLVM.h"
 #include "DotOpToLLVM.h"
 #include "ElementwiseOpToLLVM.h"
+#include "GpuAllocOpToLLVM.h"
 #include "LoadStoreOpToLLVM.h"
 #include "ReduceOpToLLVM.h"
 #include "TensorMemRefOpToLLVM.h"
@@ -209,6 +210,9 @@ public:
       populateFunc(typeConverter, patterns, numWarps, *axisInfoAnalysis,
                    &allocation, smem, /*benefit*/ 1);
     };
+    populateGpuAllocOpToLLVMPatterns(typeConverter, patterns, numWarps,
+                                     *axisInfoAnalysis, &allocation, smem,
+                                     /*benefit*/ 1, context);
     populatePatterns1(populateTritonGPUToLLVMPatterns);
     populatePatterns1(populateTensorMemRefOpToLLVMPatterns);
     populatePatterns1(populateConvertLayoutOpToLLVMPatterns);


### PR DESCRIPTION
This PR extracts the rewrite patterns for `rock.workitem_id` from RockToGPU pass and implement a simple `rock.alloc()` to LLVMIR rewrite pattern only for private memory allocations. The shared memory allocation case is handled by triton.

TODO:
add tests