### PR TITLE
[WIP][Optimization] Eliminate transop

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1090,6 +1090,17 @@ Attribute DotOperandEncodingAttr::parse(AsmParser &parser, Type type) {
   auto mmaParent = parent.dyn_cast<MmaEncodingAttr>();
   unsigned kWidth = 0;
   Attribute _kWidth = attrs.get("kWidth");
+#ifdef USE_ROCM
+  if (_kWidth) {
+    auto mfmaParent = parent.dyn_cast<MfmaEncodingAttr>();
+    if (!mfmaParent) {
+      auto loc = parser.getNameLoc();
+      parser.emitError(loc, "kWidth only supported for MFMA parent");
+      return Attribute();
+    }
+    kWidth = _kWidth.cast<IntegerAttr>().getInt();
+  }
+#else
   if (_kWidth) {
     if (!mmaParent || mmaParent.isVolta()) {
       auto loc = parser.getNameLoc();
@@ -1098,6 +1109,7 @@ Attribute DotOperandEncodingAttr::parse(AsmParser &parser, Type type) {
     }
     kWidth = _kWidth.cast<IntegerAttr>().getInt();
   }
+#endif
   return parser.getChecked<DotOperandEncodingAttr>(parser.getContext(), opIdx,
                                                    parent, kWidth);
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -122,8 +122,10 @@ public:
     auto filter = [&dotOp](Operation *op) {
       return op->getParentRegion() == dotOp->getParentRegion();
     };
-    auto slices = mlir::getSlice(dotOp, filter);
-    for (Operation *op : slices) {
+    SetVector<Operation *> backwardSlice;
+    mlir::getBackwardSlice(dotOp.getD(), &backwardSlice, filter, false);
+    bool foundDot = false;
+    for (Operation *op : backwardSlice) {
       if (isa<triton::DotOp>(op) && (op != dotOp))
         return true;
     }

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeConversions.cpp
@@ -51,10 +51,7 @@ public:
 #ifdef USE_ROCM
       if (auto srcMfmaEncoding =
               srcEncoding.dyn_cast<triton::gpu::MfmaEncodingAttr>()) {
-
-        if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
-            srcMfmaEncoding.getIsTransposed() &&
-            dstDotOp.getParent() == srcMfmaEncoding)
+        if (isMfmaToDotShortcut(srcType, dstType))
           return;
       }
 #endif


### PR DESCRIPTION
This PR introduces:
- changes in mfma dot transpose heuristics
- EliminateMFMATrans pattern that replaces transOp with convertLayoutOp
- SimplifyMFMADotOpConversions pattern which looks for chains of convertLayoutOps and replaces them with one op