### PR TITLE
[FA OPTIMIZATION] Keep results of FA dot operations in registers

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -126,6 +126,10 @@ template <typename T> T nextPowOf2(T n) {
   return n + 1;
 }
 
+#ifdef USE_ROCM
+bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy);
+#endif
+
 /// Multi-root DAG topological sort.
 /// Performs a topological sort of the Operation in the `toSort` SetVector.
 /// Returns a topologically sorted SetVector.

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -563,10 +563,7 @@ The data will be distributed between threads as follows:
     ins
     "unsigned":$nonKDim,
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
-    ArrayRefParameter<
-      "unsigned",
-      "order of axes by the rate of changing"
-    >:$order
+    "bool":$isTransposed
   );
 
   let hasCustomAssemblyFormat = 1;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -562,7 +562,11 @@ The data will be distributed between threads as follows:
   let parameters = (
     ins
     "unsigned":$nonKDim,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA
+    ArrayRefParameter<"unsigned">:$warpsPerCTA,
+    ArrayRefParameter<
+      "unsigned",
+      "order of axes by the rate of changing"
+    >:$order
   );
 
   let hasCustomAssemblyFormat = 1;

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -17,6 +17,7 @@ using ::mlir::triton::gpu::getContigPerThread;
 using ::mlir::triton::gpu::getOrder;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getSizePerThread;
+using ::mlir::triton::gpu::MfmaEncodingAttr;
 using ::mlir::triton::gpu::MmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingAttr;
 using ::mlir::triton::gpu::SliceEncodingAttr;
@@ -62,6 +63,13 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
       dstLayout.isa<DotOperandEncodingAttr>())
     if (isMmaToDotShortcut(srcTy, dstTy))
       return {};
+
+#ifdef USE_ROCM
+  if (srcLayout.isa<MfmaEncodingAttr>() &&
+      dstLayout.isa<DotOperandEncodingAttr>())
+    if (isMfmaToDotShortcut(srcTy, dstTy))
+      return {};
+#endif
 
   assert(srcLayout && dstLayout &&
          "Unexpected layout in getScratchConfigForCvtLayout()");

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -194,10 +194,8 @@ private:
       unsigned inVec = 0;
       unsigned outVec = 0;
       auto smemShape = getScratchConfigForCvtLayout(cvtLayout, inVec, outVec);
-      unsigned elems = smemShape.empty()
-                           ? 0
-                           : std::accumulate(smemShape.begin(), smemShape.end(),
-                                             1, std::multiplies{});
+      unsigned elems = std::accumulate(smemShape.begin(), smemShape.end(), 1,
+                                       std::multiplies{});
       auto bytes =
           srcTy.getElementType().isa<triton::PointerType>()
               ? elems * kPtrBitWidth / 8

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -201,10 +201,13 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   auto dstLayout = dstTy.getEncoding();
   auto mfmaLayout = srcLayout.cast<triton::gpu::MfmaEncodingAttr>();
   auto dotOperandLayout = dstLayout.cast<triton::gpu::DotOperandEncodingAttr>();
+  // TODO: Remove the restriction on the warpsPerCTA once chain dot testing is
+  // improved. In addition, we can enable this shortcut for regular MFMA
+  // layout when opIdx == 1.
   return mfmaLayout.getWarpsPerCTA()[1] == 1 &&
          dotOperandLayout.getOpIdx() == 0 &&
          dotOperandLayout.getParent() == mfmaLayout &&
-         mfmaLayout.getIsTransposed() && !srcTy.getElementType().isF32();
+         mfmaLayout.getIsTransposed() && srcTy.getElementType().isF16();
 }
 #endif
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -204,7 +204,7 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   return mfmaLayout.getWarpsPerCTA()[1] == 1 &&
          dotOperandLayout.getOpIdx() == 0 &&
          dotOperandLayout.getParent() == mfmaLayout &&
-         !srcTy.getElementType().isF32();
+         mfmaLayout.getIsTransposed() && !srcTy.getElementType().isF32();
 }
 #endif
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -666,7 +666,9 @@ private:
       SmallVector<Value> vecVals;
       SmallVector<Type> types;
       auto elemSize = elemTy.getIntOrFloatBitWidth();
-      unsigned vecSize = std::max<unsigned>(64 / elemSize, 1);
+      // TODO: Support types other than float16.
+      assert(type::isFloat(elemTy) && elemSize == 16);
+      unsigned vecSize = 4;
       Type vecTy = vec_ty(elemTy, vecSize);
       types = SmallVector<Type>(elems / vecSize, vecTy);
       for (unsigned i = 0; i < elems; i += vecSize) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -87,6 +87,12 @@ public:
         dstLayout.isa<DotOperandEncodingAttr>()) {
       return lowerMmaToDotOperand(op, adaptor, rewriter);
     }
