### PR TITLE
Benchmark FA fwd on 2 GCDs

### DIFF
--- a/python/perf-kernels/06-fused-attention-fwd-transV.py
+++ b/python/perf-kernels/06-fused-attention-fwd-transV.py
@@ -1,0 +1,305 @@
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention v2 algorithm from Tri Dao (https://tridao.me/publications/flash2/flash2.pdf)
+
+Extra Credits:
+- Original flash attention paper (https://arxiv.org/abs/2205.14135)
+- Rabe and Staats (https://arxiv.org/pdf/2112.05682v2.pdf)
+- Adam P. Goucher for simplified vector math
+
+"""
+
+import pytest
+import torch
+import sys
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def max_fn(x, y):
+    return tl.math.max(x, y)
+
+
+@triton.jit
+def _attn_fwd(
+    Q, K, V, sm_scale, M, Out,
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vn, stride_vk,
+    stride_oz, stride_oh, stride_om, stride_on,
+    Z, H,
+    N_CTX,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    pre_load_v: tl.constexpr,
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    qkv_offset = off_hz * stride_qh
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + qkv_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0)
+    )
+    K_block_ptr = tl.make_block_ptr(
+        base=K + qkv_offset,
+        shape=(BLOCK_DMODEL, N_CTX),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
+        order=(0, 1)
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + qkv_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_vk, stride_vn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
+        order=(0, 1)
+    )
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    q = tl.load(Q_block_ptr)
+    # it's even better to multiply the qk_scale and convert to f16
+    # than doing it inside the loop
+    # So conversion is quite cheap
+    q = (q * qk_scale).to(tl.float16)
+    lo, hi = 0, N_CTX
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        # -- compute qk ----
+        k = tl.load(K_block_ptr)
+        if pre_load_v:
+            v = tl.load(V_block_ptr)
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk += tl.dot(q, k)
+        #qk = (qk * qk_scale)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk = qk - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        # -- update output accumulator --
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        if not pre_load_v:
+            v = tl.load(V_block_ptr)
+        acc += tl.dot(p.to(tl.float16), v)
+        # -- update m_i and l_i
+        l_ij = tl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        # update m_i and l_i
+        m_i = m_ij
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+    acc = acc / l_i[:, None]
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out + qkv_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0)
+    )
+    tl.store(O_block_ptr, acc.to(Out.type.element_ty))
+
+
+empty = torch.empty(128, device="cuda")
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, sm_scale):
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-2]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        if torch.version.hip is None:
+            BLOCK_M = 128
+            BLOCK_N = 64 if Lk <= 64 else 32
+            num_stages = 4 if Lk <= 64 else 3
+            num_warps = 4 if Lk <= 64 else 8
+
+        ## hardcoded best perf_configs for MI250
+        if Lk == 64:
+            ## D_HEAD = 64
+            BLOCK_M = 128
+            BLOCK_N = 64
+            waves_per_eu = 3
+            num_warps = 4
+            num_stages = 1
+            ## causal=False likes to pre load v but causal=True does not
+            pre_load_v = False if causal else True
+        else:
+            ## D_HEAD = 128
+            BLOCK_M = 128
+            BLOCK_N = 128
+            waves_per_eu = 2
+            num_warps = 4
+            num_stages = 1
+            pre_load_v = False
+
+        grid = ( triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
+        M = torch.empty((q.shape[0] * q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+
+        _attn_fwd[grid](
+            q, k, v, sm_scale, M, o,
+            q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+            k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+            v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+            o.stride(0), o.stride(1), o.stride(2), o.stride(3),
+            q.shape[0], q.shape[1],
+            N_CTX=q.shape[2],
+            BLOCK_DMODEL=Lk,
+            BLOCK_M = BLOCK_M,
+            BLOCK_N = BLOCK_N,
+            waves_per_eu = waves_per_eu,
+            num_warps = num_warps,
+            num_stages = num_stages,
+            pre_load_v = pre_load_v,
+        )
+
+        return o
+
+
+attention = _attention.apply
+
+
+@pytest.mark.parametrize('Z, H, N_CTX, D_HEAD',
+                         [(4, 48, 1024, 64),
+                          (4, 48, 2048, 64),
+                          (4, 48, 4096, 64),
+                          (4, 48, 1024, 128),
+                          (4, 48, 2048, 128),
+                          (4, 48, 4096, 128),
+                          #(4, 48, 8192, 64),
+                          #(4, 48, 16384, 64)
+                          ])
+def test_op_fwd(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = (
+        torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    )
+    v = (
+        torch.empty((Z, H, D_HEAD, N_CTX), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    )
+    sm_scale = 0.5
+    dout = torch.randn_like(q)
+    # reference implementation
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    p = torch.softmax(p.float(), dim=-1).half()
+    ref_out = torch.matmul(p, v.transpose(2,3))
+    # triton implementation
+    tri_out = attention(q, k, v, sm_scale)
+    # compare
+    assert torch.allclose(ref_out, tri_out, atol=1e-2, rtol=0)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# vary seq length for fixed head and batch=4
+configs = []
+for mode in ['fwd']:
+    for D_HEAD in [128]:
+        for causal in [False]:
+            configs.append(triton.testing.Benchmark(
+                x_names=['BATCH', 'H','N_CTX'],
+                x_vals=[(16, 16, 1024),
+                        (8, 16, 2048),
+                        (4, 16, 4096),
+                        (2, 16, 8192),
+                        (1, 16, 16384),
+                        (4, 48, 1024),
+                        (4, 48, 2048),
+                        (4, 48, 4096),
+                        (4, 48, 8192),
+                        (4, 48, 16384),
+                        ],
+                line_arg='provider',
+                line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+                line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
+                styles=[('red', '-'), ('blue', '-')],
+                ylabel='ms',
+                plot_name=f'fused-attention-d{D_HEAD}-{mode}-causal={causal}',
+                args={
+                    'D_HEAD': D_HEAD,
+                    'dtype': torch.float16,
+                    'mode': mode,
+                    'causal': causal})
+            )
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, D_HEAD, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 25
+    rep = 100
+    if provider == "triton":
+        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        v = torch.randn((BATCH, H, D_HEAD, N_CTX), dtype=dtype, device="cuda", requires_grad=True)
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, sm_scale)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+        if FLASH_VER == 1:
+            lengths = torch.full((BATCH,), fill_value=N_CTX, device=device)
+            cu_seqlens = torch.zeros((BATCH + 1,), device=device, dtype=torch.int32)
+            cu_seqlens[1:] = lengths.cumsum(0)
+            qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+            fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+        elif FLASH_VER == 2:
+            fn = lambda: flash_attn_func(qkv, causal=causal)
+        else:
+            raise ValueError(f'unknown {FLASH_VER = }')
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul = 2. * BATCH * H * N_CTX * N_CTX * D_HEAD
+    total_flops = 2 * flops_per_matmul
+    return total_flops / ms * 1e-9
+
+
+def main():
+    bench_flash_attention.run(save_path='.', print_data=True)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/amd/benchmark_flash_attention.py
+++ b/scripts/amd/benchmark_flash_attention.py
@@ -1,0 +1,71 @@
+import argparse
+import sys
+import git
+
+
+git_repo = git.Repo('.', search_parent_directories=True)
+git_root = git_repo.git.rev_parse("--show-toplevel")
+sys.path.insert(0, git_root+'/python/perf-kernels')
+FA = __import__('06-fused-attention-fwd-transV')
+
+attention = FA._attention.apply
+
+import torch
+
+def benchmark_FA(BATCH, H, N_CTX, D_HEAD, causal, rep, mode, dtype=torch.float16, device="cuda"):
+    q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+    k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+    v = torch.randn((BATCH, H, D_HEAD, N_CTX), dtype=dtype, device="cuda", requires_grad=True)
+    sm_scale = 1.3
+    split_kernel = True
+    if mode == "bwd":
+        causal=True
+    fn = lambda: attention(q, k, v, sm_scale)
+
+    o = fn()
+
+    if mode == "bwd":
+        do = torch.randn_like(o)
+        o.backward(do, retain_graph=True)
+
+    for i in range(rep):
+        if mode == "bwd":
+            o = fn()
+            o.backward(do, retain_graph=True)
+        if mode == "fwd":
+            fn()
+
+    torch.cuda.synchronize()
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        prog="FA benchmarking",
+        description="benchmark FA fwd and bwd with 2 GPUs",
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-bs", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-nheads", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-d", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-seqlen", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-rep", type=int, default=argparse.SUPPRESS)
+    parser.add_argument("-mode", type=str, default=argparse.SUPPRESS)
+
+    parsed_args = parser.parse_args(args)
+
+    bs = parsed_args.bs
+    nheads = parsed_args.nheads
+    d = parsed_args.d
+    seqlen = parsed_args.seqlen
+    rep = parsed_args.rep
+    mode = parsed_args.mode
+
+    benchmark_FA(bs, nheads, seqlen, d, False, rep, mode)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/amd/run_2gcd.sh
+++ b/scripts/amd/run_2gcd.sh
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+
+## A simple script to run two flash attention kernels
+## with batch2-nheads48-d64 on two GPUs in parallel
+## $1: mode, fwd or bwd
+
+if [[ $# -eq 0 ]];then
+    echo "Must specify mode, fwd or bwd"
+    exit
+fi
+
+TRITON_DIR=$(git rev-parse --show-toplevel)
+
+BENCHMARK_DRIVER=${TRITON_DIR}/scripts/amd/benchmark_flash_attention.py
+
+bs=2
+nheads=48
+mode=$1
+
+declare -A repA
+
+if [[ $mode == "fwd" ]];then
+    repA[1024]=160000
+    repA[2048]=80000
+    repA[4096]=40000
+    repA[8192]=20000
+    repA[16384]=10000
+else
+    repA[1024]=10000
+    repA[2048]=10000
+    repA[4096]=2500
+    repA[8192]=600
+    repA[16384]=100
+fi
+
+for d in 128 64
+do
+    echo "Benchmarking FA $mode kernel with D = $d on 2 GCDs"
+    for seqlen in 1024 2048  4096 8192 16384
+    do
+        rep=${repA[$seqlen]}
+        args="-bs $bs -nheads $nheads -d $d -seqlen $seqlen -mode $mode"
+
+        ## pre-compile the kernel
+        python ${BENCHMARK_DRIVER} $args -rep 1
+
+        start_time=$(date +%s.%3N)
+        export ROCR_VISIBLE_DEVICES=0
+        python ${BENCHMARK_DRIVER} $args -rep $rep &
+
+        export ROCR_VISIBLE_DEVICES=1
+        python ${BENCHMARK_DRIVER} $args -rep $rep
+
+        wait
+        end_time=$(date +%s.%3N)
+
+        # elapsed time with millisecond resolution
+        # keep three digits after floating point.
+        elapsed=$(echo "scale=3; $end_time - $start_time" | bc)
+        # Convert second to tflops
+        if [[ $mode == "fwd" ]];then
+            tflops=$(echo "scale=2; 8*$seqlen*$seqlen*$bs*$nheads*$d*$rep/$elapsed/1000000000000" | bc)
+        else
+            tflops=$(echo "scale=2; 7*4*0.5*$seqlen*$seqlen*$bs*$nheads*$d*$rep/$elapsed/1000000000000" | bc)
+        fi
+        echo "$seqlen  $tflops tflops $elapsed s"
+
+    done
+done


### PR DESCRIPTION
This PR supersedes https://github.com/ROCmSoftwarePlatform/triton/pull/307
The benchmark script uses a standalone FA fwd implementation.