### PR TITLE
[MFMA] Move source casts from semantic.py

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1297,17 +1297,6 @@ def dot(lhs: tl.tensor,
         ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
                         ret_ty)
         return cast(ret, ret_scalar_ty, builder)
-    if is_hip() and mfma_supported(M, N, lhs.type.shape[1], allow_tf32, ret_scalar_ty) and ret_scalar_ty.primitive_bitwidth < 32:
-        if lhs.type.scalar.is_int():
-            ret_dot_scalar_ty = tl.int32
-            _0 = builder.create_splat(builder.get_int32(0), [M, N])
-        else:
-            ret_dot_scalar_ty = tl.float32
-            _0 = builder.create_splat(builder.get_fp32(0), [M, N])
-        ret_ty = tl.block_type(ret_dot_scalar_ty, [M, N])
-        ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32),
-                        ret_ty)
-        return cast(ret, ret_scalar_ty, builder)
 
     _0 = builder.create_splat(_0, [M, N])
     ret_ty = tl.block_type(ret_scalar_ty, [M, N])


### PR DESCRIPTION
This PR moves cast of 3-rd mfma dot operand from python code to C++.

Before this PR, ttgir mfma dot supported type combinarions:
- fp16 x fp16 -> fp32
- bf16 xbf16 -> fp32
- fp32 x fp32 -> fp32
- int8 x int8 -> int32

This list is extended with:
- fp16 x fp16 -> fp16