### PR TITLE
Fix default rocm path

### DIFF
--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -24,7 +24,7 @@ def libcuda_dirs():
 
 @functools.lru_cache()
 def rocm_path_dir():
-    default_path = os.path.join(os.path.dirname(__file__), "third_party", "rocm")
+    default_path = os.path.join(os.path.dirname(__file__), "..", "third_party", "rocm")
     # Check if include files have been populated locally.  If so, then we are 
     # most likely in a whl installation and he rest of our libraries should be here
     if (os.path.exists(default_path+"/include/hip/hip_runtime.h")):


### PR DESCRIPTION
Running into `fatal error: hip/hip_runtime.h: No such file or directory` with latest wheel due to incorrect directory for ROCm libs

Previously default path was:
`/opt/_internal/cpython-3.8.17/lib/python3.8/site-packages/triton/common/third_party/rocm`

Now
`/opt/_internal/cpython-3.8.17/lib/python3.8/site-packages/triton/common/../third_party/rocm`