### PR TITLE
Remove redundant fp32->fp16 conversion in FA

### DIFF
--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -90,7 +90,7 @@ def _fwd_kernel(
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float16)
         if IS_CAUSAL:
             qk = tl.where(P_SEQ + offs_m[:, None] >= (start_n + offs_n[None, :]), qk, float("-inf"))
-        qk += tl.dot(q, k, out_dtype=tl.float16)
+        qk += tl.dot(q, k)
         # -- compute scaling constant ---
         m_i_new = tl.maximum(m_i, tl.max(qk, 1))
         alpha = tl.math.exp2(m_i - m_i_new)


### PR DESCRIPTION
Reverse change introduced by upstream commit https://github.com/openai/triton/commit/5162871c6cae01a8508a309cf21a8e6b68a4c091.
This commit converts result of first dot from fp32 to fp16, but immediately after, result is converted back
to fp32 for softmax. 
Triton IR generated:
      %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x64xf16, #mfma>
      %94 = arith.truncf %93 : tensor<128x64xf32, #mfma> to tensor<128x64xf16, #mfma>
      %95 = arith.addf %94, %cst_0 : tensor<128x64xf16, #mfma>
      %96 = arith.extf %95 : tensor<128x64xf16, #mfma> to tensor<128x64xf32, #mfma>

TODO: Investigate whether we can perform softmax in fp16.