### PR TITLE
Fix runtime/test_subproc.py for hip devices

### DIFF
--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -20,7 +20,7 @@ def reset_tmp_dir():
 instance_descriptor = namedtuple("instance_descriptor", ["divisible_by_16", "equal_to_1"])
 
 
-def compile_fn(config, cc):
+def compile_fn(config, device_type, cc):
     @triton.jit
     def kernel_sub(a, b, o, N: tl.constexpr):
         idx = tl.arange(0, N)
@@ -29,6 +29,7 @@ def compile_fn(config, cc):
         fn=kernel_sub,
         signature={0: "*fp32", 1: "*fp32", 2: "*fp32"},
         device=0,
+        device_type=device_type,
         constants={3: 32},
         configs=[config],
         warm_cache_only=True,
@@ -37,20 +38,29 @@ def compile_fn(config, cc):
 
 
 def test_compile_in_subproc() -> None:
-    major, minor = torch.cuda.get_device_capability(0)
-    cc = major * 10 + minor
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("Triton requires PyTorch to be installed")
+    if torch.version.hip is None:
+        major, minor = torch.cuda.get_device_capability(0)
+        cc = major * 10 + minor
+        device_type="cuda"
+    else:
+        cc = None
+        device_type="hip"
     config = instance_descriptor(tuple(range(4)), ())
 
     multiprocessing.set_start_method('fork')
     proc = multiprocessing.Process(
         target=compile_fn,
-        args=(config, cc))
+        args=(config, device_type, cc))
     proc.start()
     proc.join()
     assert proc.exitcode == 0
 
 
-def compile_fn_dot(config, cc):
+def compile_fn_dot(config, device_type, cc):
     @triton.jit
     def kernel_dot(Z):
         offs = tl.arange(0, 16)[:, None] * 16 + tl.arange(0, 16)[None, :]
@@ -62,6 +72,7 @@ def compile_fn_dot(config, cc):
         fn=kernel_dot,
         signature={0: "*fp32"},
         device=0,
+        device_type=device_type,
         configs=[config],
         warm_cache_only=True,
         cc=cc,
@@ -70,14 +81,23 @@ def compile_fn_dot(config, cc):
 
 def test_compile_in_forked_subproc() -> None:
     reset_tmp_dir()
-    major, minor = torch.cuda.get_device_capability(0)
-    cc = major * 10 + minor
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("Triton requires PyTorch to be installed")
+    if torch.version.hip is None:
+        major, minor = torch.cuda.get_device_capability(0)
+        cc = major * 10 + minor
+        device_type="cuda"
+    else:
+        cc = None
+        device_type="hip"
     config = instance_descriptor(tuple(range(1)), ())
 
     assert multiprocessing.get_start_method() == 'fork'
     proc = multiprocessing.Process(
         target=compile_fn_dot,
-        args=(config, cc))
+        args=(config, device_type, cc))
     proc.start()
     proc.join()
     assert proc.exitcode == 0


### PR DESCRIPTION
Set device_type to "hip" here for hip devices.