### PR TITLE
Print all softmax tutorial benchmark rows.

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -187,6 +187,8 @@ def benchmark(M, N, provider):
     return gbps(ms), gbps(max_ms), gbps(min_ms)
 
 
+import pandas as pd
+pd.set_option('display.max_rows', 500)
 benchmark.run(show_plots=True, print_data=True)
 
 # %%

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -337,7 +337,7 @@ def test_layer_norm(M, N, dtype, eps=1e-5, device='cuda'):
         line_names=['Triton', 'Torch'] + (['Apex'] if HAS_APEX else []),
         styles=[('blue', '-'), ('green', '-'), ('orange', '-')],
         ylabel='GB/s',
-        plot_name='layer-norm-backward',
+        plot_name='layer-norm-forward',
         args={'M': 4096, 'dtype': torch.float16, 'mode': 'forward'}
     )
 )


### PR DESCRIPTION
This change is necessary to print all the softmax benchmark output rows.

Without this change, the output gets truncated and only prints 60 rows.

The full test result contains almost 100 rows.