### PR TITLE
remove one matrix configuration which is larger than the size of LDS

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1128,13 +1128,10 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
                          [(dtype, shape, perm)
                           # TODO: bfloat16
                           for dtype in ['float16', 'float32']
-                             for shape in [(64, 64), (128, 128)]
+                             for shape in [(64, 64)]
                              for perm in [(1, 0)]])
 def test_permute(dtype_str, shape, perm, device='cuda'):
     check_type_supported(dtype_str)  # bfloat16 on cc < 80 will not be tested
-    if torch.version.hip is not None:
-        if (dtype_str, shape) == ('float32', (128, 128)):
-            pytest.skip("Not supported: memory out of resource.")
 
     # triton kernel
     @triton.jit


### PR DESCRIPTION
The purpose of this test is to verify vector loads/stores. The size of the matrix is 128*128*4 (float32) = 64KB. An extra memory overhead is needed to eliminate bank conflicts. Therefore, we need more than 64KB in LDS to run the test. In addition, we need two memory transactions for a vectorized load of float32.