### PR TITLE
[Tests] Fix some tests in test_core_amd.py

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -617,7 +617,7 @@ class CompiledKernel:
 
         def runner(*args, stream=None):
             if stream is None:
-                if self.device_type in ["cuda", "rocm"]:
+                if self.device_type in ["cuda", "hip"]:
                     stream = get_cuda_stream()
                 else:
                     stream = get_backend(self.device_type).get_stream(None)


### PR DESCRIPTION
This PR:
- enables test_dot_mfma_vector_load for fast path in mfma dot op pipeline
- fixes kernel execution for mfma enabled GPUS
- disables mfma layout conversion tests on architectures which can not run these tests