### PR TITLE
[MFMA] Support BFloat16 on MI100 

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -507,7 +507,7 @@ An encoding for tensors that have been produced by MI100 && MI200 tensor cores.
 It is characterized by parameters `warpsPerCTA` and `nonKDim` that indicates how data should be partitioned
 between waves (analogous to the term 'warp' used in NVIDIA's CUDA programming model).
 
-For MFMA, an additional attribute `mfmaKBase` defines how many elements should be feed
+An additional attribute `kDim` defines how many elements should be feed
 to one mfma instruction along k dimension of the operand.
 This attribute is Used in derivated DotOperand encoding, do not affect pure mfma encoding.
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -507,6 +507,10 @@ An encoding for tensors that have been produced by MI100 && MI200 tensor cores.
 It is characterized by parameters `warpsPerCTA` and `nonKDim` that indicates how data should be partitioned
 between waves (analogous to the term 'warp' used in NVIDIA's CUDA programming model).
 
+For MFMA, an additional attribute `mfmaKBase` defines how many elements should be feed
+to one mfma instruction along k dimension of the operand.
+This attribute is Used in derivated DotOperand encoding, do not affect pure mfma encoding.
+
 Example 1:
 Suppose we have a tensor with a shape of [32, 64], warpsPerCTA set to [1, 2] and nonKDim set to 32.
 The data will be distributed between threads as follows:
@@ -573,6 +577,7 @@ The data will be distributed between threads as follows:
   let parameters = (
     ins
     "unsigned":$nonKDim,
+    "unsigned":$kDim,
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
     "bool":$isTransposed
   );
@@ -671,7 +676,7 @@ section 9.7.13.4.1 for more details.
     SmallVector<int64_t> getMMAv2Rep(ArrayRef<int64_t> shape,
                                      int bitwidth) const;
 #ifdef USE_ROCM
-    SmallVector<int64_t> getMFMAElemsPerThread(Type elemTy) const;
+    SmallVector<int64_t> getMFMAElemsPerInstr() const;
     SmallVector<int64_t> getMFMARep(ArrayRef<int64_t> operandShape,
                                     Type elemType) const;
 #endif

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -507,10 +507,6 @@ An encoding for tensors that have been produced by MI100 && MI200 tensor cores.
 It is characterized by parameters `warpsPerCTA` and `nonKDim` that indicates how data should be partitioned
 between waves (analogous to the term 'warp' used in NVIDIA's CUDA programming model).
 
-An additional attribute `kDim` defines how many elements should be feed
-to one mfma instruction along k dimension of the operand.
-This attribute is Used in derivated DotOperand encoding, do not affect pure mfma encoding.
-
 Example 1:
 Suppose we have a tensor with a shape of [32, 64], warpsPerCTA set to [1, 2] and nonKDim set to 32.
 The data will be distributed between threads as follows:
@@ -577,7 +573,6 @@ The data will be distributed between threads as follows:
   let parameters = (
     ins
     "unsigned":$nonKDim,
-    "unsigned":$kDim,
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
     "bool":$isTransposed
   );
@@ -652,14 +647,6 @@ section 9.7.13.4.1 for more details.
         return $_get(context, opIdx, parent, 0);
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
       unsigned kWidth = 32 / bitwidth;
-      return $_get(context, opIdx, parent, kWidth);
-    }]>,
-
-    // Specially for MFMA(MI100/MI200)
-    AttrBuilder<(ins "unsigned":$opIdx,
-                     "Attribute":$parent), [{
-      assert(llvm::isa<MfmaEncodingAttr>(parent));
-      unsigned kWidth = 0; // unused for MFMA ops
       return $_get(context, opIdx, parent, kWidth);
     }]>
   ];

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -388,6 +388,7 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   // layout when opIdx == 1.
   return mfmaLayout.getWarpsPerCTA()[1] == 1 &&
          dotOperandLayout.getOpIdx() == 0 &&
+         dotOperandLayout.getKWidth() == 8 &&
          dotOperandLayout.getParent() == mfmaLayout &&
          mfmaLayout.getIsTransposed() && (srcTy.getElementType().isF16() || srcTy.getElementType().isBF16());
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -676,7 +676,11 @@ private:
       // bf16 (represented as int16 in llvm ir).
       assert((type::isFloat(elemTy) || type::isInt(elemTy)) && elemSize == 16);
       auto dotOperandLayout = dstTy.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
