### PR TITLE
set correct arch info for unit test

### DIFF
--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2525,6 +2525,16 @@ class SharedLayout:
         return f"#{GPU_DIALECT}.shared<{{vec={self.vec}, perPhase={self.per_phase}, maxPhase={self.max_phase}, order={self.order}, CTAsPerCGA={self.ctas_per_cga}, CTASplitNum={self.cta_split_num}, CTAOrder={self.cta_order}}}>"
 
 
+def get_gpu_name():
+    arch_info = _triton.get_arch_info()
+    gfx_arch_details = re.search('amd.*', arch_info)
+    if gfx_arch_details is None:
+        return 0
+    gfx_arch_details = gfx_arch_details.group(0).strip().split('--')
+    gpu_name = gfx_arch_details[1].split(':')[0]
+    return gpu_name
+
+
 @pytest.mark.parametrize("vec_size", [2, 4])
 @pytest.mark.parametrize("swizzle", [True, False])
 @pytest.mark.parametrize("transposeA", [True, False])
@@ -2617,7 +2627,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
         f.write(ir)
         f.flush()
         arch_triple = "amdgcn-amd-amdhsa"
-        arch_name = "gfx90a"
+        arch_name = get_gpu_name()
         features = ""
         warp_size = 64
         capabilities = [arch_triple, arch_name, features, warp_size]

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2526,12 +2526,8 @@ class SharedLayout:
 
 
 def get_gpu_name():
-    arch_info = _triton.get_arch_info()
-    gfx_arch_details = re.search('amd.*', arch_info)
-    if gfx_arch_details is None:
-        return 0
-    gfx_arch_details = gfx_arch_details.group(0).strip().split('--')
-    gpu_name = gfx_arch_details[1].split(':')[0]
+    capabilities = triton.compiler.compiler.get_architecture_descriptor(None)
+    gpu_name = capabilities[1].split(':')[0]
     return gpu_name
 
 
@@ -2543,6 +2539,9 @@ def test_dot_mfma_vector_load(vec_size, swizzle, transposeA, transposeB):
     # we can not do vector loads in this case
     if transposeA and not transposeB:
         pytest.skip()
+
+    if triton.language.semantic.gpu_matrix_core_version() == 0:
+        pytest.skip("mfma is not available on hardware")
 
     # source code for following ttgir:
     # @triton.jit


### PR DESCRIPTION
This PR is for the failure of test `test_dot_mfma_vector_load`. Reason is the arch name is always set to `gfx90a`. Need to write a function to get the correct gpu_name, then it can pass on all GPUs.