### PR TITLE
[MFMA] [Dot] Support vector loads in normal path

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -77,62 +77,6 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
     return {row, colOff};
 }
 
-// Position of element in dot operand
-// nonKDim is M for A op and N for B op
-struct ElementOffsetSpatial {
-  Value nonKDim;
-  Value kDim;
-};
-
-using ElementOffsetLinear = Value;
-
-// Helper structure to store offsets for loads
-// map load operation to elements of matrix or memory offsets that it should process
-template <class Offset>
-class LoadOffsetMap {
-  std::vector<Offset> offsets;
-  int vectorSize; // number of elements which one load should process
-  int numBlocks;
-  int numKTiles;
-  int loadsPerThread;
-
-public:
-  LoadOffsetMap(int numBlocks, int numKTiles, int numElemsPerThread, int vectorSize):
-      numBlocks(numBlocks),
-      numKTiles(numKTiles),
-      loadsPerThread(numElemsPerThread/vectorSize),
-      vectorSize(vectorSize),
-      offsets(numBlocks * numKTiles * numElemsPerThread / vectorSize) {
-    assert(numElemsPerThread % vectorSize == 0);
-  }
-
-  int getNumBlocks() {
-    return numBlocks;
-  }
-
-  int getNumKTiles() {
-    return numKTiles;
-  }
-
-  int getNumLoadsPerThread() {
-    return loadsPerThread;
-  }
-
-  int getNumElemPerLoad() {
-    return vectorSize;
-  }
-
-  Offset &offset(int block, int kTile, int loadId) {
-    assert(block < numBlocks);
-    assert(kTile < numKTiles);
-    assert(loadId < loadsPerThread);
-    return offsets[numKTiles * loadsPerThread * block + loadsPerThread * kTile + loadId];
-  }
-};
-
-using LoadOffsetMapSpatial = LoadOffsetMap<ElementOffsetSpatial>;
-using LoadOffsetMapLinear = LoadOffsetMap<ElementOffsetLinear>;
-
 /**
  * @brief This function maps particular load of mfma dot operand to element
  * indexes(row, col)
@@ -159,37 +103,41 @@ using LoadOffsetMapLinear = LoadOffsetMap<ElementOffsetLinear>;
  * @param laneId lane id in warp [0..63]
  * @param warpsPerGroup number of warps in one block
  * @param numOfElems number of elements accessed by thread per repetition
- * @param reps number of instructions repretition to fully cover dot operand (nonK, K dim repetitions)
+ * @param reps number of instructions repretition to fully cover dot operand
  * @param smemStrides strides in LDS tensor
- * @return mapping from loads to row and col of operand element it processes
+ * @param loadVecSize number of elements loaded by one operation
+ * @return vector (i-th element corresponds to i-th load instruction) of
+ * 2-element vectors(tensor row and col).
  */
