### PR TITLE
revert PR#245 and #241 for gemm performance regression

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -80,41 +80,11 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
                      "Type":$eltTy), [{
 
 #ifdef USE_ROCM
-        // ---- begin GFX908/GFX90A ----
+        // ---- begin MI200 ----
         auto mfmaEnc = dotOpEnc.getParent().dyn_cast<MfmaEncodingAttr>();
-
         if (mfmaEnc) {
-          int opIdx = dotOpEnc.getOpIdx();
-
-          // number of rows per phase
-          int perPhase = 128 / (shape[order[0]] * (eltTy.getIntOrFloatBitWidth() / 8));
-          perPhase = std::max<int>(perPhase, 1);
-
-          // index of the inner dimension in `order`
-          unsigned inner = (opIdx == 0) ? 0 : 1;
-          // for now, disable swizzle when using transposed int8 tensor cores
-          if (eltTy.isInteger(8) && order[0] == inner)
-            return $_get(context, 1, 1, 1, order);
-
-          // --- handle A operand ---
-          if (opIdx == 0) { // compute swizzling for A operand
-              // This is just an example of swizzle pattern, not a production ready
-              unsigned vec = 8;
-              unsigned maxPhase = 2;
-              unsigned perPhase = 1;
-              return $_get(context, vec, perPhase, maxPhase, order);
-          }
-
-          // --- handle B operand ---
-          if (opIdx == 1) {
-              // This is an example of swizzle pattern, not a production ready
-              unsigned vec = 2;
-              unsigned maxPhase = 2;
-              unsigned perPhase = 1;
-              return $_get(context, vec, perPhase, maxPhase, order);
-          }
-
-          llvm_unreachable("invalid operand index");
+          // Swizzling is currently disabled for MFMA
+          return $_get(context, 1, 1, 1, order);
         }
 #endif
         auto mmaEnc = dotOpEnc.getParent().dyn_cast<MmaEncodingAttr>();

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -35,49 +35,6 @@ Value getWaveN(ConversionPatternRewriter &rewriter, Location loc, Value wave,
 namespace SharedToDotOperandMFMA {
 
 /**
- * @brief swizzling tensor element indexes according pattern encoded in
- * SharedEncodingAttr
- *
- * @param rewriter
- * @param loc
- * @param row row of target tensor element related to the start of smemObj
- * @param col col of target tensor element related to the start of smemObj
- * @param smemObj shared memory object, contains info about tensor in LDS
- * @param attr layout attribute, contains swizzling info
- * @return swizzled row, col indexes in tensor notation
- */
-std::pair<mlir::Value, mlir::Value>
-swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
-               Value col, SharedMemoryObject smemObj, SharedEncodingAttr attr) {
-  (void)smemObj; // unused in current pattern
-  bool transposed = (attr.getOrder()[0] != 1);
-  if (transposed) {
-    // tensor is column-wise, so swapping col and row in computations
-    std::swap(row, col);
-  }
-  auto vec = i32_val(attr.getVec());
-  auto perPhase = i32_val(attr.getPerPhase());
-  auto maxPhase = i32_val(attr.getMaxPhase());
-
-  // Original algorithm taken from getSwizzledSharedPtrs function
-  // (TritonGPUToLLVMBase.h): Basic algorithm for row-major tensor is following:
-  //
-  // phase = (row // perPhase) % maxPhase
-  // colOffSwizzled = ((col // vec) ^ phase) * vec
-  // colOffOrdered = col % vec
-  // colOff = colOffSwizzled + colOffOrdered
-  auto phase = urem(udiv(row, perPhase), maxPhase);
-  auto colOffSwizzled = mul(xor_(udiv(col, vec), phase), vec);
-  auto colOffOrdered = urem(col, vec);
-  auto colOff = add(colOffSwizzled, colOffOrdered);
-
-  if (transposed)
-    return {colOff, row};
-  else
-    return {row, colOff};
-}
-
-/**
  * @brief This function maps particular load of mfma dot operand to element
  * indexes(row, col)
  *
@@ -156,11 +113,9 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
 Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
                     Value row, Value col, SharedMemoryObject smemObj,
                     SharedEncodingAttr srcLayout) {
-  auto [swizzledRow, swizzledCol] =
-      swizzleIndexes(rewriter, loc, row, col, smemObj, srcLayout);
   auto &strides = smemObj.strides;
-  Value rowOffset = mul(swizzledRow, strides[0]);
-  Value colOffset = mul(swizzledCol, strides[1]);
+  Value rowOffset = mul(row, strides[0]);
+  Value colOffset = mul(col, strides[1]);
   return add(rowOffset, colOffset);
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -175,7 +175,7 @@ Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
                           warpsPerGroupM, numOfElems, numReps, cSwizzleOffset);
   }
 
-  Value smemBase = smemObj.getBaseBeforeSwizzle(order[0], loc, rewriter);
+  Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
 
   Type smemPtrTy = getShemPtrTy(aElemTy);
 
@@ -233,8 +233,6 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
   Value wave = udiv(thread, waveSize);
   Value lane = urem(thread, waveSize);
 
-  Value waveN =
-      getWaveN(rewriter, loc, wave, warpsPerCTA, mfmaInstrN, shape[1]);
   Value waveN = getWaveN(rewriter, loc, wave, warpsPerCTA,
                          mfmaInstrN, shape[1]);
   int numOfElems = std::max<int>(mfmaInstrK * mfmaInstrN / 64 /*wave size*/, 1);
@@ -263,7 +261,7 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
                           warpsPerGroupN, numOfElems, numReps, cSwizzleOffset);
   }
 
