### PR TITLE
[GEMM] [Tuning] Parameterize mfma type

### DIFF
--- a/scripts/amd/gemm/tune_gemm.py
+++ b/scripts/amd/gemm/tune_gemm.py
@@ -45,10 +45,7 @@ def get_full_tuning_space():
 def prune_configs(M, N, K, configs):
     pruned_configs = []
 
-    ## TODO: improve how we deal with mfma16 vs mfma32
-    ## after it becomes a tuning parameter
-    mfma_type = os.getenv('MFMA_TYPE')
-    if mfma_type == '16':
+    if M < 32 or N < 32:
         mfma = 16
     else:
         mfma = 32


### PR DESCRIPTION
Remove the request for `MFMA_TYPE` and use the same [heuristics](https://github.com/ROCmSoftwarePlatform/triton/blob/20f316b19a891a504df53199df21a1407ad4b304/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp#L98) as https://github.com/ROCmSoftwarePlatform/triton/pull/352 to determine mfma type based on M/N size.

Need to wait for https://github.com/ROCmSoftwarePlatform/triton/pull/352 to merge first.