### PR TITLE
Favor dim 1 (N) when setting warpsPerCTA for non-FA mfma

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -89,15 +89,6 @@ SmallVector<unsigned, 2> warpsPerTileMI200(triton::DotOp dotOp,
   SmallVector<unsigned, 2> ret = {1, 1};
   SmallVector<int64_t, 2> shapePerWarp = {32, 32};
   bool changed = false;
-  // TODO (@daadaada): double-check.
-  // original logic in
-  // https://github.com/openai/triton/blob/master/lib/codegen/analysis/layout.cc#L252
-  // seems buggy for shape = [32, 16] ?
-
-  // TODO(@B1tway): the comment above is also true for AMDGPU for shape =
-  // [64,32], as a temporary solution the dims have been swapped
-  if (shape[0] == 2 * shape[1])
-    tensorShape = {shape[1], shape[0]};
 
   do {
     changed = false;

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -103,8 +103,8 @@ SmallVector<unsigned, 2> warpsPerTileMI200(triton::DotOp dotOp,
     changed = false;
     if (ret[0] * ret[1] >= numWarps)
       break;
-    if (tensorShape[0] / shapePerWarp[0] / ret[0] >=
-        tensorShape[1] / (shapePerWarp[1]) / ret[1]) {
+    if (tensorShape[0] / (shapePerWarp[0] *2 )  / ret[0] >=
+        tensorShape[1] / shapePerWarp[1] / ret[1]) {
       if (ret[0] < tensorShape[0] / shapePerWarp[0]) {
         ret[0] *= 2;
       } else

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -104,7 +104,7 @@ SmallVector<unsigned, 2> warpsPerTileMI200(triton::DotOp dotOp,
     if (ret[0] * ret[1] >= numWarps)
       break;
     if (tensorShape[0] / shapePerWarp[0] / ret[0] >=
-        tensorShape[1] / (shapePerWarp[1] * 2) / ret[1]) {
+        tensorShape[1] / (shapePerWarp[1]) / ret[1]) {
       if (ret[0] < tensorShape[0] / shapePerWarp[0]) {
         ret[0] *= 2;
       } else


### PR DESCRIPTION
Fix https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4790

Surprisingly, it reduces LDS usage for `convert_layout #mfma -> #blocked`  because `getScratchConfigForCvtLayout()` uses srcShapePerCTA and dstShapePerCTA to determine the amount of LDS to allocate.

For example: test_dot[128-128-32-4-float32]
Without this PR:
- srcShapePerCTA: 128 x 32 --> dim 0 always gets more
- dstShapePerCTA: 8 x 128
- smemShape: 128 x 132 (with some padding) --> 67584 bytes

After this PR:
- srcShapePerCTA: 64 x 64 --> **more squared layout**
- dstShapePerCTA: 8 x 128
- smemShape: 64 x 132 (with some padding) --> 33792 bytes

For example: test_dot[128-256-32-4-float32]
Without this PR:
- srcShapePerCTA: 64 x 64 --> **now square does not work**
- dstShapePerCTA: 4 x 256
- smemShape: 64 x 260 (with some padding) --> 66560 bytes

After this PR:
- srcShapePerCTA: 32 x 128 --> **goes to dim 1 first**
- dstShapePerCTA: 4 x 256
- smemShape: 32 x 260 (with some padding) --> 33280 bytes