-LoadOffsetMapSpatial
+llvm::SmallVector<llvm::SmallVector<Value>>
 computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                          Value laneId, int warpsPerGroup, int numOfElems,
                          ArrayRef<int64_t> reps, ArrayRef<Value> smemOffsets,
                          int loadVecSize) {
-  auto numBlocks = reps[0];
-  auto kTiles = reps[1];
-  LoadOffsetMapSpatial mapping(numBlocks, kTiles, numOfElems, loadVecSize);
+  auto numM = reps[0];
+  auto numK = reps[1];
+  const int loadsPerThread = numOfElems / loadVecSize;
+  llvm::SmallVector<llvm::SmallVector<Value>> mapping(numM * numK *
+                                                      loadsPerThread);
 
   Value _0 = i32_val(0);
   Value _32 = i32_val(32);
 
-  for (int block = 0; block < numBlocks; ++block) {
+  for (int block = 0; block < numM; ++block) {
     Value blockVOffset = i32_val(block * elemsPerInstr[0] * warpsPerGroup);
     Value blockHOffset = _0;
     Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
     Value waveHOffset = _0;
-    for (int tile = 0; tile < kTiles; ++tile) {
+    for (int tile = 0; tile < numK; ++tile) {
       Value tileVOffset = _0;
       Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
 
       Value laneVOffset = urem(laneId, _32);
       Value laneHOffset = mul(udiv(laneId, _32), i32_val(numOfElems));
-      for (int elem = 0; elem < numOfElems/loadVecSize; ++elem) {
+      for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
         Value elemVOffset = _0;
-        Value elemHOffset = i32_val(elem*loadVecSize);
+        Value elemHOffset = i32_val(loadId * loadVecSize);
 
         Value sliceVOffset = add(
             add(add(add(blockVOffset, waveVOffset), tileVOffset), laneVOffset),
@@ -201,16 +149,15 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
         Value row = add(sliceVOffset, smemOffsets[0]);
         Value col = add(sliceHOffset, smemOffsets[1]);
 
-        mapping.offset(block, tile, elem) = {row, col};
+        mapping[numK * loadsPerThread * block + loadsPerThread * tile +
+                loadId] = {row, col};
       }
     }
   }
   return mapping;
 }
 
-bool isSwizzled(SharedEncodingAttr layout) {
-  return layout.getMaxPhase() != 1;
-}
+bool isSwizzled(SharedEncodingAttr layout) { return layout.getMaxPhase() != 1; }
 
 Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
                     Value row, Value col, SharedMemoryObject smemObj,
@@ -223,7 +170,7 @@ Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
   return add(rowOffset, colOffset);
 }
 
-LoadOffsetMapLinear
+llvm::SmallVector<Value>
 computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
@@ -240,22 +187,19 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping =
-      computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId, laneId,
-                               warpsPerGroup, numOfElems, reps, offsets, vectorSize);
-  LoadOffsetMapLinear aOffsets(reps[0], reps[1], numOfElems, vectorSize);
-  for (int block = 0; block < reps[0]; ++block)
-    for (int tile = 0; tile < reps[1]; ++tile)
-      for (int loadId = 0; loadId < numOfElems/vectorSize; ++loadId){
-        auto spatialOffset = mapping.offset(block, tile, loadId);
-        Value row = spatialOffset.nonKDim;
-        Value col = spatialOffset.kDim;
-        aOffsets.offset(block, tile, loadId) = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
-      }
+  auto mapping = computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId,
+                                          laneId, warpsPerGroup, numOfElems,
+                                          reps, offsets, vectorSize);
+  llvm::SmallVector<Value> aOffsets(mapping.size());
+  for (int i = 0; i < mapping.size(); ++i) {
+    Value row = mapping[i][0];
+    Value col = mapping[i][1];
+    aOffsets[i] = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
+  }
   return aOffsets;
 }
 
-LoadOffsetMapLinear
+llvm::SmallVector<Value>
 computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
@@ -275,18 +219,17 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping =
-      computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId, laneId,
-                               warpsPerGroup, numOfElems, tReps, toffsets, vectorSize);
-  LoadOffsetMapLinear bOffsets(reps[1], reps[0], numOfElems, vectorSize);
-  for (int block = 0; block < reps[1]; ++block)
-    for (int tile = 0; tile < reps[0]; ++tile)
-      for (int loadId = 0; loadId < numOfElems/vectorSize; ++loadId){
-        auto spatialOffset = mapping.offset(block, tile, loadId);
-        Value row = spatialOffset.kDim;
-        Value col = spatialOffset.nonKDim;
-        bOffsets.offset(block, tile, loadId) = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
-      }
+  auto mapping = computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId,
+                                          laneId, warpsPerGroup, numOfElems,
+                                          tReps, toffsets, vectorSize);
+  llvm::SmallVector<Value> bOffsets(mapping.size());
+  for (int i = 0; i < mapping.size(); ++i) {
+    // swap row and col, because operand B layout is a transposed operand A
+    // layout
+    Value row = mapping[i][1];
+    Value col = mapping[i][0];
+    bOffsets[i] = computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
+  }
   return bOffsets;
 }
 
