### PR TITLE
fix a potential issue in the pipeline pass

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -364,14 +364,14 @@ void LoopPipeliner::emitPrologue() {
     for (Operation &op : forOp.getLoopBody().front()) {
       if (depOps.contains(&op))
         orderedDeps.push_back(&op);
-      else if (loads.contains(op.getResult(0)))
+      else if (op.getNumResults() > 0 && loads.contains(op.getResult(0)))
         orderedDeps.push_back(&op);
     }
     assert(depOps.size() + loads.size() == orderedDeps.size() &&
            "depOps contains invalid values");
     for (Operation *op : orderedDeps) {
       Operation *newOp = nullptr;
-      if (loads.contains(op->getResult(0))) {
+      if (op->getNumResults() > 0 && loads.contains(op->getResult(0))) {
         // Allocate empty buffer
         if (stage == 0) {
           loadsBuffer[op->getResult(0)] = allocateEmptyBuffer(op, builder);
@@ -578,7 +578,7 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   for (Operation &op : forOp.getLoopBody().front()) {
     if (depOps.contains(&op))
       orderedDeps.push_back(&op);
-    else if (loads.contains(op.getResult(0)))
+    else if (op.getNumResults() && loads.contains(op.getResult(0)))
       orderedDeps.push_back(&op);
   }
   assert(depOps.size() + loads.size() == orderedDeps.size() &&
@@ -652,7 +652,7 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   for (Operation *op : orderedDeps) {
     Operation *nextOp = nullptr;
     // Update loading mask
-    if (loads.contains(op->getResult(0))) {
+    if (op->getNumResults() > 0 && loads.contains(op->getResult(0))) {
       auto loadOp = llvm::cast<triton::LoadOp>(op);
       auto mask = loadOp.getMask();
       auto newMask =


### PR DESCRIPTION
The fix here is relate to the function call of `op.getResult(0)`, in which an op could have zero results, then this function call will have an assert failed.

The fix is to check the number of results of an op before calling this function. Only if an op has 1 or more results, will the function `op.getResult` called.