### PR TITLE
[ROCM] Fix transposed operands processing in dot operation with MFMA.

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1227,8 +1227,8 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                                            [32, 256, 32, 8],
                                            ]
                           for allow_tf32 in [False, True]
-                          for col_a in [False]
-                          for col_b in [False]
+                          for col_a in [True,False]
+                          for col_b in [True,False]
                           for dtype in ['int8', 'float16', 'float32']])
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, device='cuda'):
     capability = torch.cuda.get_device_capability()


### PR DESCRIPTION
- Applied to `loadA()` the same fix as 2c88ed6aab9ace22ccde1f0e443a1579727ee501.
- Minor cleanup of `mfmaLayout.getWarpsPerCTA()` usage.

Partialy fixes https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4545