+#ifdef USE_ROCM
+    if (srcLayout.isa<MfmaEncodingAttr>() &&
+        dstLayout.isa<DotOperandEncodingAttr>()) {
+      return lowerMfmaToDotOperand(op, adaptor, rewriter);
+    }
+#endif
     if (srcLayout.isa<SharedEncodingAttr>() &&
         isaDistributedLayout(dstLayout)) {
       return lowerSharedToDistributed(op, adaptor, rewriter);
@@ -675,6 +681,43 @@ private:
     rewriter.replaceOp(op, res);
     return success();
   }
+
+#ifdef USE_ROCM
+  LogicalResult
+  lowerMfmaToDotOperand(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
+                        ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
+    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    if (isMfmaToDotShortcut(srcTy, dstTy)) {
+      // get source values
+      auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
+                                                       rewriter, srcTy);
+      unsigned elems = getTotalElemsPerThread(srcTy);
+      Type elemTy =
+          this->getTypeConverter()->convertType(srcTy.getElementType());
+      // for the destination type, we need to pack values together
+      // so they can be consumed by tensor core operations
+      SmallVector<Value> vecVals;
+      SmallVector<Type> types;
+      auto elemSize = elemTy.getIntOrFloatBitWidth();
+      unsigned vecSize = std::max<unsigned>(64 / elemSize, 1);
+      Type vecTy = vec_ty(elemTy, vecSize);
+      types = SmallVector<Type>(elems / vecSize, vecTy);
+      for (unsigned i = 0; i < elems; i += vecSize) {
+        Value packed = rewriter.create<LLVM::UndefOp>(loc, vecTy);
+        for (unsigned j = 0; j < vecSize; j++)
+          packed = insert_element(vecTy, packed, vals[i + j], i32_val(j));
+        vecVals.push_back(packed);
+      }
+      Value view =
+          getTypeConverter()->packLLElements(loc, vecVals, rewriter, dstTy);
+      rewriter.replaceOp(op, view);
+      return success();
+    }
+    return failure();
+  }
+#endif
 
   // mma -> dot_operand
   LogicalResult

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -211,48 +211,13 @@ private:
     }
 #ifdef USE_ROCM
     if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-      SmallVector<Value> mfmaColIdx(4);
-      SmallVector<Value> mfmaRowIdx(16);
-      Value threadId = getThreadId(rewriter, loc);
-      unsigned iWaveSize = triton::gpu::getWarpSize(layout);
-      Value warpSize = i32_val(iWaveSize);
-      Value laneId = urem(threadId, warpSize);
-      Value warpId = udiv(threadId, warpSize);
-      // TODO: fix the bug in MMAEncodingAttr document
-      SmallVector<Value> multiDimWarpId(2);
-      multiDimWarpId[0] = urem(warpId, i32_val(mfmaLayout.getWarpsPerCTA()[0]));
-      multiDimWarpId[1] = udiv(warpId, i32_val(mfmaLayout.getWarpsPerCTA()[0]));
-      Value _0 = i32_val(0);
-      Value _1 = i32_val(1);
-      Value _4 = i32_val(4);
-      Value _8 = i32_val(8);
-      Value _32 = i32_val(32);
-      multiDimWarpId[0] = urem(multiDimWarpId[0], i32_val(shape[0] / 32));
-      multiDimWarpId[1] = urem(multiDimWarpId[1], i32_val(shape[1] / 32));
-      Value halfOffset = select(icmp_uge(laneId, _32), _4, _0);
-      Value mfmaGroup32 = urem(laneId, _32);
-      Value rowWarpOffset = mul(multiDimWarpId[0], _32);
-      for (unsigned block = 0; block < 4; ++block) {
-        mfmaRowIdx[4 * block] = block == 0
-                                    ? add(halfOffset, rowWarpOffset)
-                                    : add(mfmaRowIdx[4 * (block - 1)], _8);
-        for (int r = 1; r < 4; ++r) {
-          mfmaRowIdx[4 * block + r] = add(mfmaRowIdx[4 * block + r - 1], _1);
-        }
-      }
-      Value colWarpOffset = mul(multiDimWarpId[1], _32);
-      mfmaColIdx[0] = add(mfmaGroup32, colWarpOffset);
-
+      auto multiDimBase = emitBaseIndexForLayout(loc, rewriter, layout, type);
+      SmallVector<SmallVector<unsigned>> offsets;
       assert(rank == 2);
       SmallVector<Value> multiDimOffset(rank);
