### PR TITLE
[dotOp] [rocMLIR] Complete the translation pipeline

### DIFF
--- a/bin/triton-opt.cpp
+++ b/bin/triton-opt.cpp
@@ -9,6 +9,7 @@
 
 #include "triton/Conversion/Passes.h"
 
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
@@ -45,6 +46,7 @@ int main(int argc, char **argv) {
   // Register dialects used by Rock
   registry.insert<mlir::rock::RockDialect, mlir::memref::MemRefDialect,
                   mlir::amdgpu::AMDGPUDialect, mlir::vector::VectorDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect, mlir::ROCDL::ROCDLDialect>();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "Triton (GPU) optimizer driver\n", registry));

--- a/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GpuAllocOpToLLVM.cpp
@@ -31,7 +31,7 @@ struct MIGPUAllocRewritePattern
           ptr_ty(op.getContext(),
                  mlir::ROCDL::ROCDLDialect::kPrivateMemoryAddressSpace);
       Value numElements =
-          rewriter.create<LLVM::ConstantOp>(loc, i64_ty, type.getNumElements());
+          rewriter.create<LLVM::ConstantOp>(loc, i32_ty, type.getNumElements());
       Value allocated = rewriter.create<LLVM::AllocaOp>(
           loc, ptrType, elementType, numElements, /*alignment=*/0);
       auto descr = MemRefDescriptor::fromStaticShape(

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -163,3 +163,16 @@ TritonGPUToLLVMTypeConverter::convertTritonTensorType(RankedTensorType type) {
 
   return std::nullopt;
 }
+
+// Copied from GpuOpsLowering.cpp
+void populateGpuMemorySpaceAttributeConversions(
+    TypeConverter &typeConverter, const MemorySpaceMapping &mapping) {
+  typeConverter.addTypeAttributeConversion(
+      [mapping](BaseMemRefType type,
+                mlir::gpu::AddressSpaceAttr memorySpaceAttr) {
+        mlir::gpu::AddressSpace memorySpace = memorySpaceAttr.getValue();
+        unsigned addressSpace = mapping(memorySpace);
+        return wrapNumericMemorySpace(memorySpaceAttr.getContext(),
+                                      addressSpace);
+      });
+}

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -8,6 +8,20 @@
 using namespace mlir;
 using namespace mlir::triton;
 
+// Copied from GpuOpsLowering.h
+/// A function that maps a MemorySpace enum to a target-specific integer value.
+using MemorySpaceMapping =
+    std::function<unsigned(mlir::gpu::AddressSpace gpuAddressSpace)>;
+
+/// Copied from GpuOpsLowering.cpp
+static IntegerAttr wrapNumericMemorySpace(MLIRContext *ctx, unsigned space) {
+  return IntegerAttr::get(IntegerType::get(ctx, 64), space);
+}
+
+// Copied from GpuOpsLowering.cpp
+void populateGpuMemorySpaceAttributeConversions(
+    TypeConverter &typeConverter, const MemorySpaceMapping &mapping);
+
 class TritonGPUToLLVMTypeConverter : public LLVMTypeConverter {
 public:
   using TypeConverter::convertType;


### PR DESCRIPTION
- Added in-rock transforms to lower blockwise_gemm_v2
- Complete the GPUToROCDL conversion patterns to include the following patterns:
  - AMDGPUToROCDL
  - VectorToLLVM
  - MemRefToLLVM
- Note that ArithToLLVM is another pass applied after RockToLLVMPass
- Set index-bitwidth=32 for various passes to eliminate the unresolved
`unrealized_conversion_cast` ops

Now the kernel is generated.
The next PR will fix the runtime error occurred when running the generated kernel.