### PR TITLE
[MFMA] MI200 Enable mfma bfloat16

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -57,7 +57,7 @@ struct DotOpMFMAConversionHelper {
           loc, TypeRange{resType},
           ValueRange{valA, valB, valC, zeroFlag, zeroFlag, zeroFlag});
     case MatrixCoreType::FP32_BF16_BF16_FP32:
-      return rewriter.create<ROCDL::mfma_f32_32x32x4bf16>(
+      return rewriter.create<ROCDL::mfma_f32_32x32x8bf16_1k>(
           loc, TypeRange{resType},
           ValueRange{valA, valB, valC, zeroFlag, zeroFlag, zeroFlag});
     case MatrixCoreType::FP32_FP32_FP32_FP32:

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -669,7 +669,7 @@ static SmallVector<int64_t> getMFMAInstrShape(Type abElemType) {
   if (abElemType.isF32())
     return {32l, 32l, 2l}; // FP32_FP32_FP32_FP32;
   if (abElemType.isBF16())
-    return {32l, 32l, 4l}; // FP32_BF16_BF16_FP32;
+    return {32l, 32l, 8l}; // FP32_BF16_BF16_FP32;
   if (abElemType.isInteger(8))
     return {32l, 32l, 8l}; // INT32_INT8_INT8_INT32;
   if (abElemType.isF64())


### PR DESCRIPTION
This PR enables bfloat16 support in MFMA dot on MI200.
Used mfma_f32_32x32x8bf16_1k instruction.