### PR TITLE
[dotOp] [rocMLIR] Enable tuning

### DIFF
--- a/include/triton/Conversion/Passes.td
+++ b/include/triton/Conversion/Passes.td
@@ -20,7 +20,13 @@ def ConvertTritonToTritonGPU: Pass<"convert-triton-to-tritongpu", "mlir::ModuleO
    let options = [
        Option<"numWarps", "num-warps",
               "int32_t", /*default*/"4",
-              "number of warps">
+              "number of warps">,
+       Option<"kpack", "kpack",
+              "int32_t", /*default*/"4",
+              "rock tuning parameter">,
+       Option<"mPerWave", "mPerWave",
+              "int32_t", /*default*/"16",
+              "rock tuning parameter">
    ];
 }
 

--- a/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -14,13 +14,15 @@ template <typename T> class OperationPass;
 namespace triton {
 
 constexpr static char AttrNumWarpsName[] = "triton_gpu.num-warps";
+constexpr static char AttrKPackName[] = "triton_gpu.kpack";
+constexpr static char AttrMPerWaveName[] = "triton_gpu.mPerWave";
 
 // Create the pass with numWarps passed from cl::opt.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToTritonGPUPass();
 
 // Create the pass with numWarps set explicitly.
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonToTritonGPUPass(int numWarps);
+createConvertTritonToTritonGPUPass(int numWarps, int kpack, int mPerWave);
 
 } // namespace triton
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -22,11 +22,25 @@ def TritonGPU_Dialect : Dialect {
 
   let extraClassDeclaration = [{
     static std::string getNumWarpsAttrName() { return "triton_gpu.num-warps"; }
-    static int getNumWarps(ModuleOp mod) { 
+    static std::string getKPackAttrName() { return "triton_gpu.kpack"; }
+    static std::string getMPerWaveAttrName() { return "triton_gpu.mPerWave"; }
+    static int getNumWarps(ModuleOp mod) {
       if(!mod->hasAttr("triton_gpu.num-warps"))
         llvm::report_fatal_error(
             "TritonGPU module should contain a triton_gpu.num-warps attribute");
       return mod->getAttr("triton_gpu.num-warps").cast<IntegerAttr>().getInt();
+    }
+    static int getKPack(ModuleOp mod) {
+      if(!mod->hasAttr("triton_gpu.kpack"))
+        llvm::report_fatal_error(
+            "TritonGPU module should contain a triton_gpu.kpack attribute");
+      return mod->getAttr("triton_gpu.kpack").cast<IntegerAttr>().getInt();
+    }
+    static int getMPerWave(ModuleOp mod) {
+      if(!mod->hasAttr("triton_gpu.mPerWave"))
+        llvm::report_fatal_error(
+            "TritonGPU module should contain a triton_gpu.mPerWave attribute");
+      return mod->getAttr("triton_gpu.mPerWave").cast<IntegerAttr>().getInt();
     }
   }];
   

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToRockPass.cpp
@@ -137,7 +137,7 @@ struct DotOpRewritePattern : public OpRewritePattern<triton::DotOp> {
     // Therefore, mPerWave and nPerWave need to be derived.
     // TODO: this is a duplicate from BlockedToMFMA in the
     // tritongpu-accelerate-matmul pass. We should unify them in the future.
-    uint32_t mPerWave = std::min<uint32_t>(32, mPerBlock);
+    uint32_t mPerWave = std::min<uint32_t>(16, mPerBlock);
     uint32_t nPerWave = mPerBlock * nPerBlock / numWarps / mPerWave;
     if (mPerBlock * nPerBlock / (mPerWave * nPerWave) != numWaves)
       return emitError(loc) << "Need to pick another [m|n]PerWave!\n";
@@ -412,7 +412,7 @@ private:
       // given. Therefore, mPerWave and nPerWave need to be derived.
       // TODO: this is a duplicate from BlockedToMFMA in the
       // tritongpu-accelerate-matmul pass. We should unify them in the future.
-      uint32_t mPerWave = std::min<uint32_t>(32, mPerBlock);
+      uint32_t mPerWave = std::min<uint32_t>(16, mPerBlock);
       uint32_t nPerWave = mPerBlock * nPerBlock / numWarps / mPerWave;
       if (mPerBlock * nPerBlock / (mPerWave * nPerWave) != numWaves) {
         emitError(loc) << "Need to pick another [m|n]PerWave!\n";

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -766,7 +766,11 @@ public:
       ConvertTritonToTritonGPU>::ConvertTritonToTritonGPUBase;
   ConvertTritonToTritonGPU() = default;
   // constructor with some parameters set explicitly.
-  ConvertTritonToTritonGPU(int numWarps) { this->numWarps = numWarps; }
+  ConvertTritonToTritonGPU(int numWarps, int kpack, int mPerWave) {
+    this->numWarps = numWarps;
+    this->kpack = kpack;
+    this->mPerWave = mPerWave;
+  }
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -796,6 +800,13 @@ public:
         AttrNumWarpsName,
         IntegerAttr::get(i32_ty, llvm::APInt(32, numWarps.getValue())));
 
+    mod->setAttr(AttrKPackName,
+                 IntegerAttr::get(i32_ty, llvm::APInt(32, kpack.getValue())));
+
+    mod->setAttr(
+        AttrMPerWaveName,
+        IntegerAttr::get(i32_ty, llvm::APInt(32, mPerWave.getValue())));
+
     // update layouts
     //  broadcast src => multicast, dst => broadcasted
     // if (failed(target.refineLayouts(mod, numWarps)))
@@ -806,8 +817,10 @@ public:
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
-mlir::triton::createConvertTritonToTritonGPUPass(int numWarps) {
-  return std::make_unique<::ConvertTritonToTritonGPU>(numWarps);
+mlir::triton::createConvertTritonToTritonGPUPass(int numWarps, int kpack,
+                                                 int mPerWave) {
+  return std::make_unique<::ConvertTritonToTritonGPU>(numWarps, kpack,
+                                                      mPerWave);
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -218,17 +218,11 @@ public:
     auto elementType = matA.getType().cast<RankedTensorType>().getElementType();
     auto aShape = matA.getType().cast<RankedTensorType>().getShape();
     uint32_t kPerBlock = aShape[1];
-    // TODO: kpack is needed to check the validity of the selected mfma
-    // instruction group.It is later used as one of the parameters of
-    // the LDSEncodingAttr. Make it a metadata that can be passed from
-    // kernel launch so that we have a single source of truth of its value.
-    uint32_t kpack = 4;
+    uint32_t kpack = triton::gpu::TritonGPUDialect::getKPack(mod);
     // Parameters for MfmaEncodingAttr
-    // TODO: Find a better way to derive [m|n]PerWave
-    // TODO: Check the validity of these parameters
     uint32_t mPerBlock = retShape[0];
     uint32_t nPerBlock = retShape[1];
-    uint32_t mPerWave = std::min<uint32_t>(16, mPerBlock);
+    uint32_t mPerWave = triton::gpu::TritonGPUDialect::getMPerWave(mod);
     uint32_t nPerWave = mPerBlock * nPerBlock / numWarps / mPerWave;
     if (nPerWave < 16)
       return emitError(loc) << "numWarps too large.\n";

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -228,7 +228,7 @@ public:
     // TODO: Check the validity of these parameters
     uint32_t mPerBlock = retShape[0];
     uint32_t nPerBlock = retShape[1];
-    uint32_t mPerWave = std::min<uint32_t>(32, mPerBlock);
+    uint32_t mPerWave = std::min<uint32_t>(16, mPerBlock);
     uint32_t nPerWave = mPerBlock * nPerBlock / numWarps / mPerWave;
     if (nPerWave < 16)
       return emitError(loc) << "numWarps too large.\n";

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -50,9 +50,7 @@ public:
              dstDotOp.getParent() == srcMmaEncoding))
           return;
       }
-      // TODO: Make kpack one of the tuning parameters and pass it from
-      // kernel launch
-      uint32_t kpack = 4;
+      uint32_t kpack = triton::gpu::TritonGPUDialect::getKPack(mod);
       auto tmpType = RankedTensorType::get(
           dstType.getShape(), dstType.getElementType(),
           triton::gpu::LDSEncodingAttr::get(mod.getContext(), dstDotOp, kpack));

--- a/python/batch_prof.sh
+++ b/python/batch_prof.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+## $1: config file
+##     Each line in the config file must be dims for N, M, and K
+##     separated by space
+## $2: reduced tuning space
+
+if [[ $# -lt 2 ]];then
+    echo "Usage: ./batch_prof.sh <config_file> <reducedTuningSpace>"
+    exit
+fi
+
+DRIVER="./test/unit/language/matmul.py"
+
+CONFIG_FILE=$1
+reduceSpace=$2
+
+while IFS= read -r line
+do
+    echo "config: $line"
+    gemm_config=($line)
+    N=${gemm_config[0]}
+    M=${gemm_config[1]}
+    K=${gemm_config[2]}
+    ./prof.sh $DRIVER $M $N $K $reduceSpace
+done < "$CONFIG_FILE"

--- a/python/prof.sh
+++ b/python/prof.sh
@@ -4,65 +4,123 @@
 ## $2: M
 ## $3: N
 ## $4: K
+## $5: 1: reduced tuning space
 
+if [[ $# -lt 5 ]];then
+    echo "Usage: ./prof.sh <driver program> M N K <reduceTuningSpace>"
+    exit
+fi
 
 PROF_RESULT_FILE="results.stats.csv"
 
+DRIVER=$1
 M=$2
 N=$3
 K=$4
+reduceSpace=$5
 
-
-## Tuning space for Triton
-BLOCK_RANGE=(16 32 64)
-SPLIT_K_RANGE=(2 4 8 16 18 24)
-NUM_WARPS_RANGE=(1 2 4 8)
-
+if [[ $reduceSpace -eq 0 ]];then
+    ## Tuning space for Triton
+    BLOCK_RANGE=(16 32 64 128)
+    SPLIT_K_RANGE=(2 4 6 8 10 12 14 16 18 20 22 24)
+    NUM_WARPS_RANGE=(1 2 4 8)
+    ## Tuning space for rocMLIR
+    KPACK_RANGE=(1 2 4 8)
+    mPerWave_RANGE=(16 32 64)
+else ## Reduced tuning space
+    ## Tuning space for Triton
+    BLOCK_RANGE=(16 32 64)
+    SPLIT_K_RANGE=(2 8 12 18 24)
+    NUM_WARPS_RANGE=(1 2 4 8)
+    ## Tuning space for rocMLIR
+    KPACK_RANGE=(4 8)
+    mPerWave_RANGE=(16 32)
+fi
 
 echo "Tuning GEMM for M=$M, N=$N, K=$K"
 
 minTime=""
+##################################
+## Looping BLOCK_M              ##
+##################################
 for BLOCK_M in ${BLOCK_RANGE[@]}
 do
     ## Skip BLOCK_M if it is too large for M
     if [[ $M -le 16 ]] && [[ $BLOCK_M -ne 16 ]]; then
         continue
     fi
+    ##################################
+    ## Looping BLOCK_N              ##
+    ##################################
     for BLOCK_N in ${BLOCK_RANGE[@]}
     do
         ## Skip BLOCK_N if it is too large for N
         if [[ $N -le 16 ]] && [[ $BLOCK_N -ne 16 ]]; then
             continue
         fi
+        ##################################
+        ## Looping BLOCK_K              ##
+        ##################################
         for BLOCK_K in ${BLOCK_RANGE[@]}
         do
+            ##################################
+            ## Looping SPLIT_K              ##
+            ##################################
             for SPLIT_K in ${SPLIT_K_RANGE[@]}
             do
-                for NUM_WARPS in ${NUM_WARPS_RANGE[@]}
+                ## Skip SPLIT_K if K % (SPLIT_K * BLOCK_K) != 0
+                leap=$((SPLIT_K * BLOCK_K))
+                mod=$((K%leap))
+                if [[ $mod -ne 0 ]]; then
+                    continue
+                fi
+                ##################################
+                ## Looping mPerWave            ##
+                ##################################
+                for mPerWave in ${mPerWave_RANGE[@]}
                 do
-                    perfConfig="$BLOCK_M,$BLOCK_N,$BLOCK_K,$SPLIT_K,$NUM_WARPS"
-                    ## rule out large num_warps
-                    maxNumWarps=$((BLOCK_M*BLOCK_N/256))
-                    if [[ $NUM_WARPS -gt $maxNumWarps ]]; then
+                    ## Skip mPerWave if its larger than BLOCK_M
+                    if [[ $mPerWave -gt $BLOCK_M ]]; then
                         continue
                     fi
-
-                    Msg=$(rocprof --stats python $1 -m $M -n $N -k $K \
-                                  -blockM ${BLOCK_M} -blockN ${BLOCK_N} -blockK ${BLOCK_K} \
-                                  -num_warps ${NUM_WARPS} -splitK ${SPLIT_K})
-
-                    if [[ $? != 0 ]]; then
-                        time="NA"
-                        continue
-                    else
-                        time=$(sed -n '/matmul_kernel/p' ${PROF_RESULT_FILE} \
-                                   | awk -F ',' '{print $4}')
-                        if [[ $minTime == "" ]] || [[ $time -lt $minTime ]];then
-                            minTime=$time
-                            bestPerfConfig=$perfConfig
+                    ##################################
+                    ## Looping num_warps            ##
+                    ##################################
+                    for num_warps in ${NUM_WARPS_RANGE[@]}
+                    do
+                        ## Skip large num_warps
+                        maxNumWarps=$((BLOCK_M*BLOCK_N/16/mPerWave))
+                        if [[ $num_warps -gt $maxNumWarps ]]; then
+                            continue
                         fi
-                    fi
-                    echo "Checked $perfConfig  best parameters: $bestPerfConfig --> $minTime"
+                        ##################################
+                        ## Looping kpack                ##
+                        ##################################
+                        for kpack in ${KPACK_RANGE[@]}
+                        do
+                            perfConfig="$BLOCK_M,$BLOCK_N,$BLOCK_K,$SPLIT_K,$mPerWave,$kpack,$num_warps"
+                            rm -rf ~/.triton/cache
+                            Msg=$(rocprof --stats python $DRIVER -m $M -n $N -k $K \
+                                          -blockM ${BLOCK_M} -blockN ${BLOCK_N} -blockK ${BLOCK_K} \
+                                          -num_warps ${num_warps} -splitK ${SPLIT_K}\
+                                          -kpack $kpack -mPerWave $mPerWave)
+
+                            ## Skip if there is an error (invalid kpack)
+                            if [[ $? != 0 ]]; then
+                                echo "Checked $perfConfig  invalid (kpack, BLOCK_K)"
+                                continue
+                            else
+                                time=$(sed -n '/matmul_kernel/p' ${PROF_RESULT_FILE} \
+                                           | awk -F ',' '{print $4}')
+                                if [[ $minTime == "" ]] || [[ $time -lt $minTime ]];then
+                                    minTime=$time
+                                    bestPerfConfig=$perfConfig
+                                fi
+                            fi
+                            echo "Checked $perfConfig  best parameters: $bestPerfConfig --> $minTime"
+                        done
+
+                    done
                 done
             done
         done

--- a/python/prof.sh
+++ b/python/prof.sh
@@ -1,0 +1,73 @@
+#! /bin/bash
+
+## $1: input file
+## $2: M
+## $3: N
+## $4: K
+
+
+PROF_RESULT_FILE="results.stats.csv"
+
+M=$2
+N=$3
+K=$4
+
+
+## Tuning space for Triton
+BLOCK_RANGE=(16 32 64)
+SPLIT_K_RANGE=(2 4 8 16 18 24)
+NUM_WARPS_RANGE=(1 2 4 8)
+
+
+echo "Tuning GEMM for M=$M, N=$N, K=$K"
+
+minTime=""
+for BLOCK_M in ${BLOCK_RANGE[@]}
+do
+    ## Skip BLOCK_M if it is too large for M
+    if [[ $M -le 16 ]] && [[ $BLOCK_M -ne 16 ]]; then
+        continue
+    fi
+    for BLOCK_N in ${BLOCK_RANGE[@]}
+    do
+        ## Skip BLOCK_N if it is too large for N
+        if [[ $N -le 16 ]] && [[ $BLOCK_N -ne 16 ]]; then
+            continue
+        fi
+        for BLOCK_K in ${BLOCK_RANGE[@]}
+        do
+            for SPLIT_K in ${SPLIT_K_RANGE[@]}
+            do
+                for NUM_WARPS in ${NUM_WARPS_RANGE[@]}
+                do
+                    perfConfig="$BLOCK_M,$BLOCK_N,$BLOCK_K,$SPLIT_K,$NUM_WARPS"
+                    ## rule out large num_warps
+                    maxNumWarps=$((BLOCK_M*BLOCK_N/256))
+                    if [[ $NUM_WARPS -gt $maxNumWarps ]]; then
+                        continue
+                    fi
+
+                    Msg=$(rocprof --stats python $1 -m $M -n $N -k $K \
+                                  -blockM ${BLOCK_M} -blockN ${BLOCK_N} -blockK ${BLOCK_K} \
+                                  -num_warps ${NUM_WARPS} -splitK ${SPLIT_K})
+
+                    if [[ $? != 0 ]]; then
+                        time="NA"
+                        continue
+                    else
+                        time=$(sed -n '/matmul_kernel/p' ${PROF_RESULT_FILE} \
+                                   | awk -F ',' '{print $4}')
+                        if [[ $minTime == "" ]] || [[ $time -lt $minTime ]];then
+                            minTime=$time
+                            bestPerfConfig=$perfConfig
+                        fi
+                    fi
+                    echo "Checked $perfConfig  best parameters: $bestPerfConfig --> $minTime"
+                done
+            done
+        done
+    done
+done
+
+OUTPUT=triton_perf_config.txt
+echo "$M,$N,$K  best parameters: $bestPerfConfig --> $minTime" | tee -a $OUTPUT

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1543,9 +1543,9 @@ void init_triton_ir(py::module &&m) {
              self.addPass(mlir::triton::createCombineOpsPass());
            })
       .def("add_convert_triton_to_tritongpu_pass",
-           [](mlir::PassManager &self, int numWarps) {
+           [](mlir::PassManager &self, int numWarps, int kpack, int mPerWave) {
              self.addPass(
-                 mlir::triton::createConvertTritonToTritonGPUPass(numWarps));
+                 mlir::triton::createConvertTritonToTritonGPUPass(numWarps, kpack, mPerWave));
            })
       .def("add_tritongpu_pipeline_pass",
            [](mlir::PassManager &self, int numStages) {

--- a/python/test/unit/language/matmul.py
+++ b/python/test/unit/language/matmul.py
@@ -1,0 +1,136 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+import triton
+import triton.language as tl
+
+import argparse
+import sys
+
+@triton.jit
+def matmul_kernel(
+    a_ptr, b_ptr, c_ptr,
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    M: tl.constexpr, N: tl.constexpr, K: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    SPLIT_K: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    pid_z = tl.program_id(1)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_k = pid_z * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        accumulator += tl.dot(a, b)
+        a_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_bk
+
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    if SPLIT_K == 1:
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+    else:
+        tl.atomic_add(c_ptrs, accumulator, mask=c_mask)
+
+# TODO: DotConversion in TritonGPUToLLVM cannot support non-splat C for the moment
+
+
+def get_variant_golden(a, b):
+    SIZE_M = a.shape[0]
+    SIZE_K = a.shape[1]
+    SIZE_N = b.shape[1]
+    assert a.shape[1] == b.shape[0]
+    zero_M_K = torch.zeros((SIZE_M, SIZE_K)).cuda()
+    zero_3M_K = torch.zeros((3 * SIZE_M, SIZE_K)).cuda()
+    zero_K_N = torch.zeros((SIZE_K, SIZE_N)).cuda()
+    zero_3K_N = torch.zeros((3 * SIZE_K, SIZE_N)).cuda()
+    a_padded = torch.cat((a, zero_M_K, zero_M_K), 0)
+    a_padded = torch.cat((a_padded, zero_3M_K, zero_3M_K), 1)
+    b_padded = torch.cat((b, zero_K_N, zero_K_N), 0)
+    b_padded = torch.cat((b_padded, zero_3K_N, zero_3K_N), 1)
+    c_padded = torch.matmul(a_padded, b_padded)
+    return c_padded[:SIZE_M, :SIZE_N]
+
+
+def test_gemm(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, SPLIT_K):
+    a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
+    b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
+    c = torch.zeros((SIZE_M, SIZE_N), device=a.device, dtype=torch.float32)
+    #grid = lambda META: (1, )
+    grid = lambda META: (
+        triton.cdiv(SIZE_M, BLOCK_SIZE_M) * triton.cdiv(SIZE_N, BLOCK_SIZE_N),
+        SPLIT_K
+    )
+    matmul_kernel[grid](a_ptr=a, b_ptr=b, c_ptr=c,
+                        stride_am=a.stride(0), stride_ak=a.stride(1),
+                        stride_bk=b.stride(0), stride_bn=b.stride(1),
+                        stride_cm=c.stride(0), stride_cn=c.stride(1),
+                        M=a.shape[0], N=b.shape[1], K=a.shape[1],
+                        BLOCK_SIZE_M=BLOCK_SIZE_M,
+                        BLOCK_SIZE_N=BLOCK_SIZE_N,
+                        BLOCK_SIZE_K=BLOCK_SIZE_K,
+                        SPLIT_K=SPLIT_K,
+                        num_warps=NUM_WARPS)
+    golden = torch.matmul(a, b)
+
+    # It's not easy to get a proper error threshold in different size
+    # Here the gemm calculation is padded to a different size in order to get
+    # a variant version of the golden result. And the error between golden and
+    # golden_variant provide reference on selecting the proper rtol / atol.
+    golden_variant = get_variant_golden(a, b)
+    golden_diff = golden - golden_variant
+    golden_abs_err = torch.max(torch.abs(golden_diff)).item()
+    golden_rel_err = torch.max(torch.abs(golden_diff / golden)).item()
+
+    torch.set_printoptions(profile="full")
+    assert_close(c, golden, rtol=max(1e-4, 1.5 * golden_rel_err), atol=max(1e-4, 1.5 * golden_abs_err), check_dtype=False)
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        prog="test gemm tuning",
+        description="Tuning infra for triton gemm",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-m", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-n", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-k", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-blockM", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-blockN", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-blockK", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-splitK", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-num_warps", type=int, default=argparse.SUPPRESS)
+
+    parsed_args = parser.parse_args(args)
+
+    M = parsed_args.m
+    N = parsed_args.n
+    K = parsed_args.k
+    num_warps = parsed_args.num_warps
+    BLOCK_M = parsed_args.blockM
+    BLOCK_N = parsed_args.blockN
+    BLOCK_K = parsed_args.blockK
+    SPLIT_K = parsed_args.splitK
+    test_gemm(M, N, K, num_warps, BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/test/unit/language/matmul.py
+++ b/python/test/unit/language/matmul.py
@@ -67,7 +67,7 @@ def get_variant_golden(a, b):
     return c_padded[:SIZE_M, :SIZE_N]
 
 
-def test_gemm(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, SPLIT_K):
+def test_gemm(SIZE_M, SIZE_N, SIZE_K, num_warps, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, SPLIT_K, kpack, mPerWave):
     a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
     b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
     c = torch.zeros((SIZE_M, SIZE_N), device=a.device, dtype=torch.float32)
@@ -85,7 +85,9 @@ def test_gemm(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS, BLOCK_SIZE_M, BLOCK_SIZE_N, BLO
                         BLOCK_SIZE_N=BLOCK_SIZE_N,
                         BLOCK_SIZE_K=BLOCK_SIZE_K,
                         SPLIT_K=SPLIT_K,
-                        num_warps=NUM_WARPS)
+                        num_warps=num_warps,
+                        kpack=kpack, mPerWave=mPerWave
+                        )
     golden = torch.matmul(a, b)
 
     # It's not easy to get a proper error threshold in different size
@@ -119,6 +121,8 @@ def main(args=None):
     parser.add_argument("-blockK", type=int, default=argparse.SUPPRESS)
     parser.add_argument("-splitK", type=int, default=argparse.SUPPRESS)
     parser.add_argument("-num_warps", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-kpack", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-mPerWave", type=int, default=argparse.SUPPRESS)
 
     parsed_args = parser.parse_args(args)
 
@@ -130,7 +134,9 @@ def main(args=None):
     BLOCK_N = parsed_args.blockN
     BLOCK_K = parsed_args.blockK
     SPLIT_K = parsed_args.splitK
-    test_gemm(M, N, K, num_warps, BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K)
+    kpack = parsed_args.kpack
+    mPerWave = parsed_args.mPerWave
+    test_gemm(M, N, K, num_warps, BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, kpack, mPerWave)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
This PR enables tuning by the following changes
- `kpack` and `mPerWave`, which are additional tuning parameters for lowering within Rock, are promoted as compilation options as `num_warps`. This means
    - At user level, `kpack` and `mPerWave` can be set in the same way as `num_warps`. If not set, the default values are 4 for `kpack` and 16 for `mPerWave`.
    - The jit is able to grab `kpack` and `mPerWave` and put them in the set of keyword arguments in the same way as it does for `num_warps`
    - During the conversion from triton to tritonGPU, `kpack` and `mPerWave` will be added as module attributes.
    - Whenever `kpack` and `mPerWave` is needed, they can be obtained from the module attribute set.
- `prof.sh` is a simple script that can be used to tune a single gemm configs. 
    - It traverses a tuning space that includes both triton and rocMLIR tuning paremeters: `BLOCK_M`, `BLOCK_N`, `BLOCK_K`, `SPLIT_K`, `num_warps`, `kpack`, and `mPerWave`. 
    - It uses a driver program `triton/python/test/unit/language/matmul.py` to test the gemm config.
    - `rocprof --stats` is used to measure the time of kernel `matmul_kernel` 
- `batch_prof.sh` wraps `prof.sh` and can tune multiple gemm configs
- The tuning results are written to `triton_perf_config.txt`

There is one tiny issue with the jit that it does not distinguish `kpack` values when caching. It means we need to `rm -rf ~/.triton/cache` before running the driver. This will be fixed in the future PR if needed.