### PR TITLE
ROCM support of conversion between Fp8e5m2 and fp16/fp32

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -886,7 +886,7 @@ def test_load_store_same_ptr():
 
 
 @pytest.mark.parametrize("in_dtype", [tl.float8e4]) # TODO: support tl.float8e5
-@pytest.mark.parametrize("out_dtype", [torch.float16]) # TODO: support torch.float32
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.float32]) 
 def test_f8_xf16_roundtrip(in_dtype, out_dtype):
     """Tests that converting an f8 to f16 and back to f8 doesn't change its value"""
     check_type_supported(out_dtype)

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -885,7 +885,7 @@ def test_load_store_same_ptr():
         assert torch.all(x == 2)
 
 
-@pytest.mark.parametrize("in_dtype", [tl.float8e4]) # TODO: support tl.float8e5
+@pytest.mark.parametrize("in_dtype", [tl.float8e4, tl.float8e5]) 
 @pytest.mark.parametrize("out_dtype", [torch.float16, torch.float32]) 
 def test_f8_xf16_roundtrip(in_dtype, out_dtype):
     """Tests that converting an f8 to f16 and back to f8 doesn't change its value"""


### PR DESCRIPTION
Added conversion between Fp8e5m2 and fp16/fp32 on AMDGPU.
The support of conversion between Fp8e5m2 and bf16 will be added later after picking up updates from the upstream.