-      unsigned vecSize = dotOperandLayout.getKWidth() / 2;
+      // vecSize is an number of sequential elements holing by one lane
+      // for MFMA 32x32 encoding it is 4
+      // For MFMA dot operand encding for fp16 and bfloat16 on MI200 types it is also 4, so 
+      // MFMA operand and MFMA layouts are the same
+      const unsigned vecSize = 4;
       Type vecTy = vec_ty(elemTy, vecSize);
       types = SmallVector<Type>(elems / vecSize, vecTy);
       for (unsigned i = 0; i < elems; i += vecSize) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -675,7 +675,8 @@ private:
       // TODO: Support types other than float16 and
       // bf16 (represented as int16 in llvm ir).
       assert((type::isFloat(elemTy) || type::isInt(elemTy)) && elemSize == 16);
-      unsigned vecSize = 4;
+      auto dotOperandLayout = dstTy.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
+      unsigned vecSize = dotOperandLayout.getKWidth() / 2;
       Type vecTy = vec_ty(elemTy, vecSize);
       types = SmallVector<Type>(elems / vecSize, vecTy);
       for (unsigned i = 0; i < elems; i += vecSize) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -675,11 +675,12 @@ private:
       // TODO: Support types other than float16 and
       // bf16 (represented as int16 in llvm ir).
       assert((type::isFloat(elemTy) || type::isInt(elemTy)) && elemSize == 16);
-      auto dotOperandLayout = dstTy.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
-      // vecSize is an number of sequential elements holing by one lane
-      // for MFMA 32x32 encoding it is 4
-      // For MFMA dot operand encding for fp16 and bfloat16 on MI200 types it is also 4, so 
-      // MFMA operand and MFMA layouts are the same
+      // vecSize is an number of sequential elements stored by one thread
+      // - For MFMA (nonKDim == 32) encoding it is 4
+      // - For MFMA (nonKDim == 32) operand encoding it is dotOperandEndocing::kWidth,
+      //   which is 4 for fp16 and bfloat16 dtypes
+      //
+      // For mentioned types MFMA and MFMA operand layouts are the same
       const unsigned vecSize = 4;
       Type vecTy = vec_ty(elemTy, vecSize);
       types = SmallVector<Type>(elems / vecSize, vecTy);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -420,7 +420,7 @@ Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
   auto order = sharedLayout.getOrder();
 
   auto aElemTy = aTensorTy.getElementType();
-  auto aElemsPerInstr = encoding.getMFMAElemsPerThread(aElemTy);
+  auto aElemsPerInstr = encoding.getMFMAElemsPerInstr();
   auto mfmaInstrM = aElemsPerInstr[0];
   auto mfmaInstrK = aElemsPerInstr[1];
 
@@ -559,7 +559,7 @@ Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
   auto order = sharedLayout.getOrder();
 
   auto bElemTy = bTensorTy.getElementType();
