### PR TITLE
Pick better values for `vecSize` and `maxPhase` for k-major matrices

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -89,21 +89,29 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
           if (isKDimInner) {
             const int numBanks = 32;
             const int bankBitWidth = 32;
+            const int SIMDWidth = 16;
 
             // number of inner dimension rows per one pattern repeat
-            int outerDimGranularity = mfmaEnc.getNonKDim();
             int typeBitWidth = eltTy.getIntOrFloatBitWidth();
             int innerDimLength = shape[order[0]];
             int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeBitWidth;
 
             int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
-            // Note: the following settings is customized for mfma_32x32x8f16
-            // to avoid **load** bank conflicts
-            // vecSize is set to k_base, which is 4
-            // maxPhase is set to BLOCK_K/4 so that every 16 workitems will access
-            // difference banks
-            int vecSize = 4;
-            int maxPhase = innerDimLength / 4;
+            // Note: the following settings is customized to avoid
+            // **load** bank conflicts
+            //
+            // vecSize is set to k_base, which is the number of elements each
+            // workitem loads for one mfma instruction.
+            // For now, the k_base rules are as follows
+            // 1. All selected mfma instructions produce a single block
+            // 2. For f16 data type, 2 VGPRs are used for operand A --> k_base = 4
+            // 3. For non-f16 data types, 1 VGPR are used for operand A
+            //    k_base = 32 / elemTypeInBits
+            // 4. TODO: what about f64?
+            //
+            // maxPhase is set to SIMDWidth / perPhase
+            int vecSize = (eltTy.isF16() ? 64 : 32 ) / typeBitWidth;
+            int maxPhase = SIMDWidth / perPhase;
 
             return $_get(context, vecSize, perPhase, maxPhase, order);
           } else {

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -97,9 +97,13 @@ A_{3, 2}  A_{3, 3}  A_{3, 0}  A_{3, 1} ...   [phase 1] /
             int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeBitWidth;
 
             int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
-            int maxPhase = outerDimGranularity / perPhase;
-            int vecSize = innerDimLength / maxPhase;
-            assert(vecSize > 0);
+            // Note: the following settings is customized for mfma_32x32x8f16
+            // to avoid **load** bank conflicts
+            // vecSize is set to k_base, which is 4
+            // maxPhase is set to BLOCK_K/4 so that every 16 workitems will access
+            // difference banks
+            int vecSize = 4;
+            int maxPhase = innerDimLength / 4;
 
             return $_get(context, vecSize, perPhase, maxPhase, order);
           } else {

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -77,7 +77,7 @@ def optimize_ttgir(mod, num_stages, arch):
     pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     pm.add_tritongpu_coalesce_pass()
-    pm.add_tritongpu_remove_layout_conversions_pass()
+    #pm.add_tritongpu_remove_layout_conversions_pass()
     if _is_cuda(arch):
         pm.add_tritongpu_accelerate_matmul_pass(arch)
     # TODO change interface of accelerate_matmul_pass

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -77,7 +77,7 @@ def optimize_ttgir(mod, num_stages, arch):
     pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     pm.add_tritongpu_coalesce_pass()
-    #pm.add_tritongpu_remove_layout_conversions_pass()
+    pm.add_tritongpu_remove_layout_conversions_pass()
     if _is_cuda(arch):
         pm.add_tritongpu_accelerate_matmul_pass(arch)
     # TODO change interface of accelerate_matmul_pass


### PR DESCRIPTION
The rational behind this settings is discussed here: https://github.com/ROCmSoftwarePlatform/triton/pull/285#discussion_r1287931522

Here is the performance on MI250
d | nheads | bs | seqlen | triton-mlir v1 | triton-mlir v2 | this PR v1 | this PR v2
-- | -- | -- | -- | -- | -- | -- | --
64 | 48 | 4 | 1024 | 49.67 | 49.35 | 54.57 | 52.51
64 | 48 | 4 | 2048 | 53.39 | 53.09 | 57.6 | 56.62
64 | 48 | 4 | 4096 | 55.36 | 55.05 | 59.29 | 59.06
64 | 48 | 4 | 8192 | 56.18 | 56.06 | 60.47 | 60.5
64 | 48 | 4 | 16384 | 57.46 | 56.67 | 61.01 | 61.09
64 | 16 | 1 | 1024 | 28.15 | 27.68 | 32.19 | 31.6
64 | 16 | 1 | 2048 | 35.98 | 37.2 | 36.86 | 35.8
64 | 16 | 1 | 4096 | 46.95 | 48.43 | 48.47 | 47.92
64 | 16 | 32 | 1024 | 50.85 | 50.88 | 56.07 | 53.02
64 | 16 | 32 | 2048 | 53.87 | 53.51 | 58.21 | 56.27
64 | 16 | 32 | 4096 | 55.49 | 55.52 | 59.91 | 59.21
64 | 16 | 48 | 1024 | 51.44 | 51.78 | 55.94 | 53.64
64 | 16 | 48 | 2048 | 54.07 | 53.76 | 58.47 | 56.96
64 | 16 | 64 | 1024 | 51.57 | 51.76 | 56.09 | 53.09
64 | 16 | 64 | 2048 | 54.17 | 53.86 | 58.54 | 56.91
64 | 16 | 128 | 1024 | 51.86 | 52.09 | 56.24 | 53.51


Here are some observations:
- The tile size is chosen to be 128x64 for all four experiments.
- v1 and v2 have similar performance for both `triton-mlir` and this PR

We expect v2 has better performance since it has less computations in the loop. However, it is possible that the extra computations are overlapped with memory operations (done by the compiler, since we do not have software pipelining yet).

Also note that this PR avoids the FA v2 hanging issue by https://github.com/ROCmSoftwarePlatform/triton/pull/272. We can easily revert it when https://github.com/ROCmSoftwarePlatform/triton/pull/274 is merged.
