### PR TITLE
workaround for num_programs() to get correct value

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -474,7 +474,7 @@ struct GetNumProgramsOpConversion
     Value threadsPerGrid =
         rewriter.create<::mlir::gpu::GridDimOp>(loc, dims[op.getAxis()]);
     Value threadsPerBlock =
-        rewriter.create<::mlir::gpu::BlockDimOp>(loc, bdims[op.getAxis()]);
+        rewriter.create<::mlir::gpu::BlockDimOp>(loc, dims[op.getAxis()]);
     Value threadNumPerGrid = rewriter.create<arith::TruncIOp>(loc, i32_ty, threadsPerGrid);
     Value threadNumPerBlock = rewriter.create<arith::TruncIOp>(loc, i32_ty, threadsPerBlock);    
     rewriter.replaceOpWithNewOp<LLVM::UDivOp>(op, threadNumPerGrid, threadNumPerBlock);
@@ -490,11 +490,6 @@ struct GetNumProgramsOpConversion
   static constexpr mlir::gpu::Dimension dims[] = {mlir::gpu::Dimension::x,
                                                   mlir::gpu::Dimension::y,
                                                   mlir::gpu::Dimension::z};
-#ifdef USE_ROCM
-  static constexpr mlir::gpu::Dimension bdims[] = {mlir::gpu::Dimension::x,
-                                                  mlir::gpu::Dimension::y,
-                                                  mlir::gpu::Dimension::z};
-#endif
 };
 
 struct AddPtrOpConversion

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -464,9 +464,25 @@ struct GetNumProgramsOpConversion
     Location loc = op->getLoc();
     assert(op.getAxis() < 3);
 
+#ifdef USE_ROCM
+    // Seem like GridDimOp returns the number of threads (not the number of 
+    // workgroups) in a kernel (a bug in llvm https://reviews.llvm.org/D156009), 
+    // so as a workaround here, we divide by the number of threads 
+    // per workgroup to get the number of workgroups in a kernel.
+    // TODO: when we do upstream to include llvm fix, we can remove this workaround
+    // The unit test added in this PR can guarantee that.
+    Value threadsPerGrid =
+        rewriter.create<::mlir::gpu::GridDimOp>(loc, dims[op.getAxis()]);
+    Value threadsPerBlock =
+        rewriter.create<::mlir::gpu::BlockDimOp>(loc, bdims[op.getAxis()]);
+    Value threadNumPerGrid = rewriter.create<arith::TruncIOp>(loc, i32_ty, threadsPerGrid);
+    Value threadNumPerBlock = rewriter.create<arith::TruncIOp>(loc, i32_ty, threadsPerBlock);    
+    rewriter.replaceOpWithNewOp<LLVM::UDivOp>(op, threadNumPerGrid, threadNumPerBlock);
+#else
     Value blockId =
         rewriter.create<::mlir::gpu::GridDimOp>(loc, dims[op.getAxis()]);
     rewriter.replaceOpWithNewOp<arith::TruncIOp>(op, i32_ty, blockId);
+#endif // USE_ROCM
 
     return success();
   }
@@ -474,6 +490,11 @@ struct GetNumProgramsOpConversion
   static constexpr mlir::gpu::Dimension dims[] = {mlir::gpu::Dimension::x,
                                                   mlir::gpu::Dimension::y,
                                                   mlir::gpu::Dimension::z};
+#ifdef USE_ROCM
+  static constexpr mlir::gpu::Dimension bdims[] = {mlir::gpu::Dimension::x,
+                                                  mlir::gpu::Dimension::y,
+                                                  mlir::gpu::Dimension::z};
+#endif
 };
 
 struct AddPtrOpConversion


### PR DESCRIPTION
This PR is a workaround for the function `tl.num_programs()` to return correct value. Reason for this problem is that mlir::gpu gridDimOp has a bug for gridDim to return the number of threads in a kernel (it should return the number of workgroups in the kernel), please see https://reviews.llvm.org/D156009.

So the workaround is to use grimDimOp/blockDimOp as the return value of `tl.num_programs()`. When llvm fix is available and integrated to triton, we should remove this workaround. A unit test is added to ensure that the workaround will be removed when we do upstream.

For issue:
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/5016
https://github.com/ROCmSoftwarePlatform/triton/issues/259