@@ -303,16 +246,18 @@ Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
 
 /**
  * @brief try find if value is an integer constant
- * 
+ *
  * Trace def-use chain and return integer in case we can proof it is constant.
- * Current implementation can trace chains of insertValue->extractValue operations.
- * 
+ * Current implementation can trace chains of insertValue->extractValue
+ * operations.
+ *
  * @param val Value for that we want to get constant
  * @return std::optional on found integer value or empty std::optional
-*/
+ */
 std::optional<int> findConstValue(Value val) {
   while (val && !val.getDefiningOp<LLVM::ConstantOp>()) {
-    LLVM::ExtractValueOp extractValOp = val.getDefiningOp<LLVM::ExtractValueOp>();
+    LLVM::ExtractValueOp extractValOp =
+        val.getDefiningOp<LLVM::ExtractValueOp>();
     if (!extractValOp)
       return std::optional<int>();
     auto extractPosArr = extractValOp.getPosition();
@@ -332,7 +277,7 @@ std::optional<int> findConstValue(Value val) {
         return std::optional<int>();
       insertPos = insertPosArr[0];
       container = insertValOp.getContainer();
-    } while(insertPos != extractPos);
+    } while (insertPos != extractPos);
     val = insertValOp.getValue();
   }
   if (!val)
@@ -345,7 +290,9 @@ std::optional<int> findConstValue(Value val) {
   return intAttr.getInt();
 }
 
-bool fastPathAvailable(const SharedMemoryObject &smemObj, const SharedEncodingAttr &srcEncoding, const MfmaEncodingAttr &dstEncoding) {
+bool fastPathAvailable(const SharedMemoryObject &smemObj,
+                       const SharedEncodingAttr &srcEncoding,
+                       const MfmaEncodingAttr &dstEncoding) {
   if (dstEncoding.getNonKDim() != 32)
     return false;
   if (srcEncoding.getMaxPhase() > 1)
@@ -354,11 +301,8 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj, const SharedEncodingAt
   auto stride1 = findConstValue(smemObj.strides[1]);
   auto offset0 = findConstValue(smemObj.offsets[0]);
   auto offset1 = findConstValue(smemObj.offsets[1]);
-  bool allValuesDefined =
-      stride0.has_value() &&
-      stride1.has_value() &&
-      offset0.has_value() &&
-      offset1.has_value();
+  bool allValuesDefined = stride0.has_value() && stride1.has_value() &&
+                          offset0.has_value() && offset1.has_value();
   if (!allValuesDefined)
     return false;
   if (offset0.value() != 0 || offset1.value() != 0)
@@ -378,9 +322,9 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj, const SharedEncodingAt
 // @param cSwizzleOffset
 llvm::SmallVector<Value>
 fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
-                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                  Value laneId, int warpsPerGroup, int numOfElems,
-                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
+                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                          Value laneId, int warpsPerGroup, int numOfElems,
+                          ArrayRef<int64_t> reps, Value cSwizzleOffset) {
   auto numM = reps[0];
   auto numK = reps[1];
   SmallVector<Value> offsets(numM * numK * numOfElems);
@@ -422,9 +366,9 @@ fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
 // @param cSwizzleOffset
 llvm::SmallVector<Value>
 fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
-                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                  Value laneId, int warpsPerGroup, int numOfElems,
-                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
+                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                          Value laneId, int warpsPerGroup, int numOfElems,
+                          ArrayRef<int64_t> reps, Value cSwizzleOffset) {
   auto numK = reps[0];
   auto numN = reps[1];
   SmallVector<Value> offsets(numK * numN * numOfElems);
@@ -502,13 +446,13 @@ Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
     if (isTransposed(order)) {
       SmallVector<int64_t> elemsPerInstr{mfmaInstrK, mfmaInstrM};
       SmallVector<int64_t> reps{numReps[1], numReps[0]};
-      offsets =
-          fastPathComputeOffsetsTy2(rewriter, loc, elemsPerInstr, waveM, lane,
-                            warpsPerGroupM, numOfElems, reps, cSwizzleOffset);
+      offsets = fastPathComputeOffsetsTy2(rewriter, loc, elemsPerInstr, waveM,
+                                          lane, warpsPerGroupM, numOfElems,
+                                          reps, cSwizzleOffset);
     } else {
-      offsets =
-          fastPathComputeOffsetsTy1(rewriter, loc, aElemsPerInstr, waveM, lane,
-                            warpsPerGroupM, numOfElems, numReps, cSwizzleOffset);
+      offsets = fastPathComputeOffsetsTy1(rewriter, loc, aElemsPerInstr, waveM,
+                                          lane, warpsPerGroupM, numOfElems,
+                                          numReps, cSwizzleOffset);
     }
     Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
 
@@ -533,33 +477,34 @@ Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
       }
     }
   } else { // normal path
+    SmallVector<Value> offsets = computeOffsetsAType(
+        rewriter, loc, aElemsPerInstr, waveM, lane, warpsPerGroupM, numOfElems,
+        numReps, smemObj, sharedLayout);
+
     Value smemBase = computeBasePtr(rewriter, loc, smemObj);
 
     Type smemPtrTy = getShemPtrTy(aElemTy);
 
-    LoadOffsetMapLinear offsets = computeOffsetsAType(
-      rewriter, loc, aElemsPerInstr, waveM, lane, warpsPerGroupM, numOfElems,
-      numReps, smemObj, sharedLayout);
+    int loadsPerThread = offsets.size() / (numReps[0] * numReps[1]);
+    int elemsPerLoad = numOfElems / loadsPerThread;
 
-    int loadsPerThread = offsets.getNumLoadsPerThread();
-    int elemsPerLoad = offsets.getNumElemPerLoad();
     for (int m = 0; m < numRepM; ++m) {
       for (int k = 0; k < numRepK; ++k) {
         auto vecTy = vec_ty(aElemTy, numOfElems);
         Value valVec = undef(vecTy);
         for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
           auto loadVecTy = vec_ty(aElemTy, elemsPerLoad);
-          Value loadOffset = offsets.offset(m, k, loadId);
-          Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset), getShemPtrTy(loadVecTy));
-          // llvm::errs() <<  loadAddress << "\n";
+          Value loadOffset = offsets[m * loadsPerThread * numRepK +
+                                     k * loadsPerThread + loadId];
+          Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset),
+                                      getShemPtrTy(loadVecTy));
           Value vectorValue = load(loadAddress);