-  auto bElemsPerInstr = encoding.getMFMAElemsPerThread(bElemTy);
+  auto bElemsPerInstr = encoding.getMFMAElemsPerInstr();
   auto mfmaInstrK = bElemsPerInstr[0];
   auto mfmaInstrN = bElemsPerInstr[1];
 

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -93,7 +93,7 @@ struct DotOpMFMAConversionHelper {
     if (elemTy.isBF16()) {
       auto dotOpEncoding = tensorTy.getEncoding().cast<DotOperandEncodingAttr>();
       auto mfmaEncoding = dotOpEncoding.getParent().cast<MfmaEncodingAttr>();
-      if (mfmaEncoding.getKDim() == 8)
+      if (dotOpEncoding.getKWidth() == 8)
         return MatrixCoreType::FP32_BF16_BF16_FP32_1K;
       else
         return MatrixCoreType::FP32_BF16_BF16_FP32;

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -18,6 +18,7 @@ enum class MatrixCoreType : uint8_t {
   // D = AB + C
   FP32_FP16_FP16_FP32 = 0, // default
   FP32_BF16_BF16_FP32,
+  FP32_BF16_BF16_FP32_1K,
   FP32_FP32_FP32_FP32,
   FP64_FP64_FP64_FP64,
   INT32_INT8_INT8_INT32,
@@ -57,6 +58,10 @@ struct DotOpMFMAConversionHelper {
           loc, TypeRange{resType},
           ValueRange{valA, valB, valC, zeroFlag, zeroFlag, zeroFlag});
     case MatrixCoreType::FP32_BF16_BF16_FP32:
+      return rewriter.create<ROCDL::mfma_f32_32x32x4bf16>(
+          loc, TypeRange{resType},
+          ValueRange{valA, valB, valC, zeroFlag, zeroFlag, zeroFlag});
+    case MatrixCoreType::FP32_BF16_BF16_FP32_1K:
       return rewriter.create<ROCDL::mfma_f32_32x32x8bf16_1k>(
           loc, TypeRange{resType},
           ValueRange{valA, valB, valC, zeroFlag, zeroFlag, zeroFlag});
@@ -85,8 +90,14 @@ struct DotOpMFMAConversionHelper {
       return MatrixCoreType::FP32_FP16_FP16_FP32;
     if (elemTy.isF32())
       return MatrixCoreType::FP32_FP32_FP32_FP32;
-    if (elemTy.isBF16())
-      return MatrixCoreType::FP32_BF16_BF16_FP32;
+    if (elemTy.isBF16()) {
+      auto dotOpEncoding = tensorTy.getEncoding().cast<DotOperandEncodingAttr>();
+      auto mfmaEncoding = dotOpEncoding.getParent().cast<MfmaEncodingAttr>();
+      if (mfmaEncoding.getKDim() == 8)
+        return MatrixCoreType::FP32_BF16_BF16_FP32_1K;
+      else
+        return MatrixCoreType::FP32_BF16_BF16_FP32;
+    }
     if (elemTy.isInteger(8))
       return MatrixCoreType::INT32_INT8_INT8_INT32;
     if (elemTy.isF64())

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -92,7 +92,6 @@ struct DotOpMFMAConversionHelper {
       return MatrixCoreType::FP32_FP32_FP32_FP32;
     if (elemTy.isBF16()) {
       auto dotOpEncoding = tensorTy.getEncoding().cast<DotOperandEncodingAttr>();
-      auto mfmaEncoding = dotOpEncoding.getParent().cast<MfmaEncodingAttr>();
       if (dotOpEncoding.getKWidth() == 8)
         return MatrixCoreType::FP32_BF16_BF16_FP32_1K;
       else

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -111,7 +111,7 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
     if (elemTy.isF32())
       return elemTy;
     if (elemTy.isInteger(16)) // aka BF16
-      return vec_ty(elemTy, mfmaParent.getKDim() / 2);
+      return vec_ty(elemTy, dotOpLayout.getKWidth() / 2);
     if (elemTy.isF16())
       return vec_ty(elemTy, 4);
     if (elemTy.isInteger(8))

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -108,13 +108,14 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
 
 #ifdef USE_ROCM
   if (auto mfmaParent = dotOpLayout.getParent().dyn_cast<MfmaEncodingAttr>()) {
-    const llvm::DenseMap<int, Type> targetTyMap = {
-        {32, elemTy},
-        {16, vec_ty(elemTy, 4)},
-        {8, IntegerType::get(ctx, 32)},
-    };
-    Type targetTy = targetTyMap.lookup(elemTy.getIntOrFloatBitWidth());
-    return targetTy;
+    if (elemTy.isF32())
+      return elemTy;
+    if (elemTy.isInteger(16)) // aka BF16
+      return vec_ty(elemTy, mfmaParent.getKDim() / 2);
+    if (elemTy.isF16())
+      return vec_ty(elemTy, 4);
+    if (elemTy.isInteger(8))
+      return IntegerType::get(ctx, 32);
   }
 #endif
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -582,7 +582,7 @@ unsigned SliceEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
 SmallVector<unsigned>
 MfmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
   size_t rank = shape.size();
-  assert(rank == 2 && "Unexpected rank of mma layout");
+  assert(rank == 2 && "Unexpected rank of mfma layout");
 
   SmallVector<unsigned> elemsPerThread(rank);
   if (getIsTransposed()) {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -673,44 +673,31 @@ DotOperandEncodingAttr::getMMAv2Rep(ArrayRef<int64_t> shape,
   }
 }
 
-static SmallVector<int64_t> getMFMAInstrShape(Type abElemType) {
-  if (abElemType.isF16())
-    return {32l, 32l, 8l}; // FP32_FP16_FP16_FP32
-  if (abElemType.isF32())
-    return {32l, 32l, 2l}; // FP32_FP32_FP32_FP32;
-  if (abElemType.isBF16())
-    return {32l, 32l, 8l}; // FP32_BF16_BF16_FP32;
-  if (abElemType.isInteger(8))
-    return {32l, 32l, 8l}; // INT32_INT8_INT8_INT32;
-  if (abElemType.isF64())
-    return {16l, 16l, 4l}; // FP64_FP64_FP64_FP64;
-  assert(false && "unsupported operand data type");
-  return {};
-}
-
 SmallVector<int64_t>
-DotOperandEncodingAttr::getMFMAElemsPerThread(Type elemType) const {
-  auto instrSize = getMFMAInstrShape(elemType);
+DotOperandEncodingAttr::getMFMAElemsPerInstr() const {
+  auto mfmaEncoding = getParent().cast<MfmaEncodingAttr>();
+  int64_t nonKDim = mfmaEncoding.getNonKDim();
+  int64_t kDim = mfmaEncoding.getKDim();
   if (getOpIdx() == 0)
-    return {instrSize[0], instrSize[2]};
+    return {nonKDim, kDim};
   else
-    return {instrSize[2], instrSize[1]};
+    return {kDim, nonKDim};
 }
 
 SmallVector<int64_t>
 DotOperandEncodingAttr::getMFMARep(ArrayRef<int64_t> operandShape,
                                    Type elemType) const {
-  auto instrSize = getMFMAInstrShape(elemType);
+  auto operandTileShape = getMFMAElemsPerInstr();
   auto warpsPerCTA = getParent().cast<MfmaEncodingAttr>().getWarpsPerCTA();
   if (getOpIdx() == 0)
     return {
-        std::max<int64_t>(1, operandShape[0] / (instrSize[0] * warpsPerCTA[0])),
-        std::max<int64_t>(1, operandShape[1] / instrSize[2])};
+        std::max<int64_t>(1, operandShape[0] / (operandTileShape[0] * warpsPerCTA[0])),
+        std::max<int64_t>(1, operandShape[1] / operandTileShape[1])};
   else {
     assert(getOpIdx() == 1);
-    return {std::max<int64_t>(1, operandShape[0] / instrSize[2]),
+    return {std::max<int64_t>(1, operandShape[0] / operandTileShape[0]),
             std::max<int64_t>(1, operandShape[1] /
-                                     (instrSize[1] * warpsPerCTA[1]))};
+                                     (operandTileShape[1] * warpsPerCTA[1]))};
   }
 }
 
@@ -727,7 +714,7 @@ unsigned DotOperandEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
     int warpsPerCTAM = mfmaParent.getWarpsPerCTA()[0];
     int warpsPerCTAN = mfmaParent.getWarpsPerCTA()[1];
     constexpr int waveSize = 64;
-    auto tileSize = getMFMAElemsPerThread(eltTy);
+    auto tileSize = getMFMAElemsPerInstr();
     auto rep = getMFMARep(shape, eltTy);
     return rep[0] * rep[1];
   }
@@ -948,12 +935,17 @@ Attribute MfmaEncodingAttr::parse(AsmParser &parser, Type type) {
     return {};
 
   unsigned nonKDim = 0;
+  unsigned kDim = 0;
   SmallVector<unsigned, 2> warpsPerCTA;
   bool isTransposed;
 
   for (const NamedAttribute &attr : dict) {
     if (attr.getName() == "nonKDim") {
       if (parseUInt(parser, attr, nonKDim, "nonKDim").failed())
+        return {};
+    }
+    if (attr.getName() == "kDim") {
+      if (parseUInt(parser, attr, kDim, "kDim").failed())
         return {};
     }
     if (attr.getName() == "warpsPerCTA") {
@@ -966,7 +958,7 @@ Attribute MfmaEncodingAttr::parse(AsmParser &parser, Type type) {
   }
 
   return parser.getChecked<MfmaEncodingAttr>(parser.getContext(), nonKDim,
-                                             warpsPerCTA, isTransposed);
+                                             kDim, warpsPerCTA, isTransposed);
 }
 
 void MfmaEncodingAttr::print(AsmPrinter &printer) const {

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -114,9 +114,10 @@ SmallVector<unsigned, 2> warpsPerTileMI200(triton::DotOp dotOp,
 }
 
 class BlockedToMFMA : public mlir::RewritePattern {
+  int mfmaVersion;
 public:
-  BlockedToMFMA(mlir::MLIRContext *context)
-      : mlir::RewritePattern(triton::DotOp::getOperationName(), 2, context) {}
+  BlockedToMFMA(mlir::MLIRContext *context, int mfmaVersion)
+      : mlir::RewritePattern(triton::DotOp::getOperationName(), 2, context), mfmaVersion(mfmaVersion) {}
 
   bool isChainDot(triton::DotOp &dotOp) const {
     auto filter = [&dotOp](Operation *op) {
@@ -128,6 +129,27 @@ public:
         return true;
     }
     return false;
+  }
+
+  std::pair<int64_t, int64_t> chooseMfmaDimensions(triton::DotOp dot, int mfmaVersion) const {
+    int64_t nonKDim = 32;
+    int64_t kDim = -1;
+    auto opType = dot.getA().getType().cast<RankedTensorType>();
+    auto elemType = opType.getElementType();
+    if (elemType.isF32())
+      kDim = 2;
+    if (elemType.isF16())
+      kDim = 8;
+    if (elemType.isBF16()) {
+      if (mfmaVersion == 1)
+        kDim = 4;
+      if (mfmaVersion == 2)
+        kDim = 8;
+    }
+    if (elemType.isInteger(8))
+      kDim = 8;
+    assert(kDim != -1);
+    return {nonKDim, kDim};
   }
 
   mlir::LogicalResult
@@ -157,13 +179,13 @@ public:
 
     triton::gpu::MfmaEncodingAttr mfmaEnc;
 
-    int64_t nonKDim = 32;
+    auto [nonKDim, kDim] = chooseMfmaDimensions(dotOp, mfmaVersion);
 
     auto warpsPerTile = warpsPerTileMI200(dotOp, retShape, numWarps);
 
     bool isTransposed = isChainDot(dotOp);
     mfmaEnc = triton::gpu::MfmaEncodingAttr::get(
-        oldRetType.getContext(), nonKDim, warpsPerTile, isTransposed);
+        oldRetType.getContext(), nonKDim, kDim, warpsPerTile, isTransposed);
 
     auto newRetType =
         RankedTensorType::get(retShape, oldRetType.getElementType(), mfmaEnc);
@@ -352,7 +374,10 @@ public:
 
     mlir::RewritePatternSet patterns(context);
 #ifdef USE_ROCM
-    patterns.add<::BlockedToMFMA>(context);
+    if (computeCapability == 1 || computeCapability == 2) {
+      int mfmaVersion = 1;
+      patterns.add<::BlockedToMFMA>(context, mfmaVersion);
+    }
 #else
     patterns.add<::BlockedToMMA>(context, computeCapability);
 #endif

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -185,7 +185,7 @@ public:
 
     bool isTransposed = isChainDot(dotOp);
     mfmaEnc = triton::gpu::MfmaEncodingAttr::get(
-        oldRetType.getContext(), nonKDim, kDim, warpsPerTile, isTransposed);
+        oldRetType.getContext(), nonKDim, warpsPerTile, isTransposed);
 
     auto newRetType =
         RankedTensorType::get(retShape, oldRetType.getElementType(), mfmaEnc);
@@ -207,10 +207,10 @@ public:
 
     auto newAType = RankedTensorType::get(
         oldAType.getShape(), oldAType.getElementType(),
-        triton::gpu::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc));
+        triton::gpu::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, kDim));
     auto newBType = RankedTensorType::get(
         oldBType.getShape(), oldBType.getElementType(),
-        triton::gpu::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc));
+        triton::gpu::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc, kDim));
     a = rewriter.create<triton::gpu::ConvertLayoutOp>(a.getLoc(), newAType, a);
     b = rewriter.create<triton::gpu::ConvertLayoutOp>(b.getLoc(), newBType, b);
     auto newDot = rewriter.create<triton::DotOp>(

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -375,7 +375,7 @@ public:
     mlir::RewritePatternSet patterns(context);
 #ifdef USE_ROCM
     if (computeCapability == 1 || computeCapability == 2) {
-      int mfmaVersion = 1;
+      int mfmaVersion = computeCapability;
       patterns.add<::BlockedToMFMA>(context, mfmaVersion);
     }
 #else

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2320,7 +2320,7 @@ def test_dot_mfma_vector_load(vec_size, swizzle, transposeA, transposeB):
 """ + """
 module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
   tt.func public @kernel_0d1d2d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
-    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
     %cst_0 = arith.constant dense<32> : tensor<32x1xi32, #blocked>
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
     %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<32x1xi32, #blocked>
@@ -2342,12 +2342,12 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
     %17 = tt.addptr %16, %8 : tensor<32x32x!tt.ptr<f16>, #blocked>, tensor<32x32xi32, #blocked>
     %18 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
     %19 = triton_gpu.convert_layout %18 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared1>
-    %20 = triton_gpu.convert_layout %19 : (tensor<32x32xf16, #shared1>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>}>>
+    %20 = triton_gpu.convert_layout %19 : (tensor<32x32xf16, #shared1>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>, kWidth=8}>>
     %21 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32xf16, #blocked>
     %22 = triton_gpu.convert_layout %21 : (tensor<32x32xf16, #blocked>) -> tensor<32x32xf16, #shared2>
-    %23 = triton_gpu.convert_layout %22 : (tensor<32x32xf16, #shared2>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>}>>
-    %24 = tt.dot %20, %23, %cst {allowTF32 = false} : tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>}>> * tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>}>> -> tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>>
-    %25 = triton_gpu.convert_layout %24 : (tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>>) -> tensor<32x32xf32, #blocked>
+    %23 = triton_gpu.convert_layout %22 : (tensor<32x32xf16, #shared2>) -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>, kWidth=8}>>
+    %24 = tt.dot %20, %23, %cst {allowTF32 = false} : tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>, kWidth=8}>> * tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [4, 1], isTransposed = false}>, kWidth=8}>> -> tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>
+    %25 = triton_gpu.convert_layout %24 : (tensor<32x32xf32, #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [4, 1], isTransposed = false}>>) -> tensor<32x32xf32, #blocked>
     %26 = arith.truncf %25 : tensor<32x32xf32, #blocked> to tensor<32x32xf16, #blocked>
     tt.store %17, %26 {cache = 1 : i32, evict = 1 : i32} : tensor<32x32xf16, #blocked>
     tt.return

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1281,7 +1281,7 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                                                       ('float16', 'float16'),
                                                       ('float16', 'float32'),
                                                       ('float32', 'float32')]]
