### PR TITLE
[NFC] Rename `MMAv2kWidth` to `kWidth`

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -627,7 +627,7 @@ section 9.7.13.4.1 for more details.
     ins
     "unsigned":$opIdx,
     "Attribute":$parent,
-    "unsigned":$MMAv2kWidth
+    "unsigned":$kWidth
   );
 
   let builders = [
@@ -639,16 +639,16 @@ section 9.7.13.4.1 for more details.
       if (!parentAttr || !parentAttr.isAmpere())
         return $_get(context, opIdx, parent, 0);
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
-      unsigned MMAv2kWidth = 32 / bitwidth;
-      return $_get(context, opIdx, parent, MMAv2kWidth);
+      unsigned kWidth = 32 / bitwidth;
+      return $_get(context, opIdx, parent, kWidth);
     }]>,
 
     // Specially for MFMA(MI100/MI200)
     AttrBuilder<(ins "unsigned":$opIdx,
                      "Attribute":$parent), [{
       assert(llvm::isa<MfmaEncodingAttr>(parent));
-      unsigned MMAv2kWidth = 0; // unused for MFMA ops
-      return $_get(context, opIdx, parent, MMAv2kWidth);
+      unsigned kWidth = 0; // unused for MFMA ops
+      return $_get(context, opIdx, parent, kWidth);
     }]>
   ];
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
@@ -549,7 +549,7 @@ Value loadArg(ConversionPatternRewriter &rewriter, Location loc, Value tensor,
   int matShapeM = 8, matShapeN = 8, matShapeK = 2 * 64 / bitwidth;
 
   auto numRep = encoding.getMMAv2Rep(tensorTy.getShape(), bitwidth);
-  int kWidth = encoding.getMMAv2kWidth();
+  int kWidth = encoding.getKWidth();
 
   auto warpsPerCTA = mmaLayout.getWarpsPerCTA();
   Value warp = udiv(thread, i32_val(32));

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1097,7 +1097,7 @@ void DotOperandEncodingAttr::print(mlir::AsmPrinter &printer) const {
   printer << "<{"
           << "opIdx = " << getOpIdx() << ", parent = " << getParent();
   if (mmaParent && mmaParent.isAmpere())
-    printer << ", kWidth = " << getMMAv2kWidth();
+    printer << ", kWidth = " << getKWidth();
   printer << "}>";
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -203,8 +203,8 @@ LogicalResult Prefetcher::initialize() {
     auto bType = dot.getB().getType().cast<RankedTensorType>();
     auto aEnc = aType.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
     auto bEnc = bType.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
-    int aKWidth = aEnc.getMMAv2kWidth();
-    int bKWidth = bEnc.getMMAv2kWidth();
+    int aKWidth = aEnc.getKWidth();
+    int bKWidth = bEnc.getKWidth();
     assert(aKWidth == bKWidth);
 
     auto kSize = aType.getShape()[1];


### PR DESCRIPTION
We would like to reuse the `MMAv2kWidth` parameter in dotOperandEncodingAttr to represent the number of elements each thread loads for one mfma instruction, a.k.a `k_base`. 
Upstream PR: https://github.com/openai/triton/pull/2119