### PR TITLE
remove unnecessary arch names

### DIFF
--- a/python/triton/third_party/hip/hip_backend.py
+++ b/python/triton/third_party/hip/hip_backend.py
@@ -289,10 +289,6 @@ def get_amdgpu_arch_fulldetails():
         arch_name = arch_name_features[0]
         arch_features = ""
 
-        if (len(arch_name_features) == 3):
-            arch_features = "+" + re.search('\\w+', arch_name_features[1]).group(0) + ","\
-                            "-" + re.search('\\w+', arch_name_features[2]).group(0)
-
         # overwrite if provided by user
         gfx_arch = os.environ.get('MI_GPU_ARCH', arch_name)
         if gfx_arch is None:


### PR DESCRIPTION
The lines here can cause the following errors on MI300 node. I made these change (removed these lines) before, but after moving to the third-party folder, these lines are back, so make a change again.

RuntimeError: Triton Error [HIP]:  Code: 400, Messsage: invalid resource handle