-                         if not triton.language.semantic.gpu_has_mfma() else
+                         if triton.language.semantic.gpu_matrix_core_version() == 0 else
                          # MFMA Test Dot tests
                          [(*shape, 2, False, False, epilogue, allow_tf32, in_dtype, out_dtype)
                           for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16)]

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2248,14 +2248,13 @@ class MmaLayout:
 
 
 class MfmaLayout:
-    def __init__(self, non_k_dim, k_dim, warps_per_cta, isTransposed):
+    def __init__(self, non_k_dim, warps_per_cta, isTransposed):
         self.non_k_dim = str(non_k_dim)
-        self.k_dim = str(k_dim)
         self.warps_per_cta = str(warps_per_cta)
         self.isTransposed = str(isTransposed).lower()
 
     def __str__(self):
-        return f"#triton_gpu.mfma<{{nonKDim = {self.non_k_dim}, kDim = {self.k_dim}, warpsPerCTA = {self.warps_per_cta}, isTransposed = {self.isTransposed}}}>"
+        return f"#triton_gpu.mfma<{{nonKDim = {self.non_k_dim}, warpsPerCTA = {self.warps_per_cta}, isTransposed = {self.isTransposed}}}>"
 
 
 class BlockedLayout:
@@ -2474,8 +2473,8 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
 
 if torch.version.hip is not None and _get_warp_size() == 64:
     layouts = [
-        MfmaLayout(non_k_dim=32, k_dim=2, warps_per_cta=[4, 1], isTransposed=True),
-        MfmaLayout(non_k_dim=32, k_dim=2, warps_per_cta=[2, 2], isTransposed=False),
+        MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1], isTransposed=True),
+        MfmaLayout(non_k_dim=32, warps_per_cta=[2, 2], isTransposed=False),
     ]
     shapes = [[128, 32], [128, 128], [32, 128], [64, 64]]
 else:
