### PR TITLE
Rename package to pytorch-triton-rocm

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -207,7 +207,7 @@ class CMakeBuild(build_ext):
 download_and_copy_ptxas()
 
 setup(
-    name="triton",
+    name="pytorch-triton-rocm",
     version="2.0.0",
     author="Philippe Tillet",
     author_email="phil@openai.com",


### PR DESCRIPTION
since this branch will be used to generate triton packages specifically for pytorch.

This should help avoid any issues with two different triton packages getting installed in our ROCm CI due to mismatching package names