### PR TITLE
Split k mm fix

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -371,6 +371,7 @@ verbose = False
     triton.testing.Benchmark(
         x_names=['M', 'N', 'K'],  # Argument names to use as an x-axis for the plot
         x_vals=[
+            (32, 32, 1026),
             (1024, 1024, 1024),
             (2048, 2048, 2048),
             (4096, 4096, 4096),


### PR DESCRIPTION
@scxiao @wenchenvincent @jayfurmanek @vgokhale 

While @scxiao mentioned we need adapt our autune system to enable SPLIT_K working properly, Jason suggest I should make a pull request for all to review where we should start with. 

The current changes have been summarized below:

./script/amd/gemm/matmul.py

 Fixing SPLIT_K matmul

    - add pytest coverage when using SPLIT_K.

    - add maxloc function to print out the max value discrepancy

    -  fix output matrix initialization issue

    - change the leaky_relu function to be same with torch.nn.functional.leaky_relu, and add pytest coverage when using activation leaky_relu

./python/tutorials/03-matrix-multiplication.py
- change leaky_relu definition to be same with  torch.nn.functional.leaky_relu and add test coverage if doing fused matmul


    
    