@@ -2557,7 +2556,7 @@ def test_reduce_layouts(M, N, src_layout, axis, device='cuda'):
 
 @pytest.mark.parametrize("shape", [(64, 64)])
 @pytest.mark.parametrize("dtype", ['float16'])
-@pytest.mark.parametrize("src_layout", [MfmaLayout(non_k_dim=32, k_dim=2, warps_per_cta=[2, 1], isTransposed=False), MfmaLayout(non_k_dim=32, k_dim=2, warps_per_cta=[4, 1], isTransposed=True)])
+@pytest.mark.parametrize("src_layout", [MfmaLayout(non_k_dim=32, warps_per_cta=[2, 1], isTransposed=False), MfmaLayout(non_k_dim=32, warps_per_cta=[4, 1], isTransposed=True)])
 @pytest.mark.parametrize("dst_layout", [BlockedLayout([1, 4], [4, 16], [1, 1], [1, 0])])
 def test_make_range(dtype, shape, src_layout, dst_layout, device='cuda'):
     ir = f"""

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -86,8 +86,9 @@ def optimize_ttgir(mod, num_stages, arch):
     if _is_cuda(arch):
         pm.add_tritongpu_accelerate_matmul_pass(arch)
     # TODO change interface of accelerate_matmul_pass
-    if is_hip() and gpu_has_mfma():
-        pm.add_tritongpu_accelerate_matmul_pass(80)
+    if is_hip():
+        matrix_core_version = gpu_matrix_core_version()
+        pm.add_tritongpu_accelerate_matmul_pass(matrix_core_version)
     pm.add_tritongpu_remove_layout_conversions_pass()
     pm.add_tritongpu_optimize_dot_operands_pass()
     if num_stages == 0 and is_hip() and gpu_has_mfma():
@@ -330,7 +331,7 @@ def is_hip():
         raise ImportError("Triton requires PyTorch to be installed")
     return torch.version.hip is not None
 
-from ..language.semantic import gpu_has_mfma
+from ..language.semantic import gpu_matrix_core_version
 
 def get_architecture_descriptor(capability):
     try:

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1186,9 +1186,9 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0]}>
-#mfma0 = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA=[1,1], isTranspose=false}>
-#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0}>
-#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0}>
+#mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0, kWidth = 8}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0, kWidth = 8}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_dot_mfma
   tt.func @convert_dot_mfma(%A: tensor<32x32xf16, #blocked0>, %B: tensor<32x32xf16, #blocked0>) {
@@ -1210,7 +1210,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, kDim = 2, warpsPerCTA = [2, 2], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block
@@ -1360,9 +1360,9 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [2, 2], isTransposed=false}>
-#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma}>
-#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = 8}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = 8}>
 module attributes {"triton_gpu.num-warps" = 4 : i32} {
   // CHECK-LABEL: matmul_kernel_dot_operand_layout_gcn
   tt.func @matmul_kernel_dot_operand_layout_gcn(%ptr:!tt.ptr<f32> {tt.divisibility = 16 : i32},

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1186,7 +1186,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0]}>
-#mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma0 = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
@@ -1210,7 +1210,7 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, kDim = 2, warpsPerCTA = [2, 2], isTranspose=false}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block
@@ -1360,7 +1360,7 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
+#mfma = #triton_gpu.mfma<{nonKDim = 32, kDim = 8, warpsPerCTA = [2, 2], isTransposed=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma}>
 module attributes {"triton_gpu.num-warps" = 4 : i32} {


### PR DESCRIPTION
This PR makes use of mfma_f32_32x32x4bf16 instruction, available on MI100.