-  Value smemBase = smemObj.getBaseBeforeSwizzle(order[0], loc, rewriter);
+  Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
 
   Type smemPtrTy = getShemPtrTy(bElemTy);
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -34,145 +34,97 @@ Value getWaveN(ConversionPatternRewriter &rewriter, Location loc, Value wave,
 
 namespace SharedToDotOperandMFMA {
 
-/**
- * @brief This function maps particular load of mfma dot operand to element
- * indexes(row, col)
- *
- * Whole tensor is broken into "blocks" of waves along "non-K" axis.
- * One block could be processed by multiple waves.
- * One wave works on a piece of tensor size elemsPerInstr[0] x K.
- * Each of these pieces is broken into "tiles" of size elemsPerInstr[0] x
- * elemsPerInstr[1].
- *
- * Total offset of element is a sum of following values:
- * 1. Offset of wave block in tensor
- * 2. Offset of wave inside one wave block
- * 3. Offset of tile in one wave
- * 4. Offset of one lane data in a tile
- * 5. Offset of particular element of tensor processed by one lane
- *
- * This function computes these offsets for axies independently
- *
- * @param rewriter
- * @param loc
- * @param elemsPerInstr operand tile shape consumed by one MFMA instruction
- * @param waveId id component of 2d wave grid along nono-K axis
- * @param laneId lane id in warp [0..63]
- * @param warpsPerGroup number of warps in one block
- * @param numOfElems number of elements accessed by thread per repetition
- * @param reps number of instructions repretition to fully cover dot operand
- * @param smemStrides strides in LDS tensor
- * @return vector (i-th element corresponds to i-th load instruction) of
- * 2-element vectors(tensor row and col).
- */
-llvm::SmallVector<llvm::SmallVector<Value>>
-computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
-                         const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                         Value laneId, int warpsPerGroup, int numOfElems,
-                         ArrayRef<int64_t> reps, ArrayRef<Value> smemOffsets) {
+// Computes offsets for operand A or transposed operand B
+// @param rewriter
+// @param loc
+// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
+// @param waveM wave id for the "non K" axis
+// @param laneId lane id in warp [0..63]
+// @param warpsPerGroup number of warps in one block
+// @param numOfElems number of elements accessed by thread per repetition
+// @param reps number of instructions repretition to fully cover dot operand
+// @param cSwizzleOffset
+llvm::SmallVector<Value>
+computeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
+                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                  Value laneId, int warpsPerGroup, int numOfElems,
+                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
   auto numM = reps[0];
   auto numK = reps[1];
-  SmallVector<llvm::SmallVector<Value>> mapping(numM * numK * numOfElems);
-
+  SmallVector<Value> offsets(numM * numK * numOfElems);
+  int lineSize = elemsPerInstr[1] * numK;
+  int blockSize = elemsPerInstr[0] * warpsPerGroup * lineSize;
   Value _0 = i32_val(0);
   Value _32 = i32_val(32);
+  Value waveHalf = udiv(laneId, _32);
+
+  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[0] * lineSize));
+  Value colOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
 
   for (int block = 0; block < numM; ++block) {
-    Value blockVOffset = i32_val(block * elemsPerInstr[0] * warpsPerGroup);
-    Value blockHOffset = _0;
-    Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
-    Value waveHOffset = _0;
+    Value blockOffset = i32_val(block * blockSize);
     for (int tile = 0; tile < numK; ++tile) {
-      Value tileVOffset = _0;
-      Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
-
-      Value laneVOffset = urem(laneId, _32);
-      Value laneHOffset = mul(udiv(laneId, _32), i32_val(numOfElems));
+      Value tileOffset = i32_val(tile * elemsPerInstr[1]);
       for (int elem = 0; elem < numOfElems; ++elem) {
-        Value elemVOffset = _0;
-        Value elemHOffset = i32_val(elem);
-
-        Value sliceVOffset = add(
-            add(add(add(blockVOffset, waveVOffset), tileVOffset), laneVOffset),
-            elemVOffset);
-        Value sliceHOffset = add(
-            add(add(add(blockHOffset, waveHOffset), tileHOffset), laneHOffset),
-            elemHOffset);
-
-        Value row = add(sliceVOffset, smemOffsets[0]);
-        Value col = add(sliceHOffset, smemOffsets[1]);
-
-        mapping[numK * numOfElems * block + numOfElems * tile + elem] = {row,
-                                                                         col};
+        Value rowOffset =
+            add(mul(urem(laneId, _32), i32_val(lineSize)), i32_val(elem));
+        Value elemOffset = add(rowOffset, colOffset);
+        Value offset =
+            add(add(add(waveOffset, blockOffset), tileOffset), elemOffset);
+        offsets[numK * numOfElems * block + numOfElems * tile + elem] = offset;
       }
     }
   }