-
-      multiDimOffset[0] = mfmaRowIdx[elemId % 16];
-
-      multiDimOffset[1] = mfmaColIdx[0];
-      multiDimOffset[0] = add(multiDimOffset[0],
-                              i32_val(multiDimCTAInRepId[0] * shapePerCTA[0]));
-      multiDimOffset[1] = add(multiDimOffset[1],
-                              i32_val(multiDimCTAInRepId[1] * shapePerCTA[1]));
+      emitMfmaOffsetForCTA(mfmaLayout, offsets, multiDimCTAInRepId[0], multiDimCTAInRepId[1]);
+      multiDimOffset[0] = add(multiDimBase[0], i32_val(offsets[elemId][0]));
+      multiDimOffset[1] = add(multiDimBase[1], i32_val(offsets[elemId][1]));
       return multiDimOffset;
     }
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -142,7 +142,9 @@ struct DotOpMFMAConversionHelper {
         }
 
         for (size_t k = 0; k < numRepK; k++) {
-          acc = generateMFMAOp(mfmaTy, ha[{m, k}], hb[{n, k}], acc);
+          acc = mfmaLayout.getIsTransposed()
+                    ? generateMFMAOp(mfmaTy, hb[{n, k}], ha[{m, k}], acc)
+                    : generateMFMAOp(mfmaTy, ha[{m, k}], hb[{n, k}], acc);
         }
         for (unsigned v = 0; v < 16; ++v) {
           fc[m * numRepN * 16 + n * 16 + v] =

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -655,6 +655,32 @@ public:
     llvm_unreachable("unsupported emitOffsetForLayout");
   }
 