-          // llvm::errs() << vectorValue << "\n" << loadVecTy << "\n";
           if (numOfElems > 1) {
             for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal = extract_element(aElemTy, vectorValue, i32_val(elemId));
-              // llvm::errs() << elemVal << "\n";
-              valVec = insert_element(vecTy, valVec, elemVal, i32_val(loadId * elemsPerLoad + elemId));
-              // llvm::errs() << valVec << "\n";
+              Value elemVal =
+                  extract_element(aElemTy, vectorValue, i32_val(elemId));
+              valVec = insert_element(vecTy, valVec, elemVal,
+                                      i32_val(loadId * elemsPerLoad + elemId));
             }
           } else {
             valVec = extract_element(aElemTy, vectorValue, i32_val(0));
@@ -631,13 +576,13 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
     if (isTransposed(order)) {
       SmallVector<int64_t> elemsPerInstr{mfmaInstrN, mfmaInstrK};
       SmallVector<int64_t> reps{numReps[1], numReps[0]};
-      offsets =
-          fastPathComputeOffsetsTy1(rewriter, loc, elemsPerInstr, waveN, lane,
-                            warpsPerGroupN, numOfElems, reps, cSwizzleOffset);
+      offsets = fastPathComputeOffsetsTy1(rewriter, loc, elemsPerInstr, waveN,
+                                          lane, warpsPerGroupN, numOfElems,
+                                          reps, cSwizzleOffset);
     } else {
-      offsets =
-          fastPathComputeOffsetsTy2(rewriter, loc, bElemsPerInstr, waveN, lane,
-                            warpsPerGroupN, numOfElems, numReps, cSwizzleOffset);
+      offsets = fastPathComputeOffsetsTy2(rewriter, loc, bElemsPerInstr, waveN,
+                                          lane, warpsPerGroupN, numOfElems,
+                                          numReps, cSwizzleOffset);
     }
 
     Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
@@ -663,29 +608,33 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
       }
     }
   } else { // normal path
-    LoadOffsetMapLinear offsets = computeOffsetsBType(
-      rewriter, loc, bElemsPerInstr, waveN, lane, warpsPerGroupN, numOfElems,
-      numReps, smemObj, sharedLayout);
+    llvm::SmallVector<Value> offsets = computeOffsetsBType(
+        rewriter, loc, bElemsPerInstr, waveN, lane, warpsPerGroupN, numOfElems,
+        numReps, smemObj, sharedLayout);
 
     Value smemBase = computeBasePtr(rewriter, loc, smemObj);
 
     Type smemPtrTy = getShemPtrTy(bElemTy);
 
-    int loadsPerThread = offsets.getNumLoadsPerThread();
-    int elemsPerLoad = offsets.getNumElemPerLoad();
+    int loadsPerThread = offsets.size() / (numReps[0] * numReps[1]);
+    int elemsPerLoad = numOfElems / loadsPerThread;
     for (int n = 0; n < numRepN; ++n) {
       for (int k = 0; k < numRepK; ++k) {
         auto vecTy = vec_ty(bElemTy, numOfElems);
         Value valVec = undef(vecTy);
         for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
           auto loadVecTy = vec_ty(bElemTy, elemsPerLoad);
-          Value loadOffset = offsets.offset(n, k, loadId);
-          Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset), getShemPtrTy(loadVecTy));
+          Value loadOffset = offsets[n * loadsPerThread * numRepK +
+                                     k * loadsPerThread + loadId];
+          Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset),
+                                      getShemPtrTy(loadVecTy));
           Value vectorValue = load(loadAddress);
           if (numOfElems > 1) {
             for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal = extract_element(bElemTy, vectorValue, i32_val(elemId));
-              valVec = insert_element(vecTy, valVec, elemVal, i32_val(loadId * elemsPerLoad + elemId));
+              Value elemVal =
+                  extract_element(bElemTy, vectorValue, i32_val(elemId));
+              valVec = insert_element(vecTy, valVec, elemVal,
+                                      i32_val(loadId * elemsPerLoad + elemId));
             }
           } else {
             valVec = extract_element(bElemTy, vectorValue, i32_val(0));

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1410,6 +1410,92 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, devi
             assert 'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
 
 
+@pytest.mark.parametrize("vec_size", [2, 4])
+@pytest.mark.parametrize("swizzle", [True])
+def test_dot_mfma_vector_load(vec_size, swizzle):
+
+    # source code for following ttgir:
+    # @triton.jit
+    # def kernel(X, Y, Z):
+    #     off_m = tl.arange(0, 32)
+    #     off_n = tl.arange(0, 32)
+    #     off_k = tl.arange(0, 32)
+    #     Xs = X + off_m[:, None] * 32 + off_k[None, :]
+    #     Ys = Y + off_k[:, None] * 32 + off_n[None, :]
+    #     Zs = Z + off_m[:, None] * 32 + off_n[None, :]
+    #     x = tl.load(Xs)
+    #     y = tl.load(Ys)
+    #     z = tl.dot(x, y, allow_tf32=False)
+    #     tl.store(Zs, z)
+
+    if swizzle:
+        max_phase = 2
+    else:
+        max_phase = 1
+    ir = f"""
+#blocked = #triton_gpu.blocked<{{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}}>
+#shared = #triton_gpu.shared<{{vec = {vec_size}, perPhase = 1, maxPhase = {max_phase}, order = [1, 0]}}>
+""" + """
+module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @kernel_0d1d2d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %cst_0 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<32x1xi32, #blocked>
+    %2 = arith.muli %1, %cst_0 : tensor<32x1xi32, #blocked>
+    %3 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %4 = tt.addptr %3, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %5 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x32xi32, #blocked>
+    %7 = tt.broadcast %4 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %8 = tt.broadcast %6 : (tensor<1x32xi32, #blocked>) -> tensor<32x32xi32, #blocked>
+    %9 = tt.addptr %7, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %10 = tt.splat %arg1 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %11 = tt.addptr %10, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %12 = tt.broadcast %11 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %13 = tt.addptr %12, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %14 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %15 = tt.addptr %14, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %16 = tt.broadcast %15 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %17 = tt.addptr %16, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %18 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
+    %19 = triton_gpu.convert_layout %18 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared>
+    %20 = triton_gpu.convert_layout %19 : (tensor<32x32xf16, #shared>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
+    %21 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
+    %22 = triton_gpu.convert_layout %21 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared>
+    %23 = triton_gpu.convert_layout %22 : (tensor<32x32xf16, #shared>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
+    %24 = tt.dot %20, %23, %cst {allowTF32 = false} : tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> * tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> -> tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %25 = triton_gpu.convert_layout %24 : (tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>) -> tensor<32x32xf32, #blocked>
+    %26 = arith.truncf %25 : tensor<32x32xf32, #blocked> to tensor<32x32xf16, #blocked>
+    tt.store %17, %26 {cache = 1 : i32, evict = 1 : i32} : tensor<32x32xf16, #blocked>
+    tt.return
+  }
+}
+"""
+    shape = (32, 32)
+    dtype = 'float16'
+    x_np = numpy_random(shape, dtype_str=dtype)
+    y_np = numpy_random(shape, dtype_str=dtype)
+    z_np = np.dot(x_np, y_np)
+
+    x_tri = to_triton(x_np)
+    y_tri = to_triton(y_np)
+    z_tri = torch.empty_like(x_tri)
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
+        f.write(ir)
+        f.flush()
+        kernel = triton.compile(f.name)
+
+    import triton.language.semantic as sem
+    if torch.version.hip is not None and sem.gpu_has_mfma():
+        kernel[(1, 1, 1)](x_tri, y_tri, z_tri)
+        np.testing.assert_allclose(z_np, to_numpy(z_tri), rtol=0.01, atol=1e-3)
+
+    assert(f"load <{vec_size} x half>, ptr addrspace(3)" in kernel.asm['llir'])
+
+
 @pytest.mark.parametrize("dtype_str", int_dtypes + float_dtypes + ['bfloat16'])
 def test_full(dtype_str):
     dtype = getattr(torch, dtype_str)

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1410,97 +1410,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, devi
             assert 'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
 
 
-@pytest.mark.parametrize("vec_size", [2, 4])
-@pytest.mark.parametrize("swizzle", [True])
-def test_dot_mfma_vector_load(vec_size, swizzle):
-
-    # source code for following ttgir:
-    # @triton.jit
-    # def kernel(X, Y, Z):
-    #     off_m = tl.arange(0, 32)
-    #     off_n = tl.arange(0, 32)
-    #     off_k = tl.arange(0, 32)
-    #     Xs = X + off_m[:, None] * 32 + off_k[None, :]
-    #     Ys = Y + off_k[:, None] * 32 + off_n[None, :]
-    #     Zs = Z + off_m[:, None] * 32 + off_n[None, :]
-    #     x = tl.load(Xs)
-    #     y = tl.load(Ys)
-    #     z = tl.dot(x, y, allow_tf32=False)
-    #     tl.store(Zs, z)
-
-    if swizzle:
-        max_phase = 2
-    else:
-        max_phase = 1
-    ir = f"""
-#blocked = #triton_gpu.blocked<{{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}}>
-#shared = #triton_gpu.shared<{{vec = {vec_size}, perPhase = 1, maxPhase = {max_phase}, order = [1, 0]}}>
-""" + """
-module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel_0d1d2d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
-    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
-    %cst_0 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
-    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<32x1xi32, #blocked>
-    %2 = arith.muli %1, %cst_0 : tensor<32x1xi32, #blocked>
-    %3 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
-    %4 = tt.addptr %3, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
-    %5 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
-    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x32xi32, #blocked>
-    %7 = tt.broadcast %4 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
-    %8 = tt.broadcast %6 : (tensor<1x32xi32, #blocked>) -> tensor<32x32xi32, #blocked>
-    %9 = tt.addptr %7, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
-    %10 = tt.splat %arg1 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
-    %11 = tt.addptr %10, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
-    %12 = tt.broadcast %11 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
-    %13 = tt.addptr %12, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
-    %14 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
-    %15 = tt.addptr %14, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
-    %16 = tt.broadcast %15 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
-    %17 = tt.addptr %16, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
-    %18 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
-    %19 = triton_gpu.convert_layout %18 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared>
-    %20 = triton_gpu.convert_layout %19 : (tensor<32x32xf16, #shared>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
-    %21 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
-    %22 = triton_gpu.convert_layout %21 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared>
-    %23 = triton_gpu.convert_layout %22 : (tensor<32x32xf16, #shared>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
-    %24 = tt.dot %20, %23, %cst {allowTF32 = false} : tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> * tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> -> tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
-    %25 = triton_gpu.convert_layout %24 : (tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>) -> tensor<32x32xf32, #blocked>
-    %26 = arith.truncf %25 : tensor<32x32xf32, #blocked> to tensor<32x32xf16, #blocked>
-    tt.store %17, %26 {cache = 1 : i32, evict = 1 : i32} : tensor<32x32xf16, #blocked>
-    tt.return
-  }
-}
-"""
-    shape = (32, 32)
-    dtype = 'float16'
-    x_np = numpy_random(shape, dtype_str=dtype)
-    y_np = numpy_random(shape, dtype_str=dtype)
-    z_np = np.dot(x_np, y_np)
-
-    x_tri = to_triton(x_np)
-    y_tri = to_triton(y_np)
-    z_tri = torch.empty_like(x_tri)
-
-    import tempfile
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
-        f.write(ir)
-        f.flush()
-        arch_triple = "amdgcn-amd-amdhsa"
-        arch_name = "gfx90a"
-        features = ""
-        warp_size = 64
-        capabilities = [arch_triple, arch_name, features, warp_size]
-        kernel = triton.compile(f.name, device_type="hip", cc=capabilities)
-
-    import triton.language.semantic as sem
-    if torch.version.hip is not None and sem.gpu_has_mfma():
-        kernel[(1, 1, 1)](x_tri, y_tri, z_tri)
-        np.testing.assert_allclose(z_np, to_numpy(z_tri), rtol=0.01, atol=1e-3)
-
-    assert(f"load <{vec_size} x half>, ptr addrspace(3)" in kernel.asm['llir'])
-
-
 @pytest.mark.parametrize("dtype_str", int_dtypes + float_dtypes + ['bfloat16'])
 def test_full(dtype_str):
     dtype = getattr(torch, dtype_str)
@@ -2265,6 +2174,117 @@ class BlockedLayout:
 
     def __str__(self):
         return f"#triton_gpu.blocked<{{sizePerThread={self.sz_per_thread}, threadsPerWarp={self.threads_per_warp}, warpsPerCTA={self.warps_per_cta}, order={self.order}}}>"
+
+class SharedLayout:
+    def __init__(self, vec, per_phase, max_phase, order):
+        self.vec = str(vec)
+        self.per_phase = str(per_phase)
+        self.max_phase = str(max_phase)
+        self.order = str(order)
+
+    def __str__(self):
+        return f"#triton_gpu.shared<{{vec = {self.vec}, perPhase={self.per_phase}, maxPhase={self.max_phase}, order={self.order}}}>"
+
+
+@pytest.mark.parametrize("vec_size", [2, 4])
+@pytest.mark.parametrize("swizzle", [True])
+@pytest.mark.parametrize("transposeA", [True, False])
+@pytest.mark.parametrize("transposeB", [True, False])
+def test_dot_mfma_vector_load(vec_size, swizzle, transposeA, transposeB):
+    # we can not do vector loads in this case
+    if transposeA and not transposeB:
+        pytest.skip()
+
+    # source code for following ttgir:
+    # @triton.jit
+    # def kernel(X, Y, Z):
+    #     off_m = tl.arange(0, 32)
+    #     off_n = tl.arange(0, 32)
+    #     off_k = tl.arange(0, 32)
+    #     Xs = X + off_m[:, None] * 32 + off_k[None, :]
+    #     Ys = Y + off_k[:, None] * 32 + off_n[None, :]
+    #     Zs = Z + off_m[:, None] * 32 + off_n[None, :]
+    #     x = tl.load(Xs)
+    #     y = tl.load(Ys)
+    #     z = tl.dot(x, y, allow_tf32=False)
+    #     tl.store(Zs, z)
+
+    if swizzle:
+        max_phase = 2
+    else:
+        max_phase = 1
+
+    shared_a = SharedLayout(vec = vec_size, per_phase = 1, max_phase = max_phase, order = [0, 1] if transposeA else [1, 0])
+    shared_b = SharedLayout(vec = vec_size, per_phase = 1, max_phase = max_phase, order = [0, 1] if transposeB else [1, 0])
+
+    ir = f"""
+#blocked = #triton_gpu.blocked<{{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}}>
+#shared1 = {shared_a}
+#shared2 = {shared_b}
+""" + """
+module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @kernel_0d1d2d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %cst_0 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<32x1xi32, #blocked>
+    %2 = arith.muli %1, %cst_0 : tensor<32x1xi32, #blocked>
+    %3 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %4 = tt.addptr %3, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %5 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x32xi32, #blocked>
+    %7 = tt.broadcast %4 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %8 = tt.broadcast %6 : (tensor<1x32xi32, #blocked>) -> tensor<32x32xi32, #blocked>
+    %9 = tt.addptr %7, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %10 = tt.splat %arg1 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %11 = tt.addptr %10, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %12 = tt.broadcast %11 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %13 = tt.addptr %12, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %14 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<32x1x!tt.ptr<f16>, #blocked>
+    %15 = tt.addptr %14, %2 : tensor<32x1x!tt.ptr<f16>, #blocked>, tensor<32x1xi32, #blocked>
+    %16 = tt.broadcast %15 : (tensor<32x1x!tt.ptr<f16>, #blocked>) -> tensor<32x32x!tt.ptr<f16>, #blocked>
+    %17 = tt.addptr %16, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
+    %18 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
+    %19 = triton_gpu.convert_layout %18 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared1>
+    %20 = triton_gpu.convert_layout %19 : (tensor<32x32xf16, #shared1>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
+    %21 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
+    %22 = triton_gpu.convert_layout %21 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared2>
+    %23 = triton_gpu.convert_layout %22 : (tensor<32x32xf16, #shared2>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>>
+    %24 = tt.dot %20, %23, %cst {allowTF32 = false} : tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> * tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>}>> -> tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %25 = triton_gpu.convert_layout %24 : (tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>) -> tensor<32x32xf32, #blocked>
+    %26 = arith.truncf %25 : tensor<32x32xf32, #blocked> to tensor<32x32xf16, #blocked>
+    tt.store %17, %26 {cache = 1 : i32, evict = 1 : i32} : tensor<32x32xf16, #blocked>
+    tt.return
+  }
+}
+"""
+    shape = (32, 32)
+    dtype = 'float16'
+    x_np = numpy_random(shape, dtype_str=dtype)
+    y_np = numpy_random(shape, dtype_str=dtype)
+    z_np = np.dot(x_np, y_np)
+
+    x_tri = to_triton(x_np)
+    y_tri = to_triton(y_np)
+    z_tri = torch.empty_like(x_tri)
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
+        f.write(ir)
+        f.flush()
+        arch_triple = "amdgcn-amd-amdhsa"
+        arch_name = "gfx90a"
+        features = ""
+        warp_size = 64
+        capabilities = [arch_triple, arch_name, features, warp_size]
+        kernel = triton.compile(f.name, device_type="hip", cc=capabilities)
+
+    import triton.language.semantic as sem
+    if torch.version.hip is not None and sem.gpu_has_mfma():
+        kernel[(1, 1, 1)](x_tri, y_tri, z_tri)
+        np.testing.assert_allclose(z_np, to_numpy(z_tri), rtol=0.01, atol=1e-3)
+
+    assert(f"load <{vec_size} x half>, ptr addrspace(3)" in kernel.asm['llir'])
 
 
 def _get_warp_size():

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1486,7 +1486,12 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
     with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
         f.write(ir)
         f.flush()
-        kernel = triton.compile(f.name)
+        arch_triple = "amdgcn-amd-amdhsa"
+        arch_name = "gfx90a"
+        features = ""
+        warp_size = 64
+        capabilities = [arch_triple, arch_name, features, warp_size]
+        kernel = triton.compile(f.name, device_type="hip", cc=capabilities)
 
     import triton.language.semantic as sem
     if torch.version.hip is not None and sem.gpu_has_mfma():

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1367,7 +1367,8 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
   tt.func @matmul_kernel_dot_operand_layout_gcn(%ptr:!tt.ptr<f32> {tt.divisibility = 16 : i32},
     %a:tensor<128x32xf16, #shared>, %b:tensor<32x256xf16, #shared>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mfma>
-    // GCN-COUNT-96: llvm.load {{.*}} : !llvm.ptr<f16, 3>
+    // GCN-COUNT-8: llvm.load {{.*}} : !llvm.ptr<vector<4xf16>, 3>
+    // GCN-COUNT-64: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>, 3>
     %a_mat = triton_gpu.convert_layout %a : (tensor<128x32xf16, #shared>) -> tensor<128x32xf16, #dot_operand_a>
     %b_mat = triton_gpu.convert_layout %b : (tensor<32x256xf16, #shared>) -> tensor<32x256xf16, #dot_operand_b>
 


### PR DESCRIPTION
This PR adds generation of vector loads in normal path of MFMA dot operand loading.
This requires shared layout to have contiguous elements which should be loaded by one lane.