-  return mapping;
+  return offsets;
 }
 
-Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
-                    Value row, Value col, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout) {
-  auto &strides = smemObj.strides;
-  Value rowOffset = mul(row, strides[0]);
-  Value colOffset = mul(col, strides[1]);
-  return add(rowOffset, colOffset);
-}
-
+// Computes offsets for operand B or transposed operand A
+// @param rewriter
+// @param loc
+// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
+// @param waveId wave id for the "non K" axis
+// @param laneId lane id in warp [0..63]
+// @param warpsPerGroup number of warps per horizontal axis
+// @param numOfElems number of elements accessed by threads per repetition
+// @param reps number of instructions repretition to fully cover dot operand
+// @param cSwizzleOffset
 llvm::SmallVector<Value>
-computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
-                    const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                    Value laneId, int warpsPerGroup, int numOfElems,
-                    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout) {
-  SmallVector<Value> strides{smemObj.strides[0], smemObj.strides[1]};
-  SmallVector<Value> offsets{smemObj.offsets[0], smemObj.offsets[1]};
-  auto mapping =
-      computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId, laneId,
-                               warpsPerGroup, numOfElems, reps, offsets);
-  llvm::SmallVector<Value> aOffsets(mapping.size());
-  for (int i = 0; i < mapping.size(); ++i) {
-    Value row = mapping[i][0];
-    Value col = mapping[i][1];
-    aOffsets[i] = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
+computeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
+                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                  Value laneId, int warpsPerGroup, int numOfElems,
+                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
+  auto numK = reps[0];
+  auto numN = reps[1];
+  SmallVector<Value> offsets(numK * numN * numOfElems);
+
+  int lineSize = warpsPerGroup * elemsPerInstr[1] * numN;
+  Value _0 = i32_val(0);
+  Value _32 = i32_val(32);
+  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[1]));
+  Value colOffset = urem(laneId, _32);
+
+  for (int block = 0; block < numN; ++block) {
+    Value blockOffset = i32_val(block * elemsPerInstr[1] * warpsPerGroup);
+    for (int tile = 0; tile < numK; ++tile) {
+      Value tileOffset = i32_val(tile * elemsPerInstr[0] * lineSize);
+      for (int elem = 0; elem < numOfElems; ++elem) {
+        Value halfOffset =
+            select(icmp_uge(laneId, _32), i32_val(numOfElems * lineSize), _0);
+        Value rowOffset = add(i32_val(elem * lineSize), halfOffset);
+        Value elemOffset = add(rowOffset, colOffset);
+        Value offset =
+            add(add(add(waveOffset, blockOffset), tileOffset), elemOffset);
+        offsets[numK * numOfElems * block + numOfElems * tile + elem] = offset;
+      }
+    }
   }