+  void emitMfmaOffsetForCTA(const MfmaEncodingAttr &mfmaLayout,
+                        SmallVector<SmallVector<unsigned>> &offsets, unsigned i,
+                        unsigned j) const {
+    const unsigned iterationCount = 4;
+    auto shapePerCta = getShapePerCTA(mfmaLayout);
+    if (mfmaLayout.getIsTransposed()) {
+      unsigned colOffset = 0;
+      for (unsigned k = 0; k < iterationCount; k++) {
+        for (unsigned l = 0; l < iterationCount; l++) {
+          offsets.push_back(
+              {i * shapePerCta[0], j * shapePerCta[1] + l + colOffset});
+        }
+        colOffset += iterationCount * 2;
+      }
+    } else {
+      unsigned rowOffset = 0;
+      for (unsigned k = 0; k < iterationCount; k++) {
+        for (unsigned l = 0; l < iterationCount; l++) {
+          offsets.push_back(
+              {i * shapePerCta[0] + l + rowOffset, j * shapePerCta[1]});
+        }
+        rowOffset += iterationCount * 2;
+      }
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Emit indices
   // -----------------------------------------------------------------------
@@ -979,16 +1005,16 @@ private:
 
   SmallVector<Value>
   emitBaseIndexForMfmaLayout(Location loc, ConversionPatternRewriter &rewriter,
-                             const MfmaEncodingAttr &mmaLayout,
+                             const MfmaEncodingAttr &mfmaLayout,
                              RankedTensorType type) const {
     auto shape = type.getShape();
-    auto _warpsPerCTA = mmaLayout.getWarpsPerCTA();
+    auto _warpsPerCTA = mfmaLayout.getWarpsPerCTA();
     assert(_warpsPerCTA.size() == 2);
     SmallVector<Value> warpsPerCTA = {i32_val(_warpsPerCTA[0]),
                                       i32_val(_warpsPerCTA[1])};
 
     Value threadId = getThreadId(rewriter, loc);
-    Value warpSize = i32_val(triton::gpu::getWarpSize(mmaLayout));
+    Value warpSize = i32_val(triton::gpu::getWarpSize(mfmaLayout));
     Value laneId = urem(threadId, warpSize);
 
     Value warpId = udiv(threadId, warpSize);
@@ -1000,29 +1026,35 @@ private:
     Value offWarp1 = mul(warpId1, i32_val(32));
 
     SmallVector<Value> multiDimBase(2);
-    multiDimBase[0] = add(mul(i32_val(4), udiv(laneId, i32_val(32))), offWarp0);
-    multiDimBase[1] = add(urem(laneId, i32_val(32)), offWarp1);
+    if (mfmaLayout.getIsTransposed()) {
+      multiDimBase[1] =
+          add(mul(i32_val(4), udiv(laneId, i32_val(32))), offWarp1);
+      multiDimBase[0] = add(urem(laneId, i32_val(32)), offWarp0);
+    } else {
+      multiDimBase[0] =
+          add(mul(i32_val(4), udiv(laneId, i32_val(32))), offWarp0);
+      multiDimBase[1] = add(urem(laneId, i32_val(32)), offWarp1);
+    }
     return multiDimBase;
   }
 
   SmallVector<SmallVector<unsigned>>
-  emitOffsetForMfmaLayout(const MfmaEncodingAttr &mmaLayout,
+  emitOffsetForMfmaLayout(const MfmaEncodingAttr &mfmaLayout,
                           RankedTensorType type) const {
 
     auto tensorShape = type.getShape();
     SmallVector<SmallVector<unsigned>> offsets;
-    auto shapePerCta = getShapePerCTA(mmaLayout);
-    const unsigned iterationCount = 4;
+    auto shapePerCta = getShapePerCTA(mfmaLayout);
 
-    for (unsigned i = 0; i < tensorShape[0]; i += shapePerCta[0]) {
-      for (unsigned j = 0; j < tensorShape[1]; j += shapePerCta[1]) {
-        unsigned rowOffset = 0;
-        for (unsigned k = 0; k < iterationCount; k++) {
-          for (unsigned l = 0; l < iterationCount; l++) {
-            offsets.push_back({i + l + rowOffset, j});
-          }
-          rowOffset += iterationCount * 2;
-        }
+    SmallVector<unsigned> numCTAPerDim(2);
+    for (unsigned d = 0; d < 2; ++d) {
+      unsigned inPerCTA = std::min<unsigned>(tensorShape[d], shapePerCta[d]);
+      numCTAPerDim[d] = ceil<unsigned>(tensorShape[d], inPerCTA);
+    }
+
+    for (unsigned i = 0; i < numCTAPerDim[0]; ++i) {
+      for (unsigned j = 0; j < numCTAPerDim[1]; ++j) {
+        emitMfmaOffsetForCTA(mfmaLayout, offsets, i, j);
       }
     }
     return offsets;

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -659,16 +659,16 @@ public:
   void emitMfmaOffsetForCTA(const MfmaEncodingAttr &mfmaLayout,
                             SmallVector<SmallVector<unsigned>> &offsets,
                             unsigned ctaOffsetX, unsigned ctaOffsetY) const {
-    // MFMA output tile consists of repeated "dot operand B" layout blocks along
-    // row axis. This variable defines number of these blocks
-    const unsigned numBlocks = 4;
-    const unsigned elemsPerThreadPerBlock = 4;
+    // MFMA output tile consists of repeated "dot operand B" layout groups along
+    // row axis. This variable defines number of these groups.
+    const unsigned numGroups = 4;
+    const unsigned elemsPerThreadPerGroup = 4;
     auto warpSize = getWarpSize(mfmaLayout);
     assert(warpSize == 64);
     auto shapePerCta = getShapePerCTA(mfmaLayout);
-    for (unsigned block = 0; block < numBlocks; block++) {
-      unsigned rowOrColOffset = block * elemsPerThreadPerBlock * warpSize / 32;
-      for (unsigned elem = 0; elem < elemsPerThreadPerBlock; elem++) {
+    for (unsigned block = 0; block < numGroups; block++) {
+      unsigned rowOrColOffset = block * elemsPerThreadPerGroup * warpSize / 32;
+      for (unsigned elem = 0; elem < elemsPerThreadPerGroup; elem++) {
         if (mfmaLayout.getIsTransposed()) {
           offsets.push_back(
               {ctaOffsetX * shapePerCta[0],

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1318,11 +1318,11 @@ LogicalResult ConvertLayoutOp::canonicalize(ConvertLayoutOp op,
   if (!arg)
     return mlir::failure();
   // cvt(view) -> view
-  // if (auto view = dyn_cast<triton::ViewOp>(arg)) {
-  //   rewriter.replaceOpWithNewOp<triton::ViewOp>(op, op->getResult(0).getType(),
-  //                                               view.getResult());
-  //   return mlir::success();
-  // }
+  if (auto view = dyn_cast<triton::ViewOp>(arg)) {
+    rewriter.replaceOpWithNewOp<triton::ViewOp>(op, op->getResult(0).getType(),
+                                                view.getResult());
+    return mlir::success();
+  }
   // cvt(cat) -> cat
   if (auto cat = dyn_cast<triton::CatOp>(arg)) {
     auto encoding =

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1,4 +1,3 @@
-#include "Utility.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/Utility.h"

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -122,23 +122,22 @@ SmallVector<unsigned, 2> warpsPerTileMI200(triton::DotOp dotOp,
   return ret;
 }
 
-bool isChainDot(triton::DotOp &dotOp) {
-  // TODO: Improve analysis to detect distiguish between simple chain dot and FA
-  // case.
-  auto filter = [&dotOp](Operation *op) {
-    return op->getParentRegion() == dotOp->getParentRegion();
-  };
-  auto slices = mlir::getSlice(dotOp, filter);
-  for (Operation *op : slices) {
-    if (isa<triton::DotOp>(op) && (op != dotOp))
-      return true;
-  }
-  return false;
-}
 class BlockedToMFMA : public mlir::RewritePattern {
 public:
   BlockedToMFMA(mlir::MLIRContext *context)
       : mlir::RewritePattern(triton::DotOp::getOperationName(), 2, context) {}
+
+  bool isChainDot(triton::DotOp &dotOp) const {
+    auto filter = [&dotOp](Operation *op) {
+      return op->getParentRegion() == dotOp->getParentRegion();
+    };
+    auto slices = mlir::getSlice(dotOp, filter);
+    for (Operation *op : slices) {
+      if (isa<triton::DotOp>(op) && (op != dotOp))
+        return true;
+    }
+    return false;
+  }
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
@@ -209,97 +208,6 @@ public:
     return success();
   }
 };
-
-class ChainDotAMD : public mlir::RewritePattern {
-
-public:
-  ChainDotAMD(mlir::MLIRContext *context)
-      : mlir::RewritePattern(triton::DotOp::getOperationName(), 2, context) {}
-
-  bool hasView(triton::DotOp &dotOp) const {
-    // Check if we already optimized chain dot.
-    auto filter = [&dotOp](Operation *op) {
-      return op->getParentRegion() == dotOp->getParentRegion();
-    };
-    SetVector<Operation *> bwdSlices;
-    bwdSlices.clear();
-    mlir::getBackwardSlice(dotOp.getResult(), &bwdSlices, filter);
-
-    bool hasView = false;
-    for (Operation *op : bwdSlices) {
-      if (isa<mlir::triton::ViewOp>(op))
-        hasView = true;
-    }
-    return hasView;
-  }
-
-  mlir::LogicalResult
-  matchAndRewrite(mlir::Operation *op,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto dotOp = cast<triton::DotOp>(op);
-
-    auto oldRetType = dotOp.getResult().getType().cast<RankedTensorType>();
-    auto operandType = dotOp.getA().getType().cast<RankedTensorType>();
-    if (!isChainDot(dotOp) || hasView(dotOp) ||
-        operandType.getElementType().isF32()) {
-      return failure();
-    }
-
-    // get MFMA encoding for the given number of warps
-    auto retShape = oldRetType.getShape();
-    auto mod = op->getParentOfType<mlir::ModuleOp>();
-    int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
-
-    Value a = dotOp.getA();
-    Value b = dotOp.getB();
-    Value acc = dotOp.getOperand(2);
-    auto oldAType = a.getType().cast<RankedTensorType>();
-    auto oldBType = b.getType().cast<RankedTensorType>();
-    auto oldAccType = acc.getType().cast<RankedTensorType>();
-    auto ctx = oldAType.getContext();
-
-    auto mfmaEnc = oldRetType.cast<RankedTensorType>()
-                       .getEncoding()
-                       .cast<triton::gpu::MfmaEncodingAttr>();
-
-    auto warpsPerCTA = mfmaEnc.getWarpsPerCTA();
-    auto newMfmaEnc = triton::gpu::MfmaEncodingAttr::get(
-        oldRetType.getContext(), {warpsPerCTA[1], warpsPerCTA[0]},
-        /*isTransposed*/ true);
-
-    auto newRetType = RankedTensorType::get(
-        {retShape[1], retShape[0]}, oldRetType.getElementType(), newMfmaEnc);
-
-    assert(mfmaEnc);
-    auto newDotA = triton::gpu::DotOperandEncodingAttr::get(ctx, 1, newMfmaEnc);
-    auto newDotB = triton::gpu::DotOperandEncodingAttr::get(ctx, 0, newMfmaEnc);
-
-    auto newAType =
-        RankedTensorType::get({oldAType.getShape()[1], oldAType.getShape()[0]},
-                              oldAType.getElementType(), newDotA);
-    auto newBType =
-        RankedTensorType::get({oldBType.getShape()[1], oldBType.getShape()[0]},
-                              oldAType.getElementType(), newDotB);
-
-    auto newAccType = RankedTensorType::get(
-        {oldAccType.getShape()[1], oldAccType.getShape()[0]},
-        oldAccType.getElementType(), newMfmaEnc);
-
-    auto viewA = rewriter.create<mlir::triton::ViewOp>(a.getLoc(), newAType, a);
-    auto viewB = rewriter.create<mlir::triton::ViewOp>(b.getLoc(), newBType, b);
-    auto viewAcc =
-        rewriter.create<mlir::triton::ViewOp>(acc.getLoc(), newAccType, acc);
-
-    auto newDot =
-        rewriter.create<triton::DotOp>(dotOp.getLoc(), newRetType, viewB, viewA,
-                                       viewAcc, dotOp.getAllowTF32());
-
-    rewriter.replaceOpWithNewOp<mlir::triton::ViewOp>(op, oldRetType,
-                                                      newDot.getResult());
-    return success();
-  }
-};
-
 #endif
 
 class BlockedToMMA : public mlir::RewritePattern {
@@ -438,7 +346,6 @@ public:
     mlir::RewritePatternSet patterns(context);
 #ifdef USE_ROCM
     patterns.add<::BlockedToMFMA>(context);
-    patterns.add<::ChainDotAMD>(context);
 #else
     patterns.add<::BlockedToMMA>(context, computeCapability);
 #endif

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -53,6 +53,7 @@ public:
               srcEncoding.dyn_cast<triton::gpu::MfmaEncodingAttr>()) {
 
         if (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
+            srcMmaEncoding.getIsTransposed() &&
             dstDotOp.getParent() == srcMmaEncoding)
           return;
       }

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -49,12 +49,12 @@ public:
           return;
       }
 #ifdef USE_ROCM
-      if (auto srcMmaEncoding =
+      if (auto srcMfmaEncoding =
               srcEncoding.dyn_cast<triton::gpu::MfmaEncodingAttr>()) {
 
-        if (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
-            srcMmaEncoding.getIsTransposed() &&
-            dstDotOp.getParent() == srcMmaEncoding)
+        if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
+            srcMfmaEncoding.getIsTransposed() &&
+            dstDotOp.getParent() == srcMfmaEncoding)
           return;
       }
 #endif

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -48,6 +48,15 @@ public:
              dstDotOp.getParent() == srcMmaEncoding))
           return;
       }
+#ifdef USE_ROCM
+      if (auto srcMmaEncoding =
+              srcEncoding.dyn_cast<triton::gpu::MfmaEncodingAttr>()) {
+
+        if (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
+            dstDotOp.getParent() == srcMmaEncoding)
+          return;
+      }
+#endif
       auto tmpType = RankedTensorType::get(
           dstType.getShape(), dstType.getElementType(),
           triton::gpu::SharedEncodingAttr::get(

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -138,8 +138,7 @@ bool canFoldConversion(Operation *op, Attribute &targetEncoding) {
   if (isa<triton::CatOp>(op))
     return !isExpensiveCat(cast<triton::CatOp>(op), targetEncoding);
   return isa<triton::gpu::ConvertLayoutOp, arith::ConstantOp,
-             triton::MakeRangeOp, triton::SplatOp, triton::ViewOp,
-             triton::CatOp>(*op);
+             triton::MakeRangeOp, triton::SplatOp, triton::ViewOp>(op);
 }
 
 int simulateBackwardRematerialization(

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -82,7 +82,7 @@ LogicalResult invertEncoding(Attribute targetEncoding, Operation *op,
       return failure();
     ret = sliceEncoding.getParent();
   }
-  if (isa<triton::ViewOp, triton::CatOp>(op)) {
+  if (isa<triton::CatOp>(op)) {
     return failure();
   }
   return success();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -82,7 +82,7 @@ LogicalResult invertEncoding(Attribute targetEncoding, Operation *op,
       return failure();
     ret = sliceEncoding.getParent();
   }
-  if (isa<triton::CatOp>(op)) {
+  if (isa<triton::ViewOp, triton::CatOp>(op)) {
     return failure();
   }
   return success();
@@ -138,7 +138,8 @@ bool canFoldConversion(Operation *op, Attribute &targetEncoding) {
   if (isa<triton::CatOp>(op))
     return !isExpensiveCat(cast<triton::CatOp>(op), targetEncoding);
   return isa<triton::gpu::ConvertLayoutOp, arith::ConstantOp,
-             triton::MakeRangeOp, triton::SplatOp, triton::ViewOp>(op);
+             triton::MakeRangeOp, triton::SplatOp, triton::ViewOp,
+             triton::CatOp>(*op);
 }
 
 int simulateBackwardRematerialization(

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2128,12 +2128,12 @@ class MmaLayout:
 
 
 class MfmaLayout:
-    def __init__(self, non_k_dim, warps_per_cta):
-        self.non_k_dim = str(non_k_dim)
+    def __init__(self, non_k_dim, warps_per_cta, isTranspose):
         self.warps_per_cta = str(warps_per_cta)
+        self.isTranspose = str(isTranspose).lower()
 
     def __str__(self):
-        return f"#triton_gpu.mfma<{{nonKDim = {self.non_k_dim}, warpsPerCTA = {self.warps_per_cta}}}>"
+        return f"#triton_gpu.mfma<{{nonKDim = {self.non_k_dim}, warpsPerCTA = {self.warps_per_cta}, isTranspose = {self.isTranspose}}}>"
 
 
 class BlockedLayout:
@@ -2238,8 +2238,8 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
 
 if _get_warp_size() == 64:
     layouts = [
-        MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1]),
-        MfmaLayout(non_k_dim=32, warps_per_cta=[2, 2]),
+        MfmaLayout(nonKDim=32, warps_per_cta=[4, 1], isTranspose=True),
+        MfmaLayout(nonKDim=32, warps_per_cta=[2, 2], isTranspose=False),
     ]
     shapes = [[128, 32], [128, 128], [32, 128], [64, 64]]
 else:
@@ -2318,7 +2318,7 @@ def test_reduce_layouts(M, N, src_layout, axis, device='cuda'):
 
 @pytest.mark.parametrize("shape", [(64, 64)])
 @pytest.mark.parametrize("dtype", ['float16'])
-@pytest.mark.parametrize("src_layout", [MfmaLayout(non_k_dim=32, warps_per_cta=[2, 1]), MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1])])
+@pytest.mark.parametrize("src_layout", [MfmaLayout(non_k_dim=32, warps_per_cta=[2, 1], isTranspose=False), MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1], isTranspose = True)])
 @pytest.mark.parametrize("dst_layout", [BlockedLayout([1, 4], [4, 16], [1, 1], [1, 0])])
 def test_make_range(dtype, shape, src_layout, dst_layout, device='cuda'):
     ir = f"""

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2129,6 +2129,7 @@ class MmaLayout:
 
 class MfmaLayout:
     def __init__(self, non_k_dim, warps_per_cta, isTransposed):
+        self.non_k_dim = str(non_k_dim)
         self.warps_per_cta = str(warps_per_cta)
         self.isTransposed = str(isTransposed).lower()
 
@@ -2238,8 +2239,8 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
 
 if _get_warp_size() == 64:
     layouts = [
-        MfmaLayout(nonKDim=32, warps_per_cta=[4, 1], isTransposed=True),
-        MfmaLayout(nonKDim=32, warps_per_cta=[2, 2], isTransposed=False),
+        MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1], isTransposed=True),
+        MfmaLayout(non_k_dim=32, warps_per_cta=[2, 2], isTransposed=False),
     ]
     shapes = [[128, 32], [128, 128], [32, 128], [64, 64]]
 else:

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1202,7 +1202,7 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
 @pytest.mark.parametrize("M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype",
                          [(*shape, 2, False, False, epilogue, allow_tf32, dtype)
                           for shape in [(64, 64, 64), (32, 32, 32)]
-                          for epilogue in ['none', 'trans', 'add-matrix']
+                          for epilogue in ['none', 'trans', 'add-matrix', 'chain-dot', 'softmax']
                           for allow_tf32 in [True, False]
                           for dtype in ['float16', 'float32']
                           if not (allow_tf32 and (dtype in ['float16']))] +

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -14,7 +14,7 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype):
     capability = torch.cuda.get_device_capability()
     if torch.version.hip is not None:
         if dtype != torch.float16:
-            pytest.skip("Currentlu flash attention on AMD gpu is only supported in fp16.")
+            pytest.skip("Currently flash attention on AMD gpu is only supported in fp16.")
         if D_HEAD < 32:
             pytest.skip("D_HEAD < 32 is not supported. It will be enabled once smaller tile size is supported in MFMA pipeline.")
         if D_HEAD > 64:

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -12,6 +12,14 @@ import triton.ops
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
 def test_op(Z, H, N_CTX, D_HEAD, dtype):
     capability = torch.cuda.get_device_capability()
+    if torch.version.hip is not None:
+        if dtype != torch.float16:
+            pytest.skip("Currentlu flash attention on AMD gpu is only supported in fp16.")
+        if D_HEAD < 32:
+            pytest.skip("D_HEAD < 32 is not supported. It will be enabled once smaller tile size is supported in MFMA pipeline.")
+        if D_HEAD > 64:
+            pytest.skip("D_HEAD > 64 is not supported. Currently it causes shared memory out of resource error.")
+
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability < 80")
     torch.manual_seed(20)
@@ -29,21 +37,26 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype):
     p = torch.softmax(p.float(), dim=-1).to(dtype)
     # p = torch.exp(p)
     ref_out = torch.matmul(p, v)
-    ref_out.backward(dout)
-    ref_dv, v.grad = v.grad.clone(), None
-    ref_dk, k.grad = k.grad.clone(), None
-    ref_dq, q.grad = q.grad.clone(), None
+
+    if torch.version.hip is None:
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
+
     # # triton implementation
     tri_out = triton.ops.attention(q, k, v, sm_scale)
     # print(ref_out)
     # print(tri_out)
-    tri_out.backward(dout)
-    tri_dv, v.grad = v.grad.clone(), None
-    tri_dk, k.grad = k.grad.clone(), None
-    tri_dq, q.grad = q.grad.clone(), None
+    if torch.version.hip is None:
+        tri_out.backward(dout)
+        tri_dv, v.grad = v.grad.clone(), None
+        tri_dk, k.grad = k.grad.clone(), None
+        tri_dq, q.grad = q.grad.clone(), None
     # compare
     atol = 1e-1 if dtype == torch.bfloat16 else 1e-2
     torch.testing.assert_allclose(ref_out, tri_out, atol=atol, rtol=0)
-    torch.testing.assert_allclose(ref_dv, tri_dv, atol=atol, rtol=0)
-    torch.testing.assert_allclose(ref_dk, tri_dk, atol=atol, rtol=0)
-    torch.testing.assert_allclose(ref_dq, tri_dq, atol=atol, rtol=0)
+    if torch.version.hip is None:
+        torch.testing.assert_allclose(ref_dv, tri_dv, atol=atol, rtol=0)
+        torch.testing.assert_allclose(ref_dk, tri_dk, atol=atol, rtol=0)
+        torch.testing.assert_allclose(ref_dq, tri_dq, atol=atol, rtol=0)

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -202,7 +202,10 @@ class _attention(torch.autograd.Function):
         capability = torch.cuda.get_device_capability()
         if capability[0] < 8:
             raise RuntimeError("Flash attention currently only supported for compute capability >= 80")
-        BLOCK = 128
+        if torch.version.hip is not None:
+            BLOCK = 64
+        else:
+            BLOCK = 128
         # shape constraints
         Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
         assert Lq == Lk and Lk == Lv

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -369,4 +369,4 @@ def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, mode, provider, dtype=torch.f
 
 
 # only works on post-Ampere GPUs right now
-# bench_flash_attention.run(save_path='.', print_data=True)
+bench_flash_attention.run(save_path='.', print_data=True)

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -300,10 +300,11 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
     tri_out = attention(q, k, v, sm_scale)
     # print(ref_out)
     # print(tri_out)
-    tri_out.backward(dout)
-    tri_dv, v.grad = v.grad.clone(), None
-    tri_dk, k.grad = k.grad.clone(), None
-    tri_dq, q.grad = q.grad.clone(), None
+    if torch.version.hip is None:
+        tri_out.backward(dout)
+        tri_dv, v.grad = v.grad.clone(), None
+        tri_dk, k.grad = k.grad.clone(), None
+        tri_dq, q.grad = q.grad.clone(), None
     # compare
     assert torch.allclose(ref_out, tri_out, atol=1e-2, rtol=0)
     if torch.version.hip is None:
@@ -366,4 +367,4 @@ def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, mode, provider, dtype=torch.f
 
 
 # only works on post-Ampere GPUs right now
-bench_flash_attention.run(save_path='.', print_data=True)
+# bench_flash_attention.run(save_path='.', print_data=True)

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -292,10 +292,12 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
     p = torch.softmax(p.float(), dim=-1).half()
     # p = torch.exp(p)
     ref_out = torch.matmul(p, v)
-    ref_out.backward(dout)
-    ref_dv, v.grad = v.grad.clone(), None
-    ref_dk, k.grad = k.grad.clone(), None
-    ref_dq, q.grad = q.grad.clone(), None
+
+    if torch.version.hip is None:
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
     # # triton implementation
     tri_out = attention(q, k, v, sm_scale)
     # print(ref_out)

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1186,11 +1186,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0]}>
-<<<<<<< HEAD
 #mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
-=======
-#mfma0 = #triton_gpu.mfma<{warpsPerCTA=[1,1], isTransposed=false}>
->>>>>>> Move operand swapping in ttgir -> llir lowering phase
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
@@ -1213,11 +1209,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-<<<<<<< HEAD
 #mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
-=======
-#mfma = #triton_gpu.mfma<{warpsPerCTA = [2, 2], isTransposed=false}>
->>>>>>> Move operand swapping in ttgir -> llir lowering phase
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1186,7 +1186,11 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0]}>
+<<<<<<< HEAD
 #mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
+=======
+#mfma0 = #triton_gpu.mfma<{warpsPerCTA=[1,1], isTransposed=false}>
+>>>>>>> Move operand swapping in ttgir -> llir lowering phase
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
@@ -1209,7 +1213,11 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+<<<<<<< HEAD
 #mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
+=======
+#mfma = #triton_gpu.mfma<{warpsPerCTA = [2, 2], isTransposed=false}>
+>>>>>>> Move operand swapping in ttgir -> llir lowering phase
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block
@@ -1359,7 +1367,7 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma}>
 module attributes {"triton_gpu.num-warps" = 4 : i32} {

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1186,7 +1186,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0]}>
-#mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [1, 1]}>
+#mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
@@ -1209,7 +1209,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2]}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block
@@ -1359,7 +1359,7 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2]}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma}>
 module attributes {"triton_gpu.num-warps" = 4 : i32} {


### PR DESCRIPTION
This PR optimizes flash attention algorithm on AMD MI100/200 GPUs by keeping results of dot operations in registers instead of going trough LDS memory.
Currently, this optimizations will happen only if:
- Dot A and B operands have fp16 type. Parameters related to type are hard coded.
- WarpsPerCTA[1] in MFMA layout is 1.

In addition to eliminating the constraints mentioned above, this optimization should be generalized to function with any arbitrary chain dot operation. This PR addresses the specific case where the result of the first dot operation is used as operand A (opIdx == 0) in the subsequent dot - a scenario found in FA.

Issue:
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4788