### PR TITLE
[MFMA] [FA] Keep bf16 results of FA dot operations in registers 

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -228,7 +228,7 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   return mfmaLayout.getWarpsPerCTA()[1] == 1 &&
          dotOperandLayout.getOpIdx() == 0 &&
          dotOperandLayout.getParent() == mfmaLayout &&
-         mfmaLayout.getIsTransposed() && srcTy.getElementType().isF16();
+         mfmaLayout.getIsTransposed() && (srcTy.getElementType().isF16() || srcTy.getElementType().isBF16());
 }
 #endif
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -666,8 +666,9 @@ private:
       SmallVector<Value> vecVals;
       SmallVector<Type> types;
       auto elemSize = elemTy.getIntOrFloatBitWidth();
-      // TODO: Support types other than float16.
-      assert(type::isFloat(elemTy) && elemSize == 16);
+      // TODO: Support types other than float16 and
+      // bf16 (represented as int16 in llvm ir).
+      assert((type::isFloat(elemTy) || type::isInt(elemTy)) && elemSize == 16);
       unsigned vecSize = 4;
       Type vecTy = vec_ty(elemTy, vecSize);
       types = SmallVector<Type>(elems / vecSize, vecTy);


### PR DESCRIPTION
This PR enables optimization for keeping bf16 values in registers between dot operations.