-  return aOffsets;
+  return offsets;
 }
 
-llvm::SmallVector<Value>
-computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
-                    const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                    Value laneId, int warpsPerGroup, int numOfElems,
-                    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout) {
-  // transpose reps and offsets, because operand B has layout equal to
-  // transposed operand A layout
-  SmallVector<int64_t> tElemsPerInstr{elemsPerInstr[1], elemsPerInstr[0]};
-  SmallVector<int64_t> tReps{reps[1], reps[0]};
-  SmallVector<Value> toffsets{smemObj.offsets[1], smemObj.offsets[0]};
-  auto mapping =
-      computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId, laneId,
-                               warpsPerGroup, numOfElems, tReps, toffsets);
-  llvm::SmallVector<Value> bOffsets(mapping.size());
-  for (int i = 0; i < mapping.size(); ++i) {
-    // swap row and col, because operand B layout is a transposed operand A
-    // layout
-    Value row = mapping[i][1];
-    Value col = mapping[i][0];
-    bOffsets[i] = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
-  }
-  return bOffsets;
-}
-
-Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
-                     const SharedMemoryObject &smemObj) {
-  Value base = smemObj.base;
-  Type type = base.getType();
-  for (int i = 0; i < smemObj.strides.size(); ++i) {
-    Value offset = sub(i32_val(0), mul(smemObj.offsets[i], smemObj.strides[i]));
-    base = gep(type, base, offset);
-  }
-  return base;
+bool isTransposed(::llvm::ArrayRef<unsigned> order) {
+  assert(order.size() == 2 && (order[0] & ~1ul) == 0 &&
+         order[0] + order[1] == 1);
+  return order[0] == 0;
 }
 
 Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
@@ -207,13 +159,23 @@ Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
       getWaveM(rewriter, loc, wave, warpsPerCTA, mfmaInstrM, shape[0]);
   int numOfElems =
       std::max<int>(mfmaInstrM * mfmaInstrK / iWaveSize /*wave size*/, 1);
+  Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
   unsigned int maxNumWarps = shape[0] / mfmaInstrM;
   int warpsPerGroupM = std::min(warpsPerCTA[0], maxNumWarps);
-  SmallVector<Value> offsets = computeOffsetsAType(
-      rewriter, loc, aElemsPerInstr, waveM, lane, warpsPerGroupM, numOfElems,
-      numReps, smemObj, sharedLayout);
+  SmallVector<Value> offsets;
+  if (isTransposed(order)) {
+    SmallVector<int64_t> elemsPerInstr{mfmaInstrK, mfmaInstrM};
+    SmallVector<int64_t> reps{numReps[1], numReps[0]};
+    offsets =
+        computeOffsetsTy2(rewriter, loc, elemsPerInstr, waveM, lane,
+                          warpsPerGroupM, numOfElems, reps, cSwizzleOffset);
+  } else {
+    offsets =
+        computeOffsetsTy1(rewriter, loc, aElemsPerInstr, waveM, lane,
+                          warpsPerGroupM, numOfElems, numReps, cSwizzleOffset);
+  }
 
-  Value smemBase = computeBasePtr(rewriter, loc, smemObj);
+  Value smemBase = smemObj.getBaseBeforeSwizzle(order[0], loc, rewriter);
 
   Type smemPtrTy = getShemPtrTy(aElemTy);
 
@@ -273,22 +235,35 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
 
   Value waveN =
       getWaveN(rewriter, loc, wave, warpsPerCTA, mfmaInstrN, shape[1]);
-  int numOfElems =
-      std::max<int>(mfmaInstrK * mfmaInstrN / iWaveSize /*wave size*/, 1);
+  Value waveN = getWaveN(rewriter, loc, wave, warpsPerCTA,
+                         mfmaInstrN, shape[1]);
+  int numOfElems = std::max<int>(mfmaInstrK * mfmaInstrN / 64 /*wave size*/, 1);
+  Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
 
-  int macroTileM = std::max<int>(shape[0] / (warpsPerCTA[0] * 32), 1);
+  int macroTileM =
+      std::max<int>(shape[0] / (warpsPerCTA[0] * 32), 1);
   int wptM = std::min<int>(warpsPerCTA[0], macroTileM);
-  int macroTileN = std::max<int>(shape[1] / (warpsPerCTA[1] * 32), 1);
+  int macroTileN =
+      std::max<int>(shape[1] / (warpsPerCTA[1] * 32), 1);
   int wptN = std::min<int>(warpsPerCTA[1], macroTileN);
   int wpt = std::max<int>(wptM, wptN);
 
+  llvm::SmallVector<Value> offsets;
   unsigned int maxNumWarps = shape[1] / mfmaInstrN;
   int warpsPerGroupN = std::min(warpsPerCTA[1], maxNumWarps);
-  llvm::SmallVector<Value> offsets = computeOffsetsBType(
-      rewriter, loc, bElemsPerInstr, waveN, lane, warpsPerGroupN, numOfElems,
-      numReps, smemObj, sharedLayout);
+  if (isTransposed(order)) {
+    SmallVector<int64_t> elemsPerInstr{mfmaInstrN, mfmaInstrK};
+    SmallVector<int64_t> reps{numReps[1], numReps[0]};
+    offsets =
+        computeOffsetsTy1(rewriter, loc, elemsPerInstr, waveN, lane,
+                          warpsPerGroupN, numOfElems, reps, cSwizzleOffset);
+  } else {
+    offsets =
+        computeOffsetsTy2(rewriter, loc, bElemsPerInstr, waveN, lane,
+                          warpsPerGroupN, numOfElems, numReps, cSwizzleOffset);
+  }
 
-  Value smemBase = computeBasePtr(rewriter, loc, smemObj);
+  Value smemBase = smemObj.getBaseBeforeSwizzle(order[0], loc, rewriter);
 
   Type smemPtrTy = getShemPtrTy(bElemTy);
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -85,7 +85,9 @@ def optimize_ttgir(mod, num_stages, arch):
         pm.add_tritongpu_accelerate_matmul_pass(80)
     pm.add_tritongpu_remove_layout_conversions_pass()
     pm.add_tritongpu_optimize_dot_operands_pass()
-    pm.add_tritongpu_pipeline_pass(num_stages)
+    # TODO enable this pass for AMD GPU when it is ready
+    if not is_hip():
+        pm.add_tritongpu_pipeline_pass(num_stages)
     pm.add_tritongpu_prefetch_pass()
     pm.add_tritongpu_optimize_dot_operands_pass()
     pm.add_tritongpu_remove_layout_conversions_pass()


### PR DESCRIPTION
PR#241 caused performance regression for GEMM performance, and PR#245 depends on PR#241, so we have to revert both to avoid the GEMM performance regression. 

After reverting these two PRs, the best performance we can get for GEMM is (Unit: TFLOPS, larger is better.):

```
         M      cuBLAS     Triton
0    256.0    2.036070   1.466540
1    384.0    5.573140   3.976341
2    512.0   11.570494   8.224126
3    640.0   23.918249  12.900787
4    768.0   34.110305  19.391473
5    896.0   49.677011  25.328279
6   1024.0   59.918627  31.880696
7   1152.0   50.825260  34.094899
8   1280.0   68.985262  42.555845
9   1408.0   84.278666  42.446917
10  1536.0   58.149528  51.888298
11  1664.0   80.549702  42.535283
12  1792.0   90.938448  49.404061
13  1920.0  102.045671  51.229645
14  2048.0  115.828971  55.490534
15  2176.0   75.360647  56.093793
16  2304.0   84.232423  50.623200
17  2432.0  106.582439  56.215227
18  2560.0   99.156121  58.254122
19  2688.0  108.914707  57.816471
20  2816.0  109.484449  55.537322
21  2944.0  118.042138  58.213223
22  3072.0  114.425998  57.357950
23  3200.0  111.455590  56.873042
24  3328.0  105.675142  60.552494
25  3456.0  113.927424  58.105592
26  3584.0  121.430369  58.422145
27  3712.0  109.664204  60.066013
28  3840.0  114.325324  60.801311
29  3968.0  122.348805  61.021442
30  4096.0  129.113578  62.631608
```