### PR TITLE
Add a kernel to measure HBM bandwidth vs WGs

### DIFF
--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -1,0 +1,740 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
+
+import torch
+
+from ..common import _has_triton21, register_operator
+from .attn_bias import BlockDiagonalCausalWithOffsetPaddedKeysMask
+from .common import AttentionFwOpBase, Context, Inputs, check_lastdim_alignment_stride1
+
+
+def _strides(x: torch.Tensor, *stride_names: str):
+    assert x.ndim == len(stride_names)
+    return {f"stride_{s}": x.stride(i) for i, s in enumerate(stride_names)}
+
+
+if TYPE_CHECKING or _has_triton21():
+    import triton
+    import triton.language as tl
+
+    from xformers.triton.vararg_kernel import VAR_ARGS_ARRAY, unroll_varargs
+
+    @triton.jit
+    def _fwd_kernel_splitK(
+        Q,
+        K,
+        V,
+        sm_scale,
+        Out_splitK,  # [B, H, split_k, Mq, K]
+        Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+        Seq_len,
+        stride_qz,
+        stride_qm,
+        stride_qg,
+        stride_qh,
+        stride_qk,
+        stride_kz,
+        stride_kn,
+        stride_kg,
+        stride_kh,
+        stride_kk,
+        stride_vz,
+        stride_vn,
+        stride_vg,
+        stride_vh,
+        stride_vk,
+        stride_osk_zhg,
+        stride_osk_s,
+        stride_osk_m,
+        stride_osk_k,
+        stride_mzhg,
+        stride_m2,
+        stride_ms,
+        stride_mm,
+        Z,
+        N_CTX_Q,
+        N_CTX_K,
+        BLOCK_N_PER_SPLIT,
+        H: tl.constexpr,
+        G: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_DMODEL: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BOUNDS_CHECKS_N: tl.constexpr,
+        USE_SEQ_LEN: tl.constexpr,
+        PACKED_PER_VAL: tl.constexpr = 1,
+        N_GROUPS: tl.constexpr = 1,
+    ):
+        """This kernel can accept non-quantized or int4-quantized keys/values.
+        PACKED_PER_VAL determines the quantization type:
+            - PACKED_PER_VAL == 1 means no quantization
+            - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
+        For the quantized case K/V should be int32 tensors.
+        Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
+        Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
+        So K[B, H, M, :] has a form
+        [   quant_coef0, quant_coef1, ...|
+            group0_quant_value0, group0_quant_value1,... |
+            group1_quant_value0, group1_quant_value1,...]
+        where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
+
+        Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
+        before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
+        See how FwOp.apply does it below.
+        """
+        tl.static_assert(
+            (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
+            or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
+            f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
+            f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
+        )
+        tl.static_assert(
+            (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
+            "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
+        )
+
+        QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
+        PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
+        D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
+
+        start_m = tl.program_id(0)
+        off_zhg = tl.program_id(1)
+        off_z = off_zhg // (H * G)
+        off_h = (off_zhg // G) % H
+        off_g = off_zhg % G
+        splitk_idx = tl.program_id(2)
+
+        lo = splitk_idx * BLOCK_N_PER_SPLIT
+        if USE_SEQ_LEN:
+            kv_len = tl.load(Seq_len + off_z)
+        else:
+            kv_len = N_CTX_K
+        hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
+
+        Q_block_ptr = tl.make_block_ptr(
+            base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
+            shape=(N_CTX_Q, D_PER_GROUP),
+            strides=(stride_qm, stride_qk),
+            offsets=(start_m * BLOCK_M, 0),
+            block_shape=(BLOCK_M, D_PER_GROUP),
+            order=(1, 0),
+        )
+
+        k_base = K + off_h * stride_kh + off_z * stride_kz + off_g * stride_kg
+        # Additional shift by 1 along the last dimension in the quantized case, since
+        # the first element along that dim contains packed quantization coefficients.
+        K_block_ptr = tl.make_block_ptr(
+            base=k_base + stride_kk * QUANTIZED * N_GROUPS,
+            shape=(PACKED_D_PER_GROUP, hi),
+            strides=(stride_kk, stride_kn),
+            offsets=(0, lo),
+            block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+            order=(0, 1),
+        )
+        v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
+        V_block_ptr = tl.make_block_ptr(
+            base=v_base + stride_vk * QUANTIZED * N_GROUPS,
+            shape=(hi, PACKED_D_PER_GROUP),
+            strides=(stride_vn, stride_vk),
+            offsets=(lo, 0),
+            block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+            order=(1, 0),
+        )
+
+        if QUANTIZED:
+            # Pointers to quantization coefficients. Even those they are 1D,
+            # we have to use block pointers, since usual pointers
+            # don't support boundary checks
+            K_scale_shift_block_ptr = tl.make_block_ptr(
+                base=k_base,
+                shape=(1, hi),
+                strides=(stride_kk, stride_kn),
+                offsets=(0, lo),
+                block_shape=(1, BLOCK_N),
+                order=(0, 1),
+            )
+            V_scale_shift_block_ptr = tl.make_block_ptr(
+                base=v_base,
+                shape=(hi, 1),
+                strides=(stride_vn, stride_vk),
+                offsets=(lo, 0),
+                block_shape=(BLOCK_N, 1),
+                order=(1, 0),
+            )
+        else:
+            K_scale_shift_block_ptr = None
+            V_scale_shift_block_ptr = None
+
+        # initialize pointer to m and l
+        m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+        l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+        # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
+        # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
+        # This is a solution for Triton native lack of support for lists of tensors.
+        acc: "VAR_ARGS_ARRAY"  # noqa: F821
+
+        for i in range(len(acc)):  # noqa: F821
+            acc[i] = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
+        # scale sm_scale by log_2(e) and use
+        # 2^x instead of exp in the loop because CSE and LICM
+        # don't work as expected with `exp` in the loop
+        qk_scale = sm_scale * 1.44269504
+        # load q: it will stay in SRAM throughout
+        q: "VAR_ARGS_ARRAY"  # noqa: F821
+        for i in range(len(acc)):  # noqa: F821
+            q[i] = tl.load(  # noqa: F821
+                tl.advance(Q_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
+            )
+        # loop over k, v and update accumulator
+        for start_n in range(lo, hi, BLOCK_N):
+            k: "VAR_ARGS_ARRAY"  # noqa: F821
+            v: "VAR_ARGS_ARRAY"  # noqa: F821
+            for i in range(len(acc)):  # noqa: F821
+                k[i], v[i] = load_dequantize_k_v_group(  # noqa: F821
+                    K_block_ptr,
+                    V_block_ptr,
+                    K_scale_shift_block_ptr,
+                    V_scale_shift_block_ptr,
+                    BOUNDS_CHECKS_N,
+                    PACKED_PER_VAL,
+                    PACKED_D_PER_GROUP,
+                    Q.dtype.element_ty,
+                    i,
+                )
+
+            # -- compute qk ---
+            qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+            for i in range(len(acc)):  # noqa: F821
+                qk += tl.dot(q[i], k[i])  # noqa: F821
+            qk *= qk_scale
+
+            # TODO: This is slow, and only needed at the last iteration.
+            # Maybe we can unroll the last iteration instead?
+            if BOUNDS_CHECKS_N:
+                qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+            # -- compute scaling constant ---
+            m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+            alpha = tl.math.exp2(m_i - m_i_new)
+            p = tl.math.exp2(qk - m_i_new[:, None])
+
+            # -- update m_i and l_i --
+            l_i = l_i * alpha + tl.sum(p, 1)
+            m_i = m_i_new
+            p = p.to(Q.dtype.element_ty)
+
+            # -- scale and update acc --
+            for i in range(len(acc)):  # noqa: F821
+                acc[i] *= alpha[:, None]  # noqa: F821
+                acc[i] += tl.dot(p, v[i])  # noqa: F821
+            # update pointers
+            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+            if PACKED_PER_VAL > 1:
+                K_scale_shift_block_ptr = tl.advance(
+                    K_scale_shift_block_ptr, (0, BLOCK_N)
+                )
+                V_scale_shift_block_ptr = tl.advance(
+                    V_scale_shift_block_ptr, (BLOCK_N, 0)
+                )
+
+        # write back O
+        O_block_ptr = tl.make_block_ptr(
+            base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
+            shape=(N_CTX_Q, D_PER_GROUP),
+            strides=(stride_osk_m, 1),
+            offsets=(start_m * BLOCK_M, 0),
+            block_shape=(BLOCK_M, D_PER_GROUP),
+            order=(1, 0),
+        )
+        for i in range(len(acc)):  # noqa: F821
+            tl.store(
+                tl.advance(O_block_ptr, (0, i * D_PER_GROUP)),
+                acc[i],  # noqa: F821
+                boundary_check=(0,),
+            )
+        # Write metadata for split-K reduction
+        Metadata_ptr = (
+            Metadata
+            + off_zhg * stride_mzhg
+            + splitk_idx * stride_ms
+            + start_m * BLOCK_M
+            + tl.arange(0, BLOCK_M)
+        )
+        tl.store(Metadata_ptr, m_i)
+        tl.store(Metadata_ptr + stride_m2, l_i)
+
+    @triton.jit
+    def load_dequantize_k_v_group(
+        K_block_ptr,
+        V_block_ptr,
+        K_scale_shift_block_ptr,
+        V_scale_shift_block_ptr,
+        BOUNDS_CHECKS_N: tl.constexpr,
+        PACKED_PER_VAL: tl.constexpr,
+        PACKED_D_PER_GROUP: tl.constexpr,
+        dtype: tl.constexpr,
+        group_id: tl.constexpr,
+    ):
+        """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
+        If quantization is group-wise, use group_id to advance the pointers to the current group.
+        """
+        # Advance to the current quantization group
+        K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
+        V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+
+        # -- load k, v --
+        k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
+        v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+
+        if PACKED_PER_VAL > 1:
+            # K/V are quantized, load quantization coefficients and dequantize
+
+            K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
+            V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
+
+            k_scale_shift = tl.load(
+                K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+            )
+            v_scale_shift = tl.load(
+                V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+            )
+
+            k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
+            v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
+            v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
+            k_t = dequantize(
+                tl.trans(k),
+                tl.trans(k_scale),
+                tl.trans(k_shift),
+                PACKED_PER_VAL,
+            ).to(dtype)
+            k = tl.trans(k_t)
+        return k, v
+
+    @triton.jit
+    def cast_uint32_to_half2(scale_shift):
+        """Extract two float16 packed into one int32"""
+        scale = scale_shift & 0xFFFF
+        shift = scale_shift >> 16
+        scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
+        shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
+        return scale, shift
+
+    @triton.jit
+    def dequantize(
+        x_,
+        scale,
+        shift,
+        PACKED_PER_VAL: tl.constexpr = 8,
+    ):
+        """PACKED_PER_VAL is the number of values packed into each element x_.
+        For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+        """
+
+        # Axis along which offsets are applied matters here
+        # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+        # and expand K/V to that shape before applying offsets
+        # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
+        # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
+        # on the implementation details which might change in the future.
+        # Ideally we would like to use tl.reshape, but it's not implemented yet.
+        # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
+
+        # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+        # scale: (BLOCK_N, 1)
+        # offsets: (PACKED_PER_VAL,)
+        BLOCK_N: tl.constexpr = x_.shape[0]
+        BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+        offsets = tl.arange(0, PACKED_PER_VAL) * 4
+        quant_offset = (
+            x_[:, None, :] >> offsets[None, :, None]
+        )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
+
+        quant_offset = tl.view(
+            quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+        )
+        # Trick - instead of converting int4 to float16 we view it as float16
+        # and then multiply by 32768 * 512 == 2**24
+        quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
+        quant_offset = (quant_offset * 32768.0).to(tl.float16)
+        scale_512 = scale * 512
+
+        dequant = quant_offset * scale_512 + shift
+        return dequant
+
+    @triton.jit
+    def _splitK_reduce(
+        Out_splitK,  # [B, H, split_k, Mq, K]
+        Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+        Out,  # [B, H, M, K]
+        LSE,  # [B, H, M]
+        split_k,
+        stride_osk_zhg,
+        stride_osk_s,
+        stride_osk_m,
+        stride_osk_k,
+        stride_mzhg,
+        stride_m2,
+        stride_ms,
+        stride_mm,
+        stride_oz,
+        stride_oh,
+        stride_og,
+        stride_om,
+        stride_ok,
+        stride_lse_zhg,
+        stride_lse_m,
+        BLOCK_SIZE: tl.constexpr,
+        H: tl.constexpr,
+        G: tl.constexpr,
+    ):
+        off_zhg = tl.program_id(0)
+        off_z = off_zhg // (H * G)
+        off_h = (off_zhg // G) % H
+        off_g = off_zhg % G
+        off_m = tl.program_id(1)
+
+        Out_splitK_ptr = (
+            Out_splitK
+            + stride_osk_zhg * off_zhg
+            + stride_osk_m * off_m
+            + tl.arange(0, BLOCK_SIZE)
+        )
+        Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
+        m = tl.load(Metadata_ptr)
+        l_sum = tl.load(Metadata_ptr + stride_m2)
+        acc = tl.load(Out_splitK_ptr)
+
+        for split_k_idx in range(1, split_k):
+            Metadata_ptr = Metadata_ptr + stride_ms
+            Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+
+            m_k = tl.load(Metadata_ptr)
+            l_k = tl.load(Metadata_ptr + stride_m2)
+            acc_k = tl.load(Out_splitK_ptr)
+
+            m_new = tl.maximum(m, m_k)
+            if m_k < m:
+                # Scale incoming values
+                alpha = tl.math.exp2(m_k - m_new)
+                acc_k = acc_k * alpha
+                l_k = l_k * alpha
+            else:
+                # Scale our values
+                alpha = tl.math.exp2(m - m_new)
+                acc = acc * alpha
+                l_sum = l_sum * alpha
+
+            m = m_new
+            l_sum = l_sum + l_k
+            acc = acc + acc_k
+
+        acc = acc / l_sum
+        Out_ptr = (
+            Out
+            + stride_oz * off_z
+            + stride_oh * off_h
+            + stride_og * off_g
+            + stride_om * off_m
+            + tl.arange(0, BLOCK_SIZE)
+        )
+        tl.store(Out_ptr, acc)
+
+        l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
+        tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
+else:
+    _fwd_kernel_splitK = None
+    _splitK_reduce = None
+
+
+@register_operator
+class FwOp(AttentionFwOpBase):
+    """Flash-Attention with Split-K. Supports fused int-4 K/V quantization.
+    Quantized path will be taken if input K/V have type int32.
+
+    Quantization can be row-wise or group-wise (when cls.NUM_GROUPS > 1) along
+    the last dimension of K and V. Currently 1, 2, 4, or 8 groups per row are supported.
+    Quantization coefficients (scale and shift) are represented as two
+    float16 constants per group, packed into int32. Quantization coefficients of
+    all groups are placed at the beginning of the row. So, if unquantized K/V have head
+    dimension D, the quantized versions have head dimension D // 8 + NUM_GROUPS
+    and dtype int32.
+    Pseudocode for dequantizing one row can look like:
+    group_size = D // 8
+    for i in range(NUM_GROUPS):
+        group_start = NUM_GROUPS + i * group_size
+        group_quant = K[..., group_start: group_start + group_size]
+        scale, shift = unpack_int32_into_float16x2(group_quant[0])
+        group_dequant = group_quant[..., 1:] * scale + shift
+    ...
+
+    """
+
+    OPERATOR = _fwd_kernel_splitK
+    SUPPORTED_DEVICES = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
+    SUPPORTED_DTYPES = {
+        torch.half,
+        torch.bfloat16,
+    }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
+    SUPPORTED_MAX_K = 128
+    SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
+        type(None),
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    }
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    NAME = "triton_splitKF"
+
+    SPLIT_K: Optional[int] = None
+    BLOCK_M = 16
+    BLOCK_N = 64
+
+    NUM_GROUPS = 1  # Default quantization is row-wise
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in {16, 32, 64, 128}:
+            reasons.append(f"Embed dim {K} not supported")
+        return reasons
+
+    @classmethod
+    def not_supported_reasons(cls, d: Inputs) -> List[str]:
+        reasons = super(FwOp, cls).not_supported_reasons(d)
+        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+        if d.key.dtype != torch.int32:
+            check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+            check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+        if cls.OPERATOR is None:
+            reasons.append("triton is not available")
+        if d.device.type == "cuda":
+            # Has only been tested on 8.0 / 9.0.
+            if torch.cuda.get_device_capability(d.device) < (8, 0):
+                reasons.append(
+                    "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+                )
+
+        q_len = d.query.shape[1]
+        if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+            seqinfo = d.attn_bias.q_seqinfo
+            if q_len != seqinfo.seqstart_py[-1]:
+                reasons.append(
+                    f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+                )
+            q_len = seqinfo.min_seqlen
+            if q_len != seqinfo.max_seqlen:
+                reasons.append(
+                    "Variable query len is not supported in the presence of causal mask."
+                )
+
+        if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
+            if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
+                reasons.append("multiquery is only supported with query seqlen=1")
+
+        if d.attn_bias is not None and q_len > 1:
+            reasons.append(
+                "query with seqlen > 1 is not supported in the presence of causal mask"
+            )
+        return reasons
+
+    @classmethod
+    def get_split_k(cls, B: int, H: int, Mk: int) -> int:
+        """Heuristic for the number of splits"""
+        bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+        split_k = max(Mk, 1024) // bh
+        max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+        while split_k > 0 and Mk / split_k < max_chunk_size:
+            split_k = split_k // 2
+        split_k = min(split_k, 64)
+        split_k = max(split_k, 1)
+        return split_k
+
+    @classmethod
+    def apply(
+        cls, inp: Inputs, needs_gradient: bool
+    ) -> Tuple[torch.Tensor, Optional[Context]]:
+        attn_bias = inp.attn_bias
+        seq_len = None
+        q, k, v = inp.get_qkv_in_bmghk()
+
+        if attn_bias is not None:
+            assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+            # TODO: do we really need to do this cast? seems fishy but
+            # I just copied it from the decoder.py
+            attn_bias.k_seqinfo.to(inp.query.device)
+            attn_bias.q_seqinfo.to(inp.query.device)
+            seq_len = attn_bias.k_seqinfo.seqlen
+            B = len(seq_len)
+            G, H, Kq = q.shape[-3:]
+            Kkv = v.shape[-1]
+
+            # assume kv has been padded
+            q = q.reshape(B, -1, G, H, Kq)
+            k = k.reshape(B, -1, G, H, Kkv)
+            v = v.reshape(B, -1, G, H, Kkv)
+
+        # Transpose in the case of MQA/GQA
+        mqa_swap_seqlen_head = False
+        if k.shape[3] > 1 and k.stride(3) == 0 and v.stride(3) == 0:
+            mqa_swap_seqlen_head = True
+            assert q.shape[1] == 1
+            q = q.transpose(1, 3)
+            k = k[:, :, :, :1]
+            v = v[:, :, :, :1]
+
+        if k.dtype == torch.int32:
+            # Quantized K/V
+            PACKED_PER_VAL = 8
+            Lk = (k.shape[-1] - cls.NUM_GROUPS) * 8
+        else:
+            Lk = k.shape[-1]
+            PACKED_PER_VAL = 1
+
+        B, Mk, G, H, Kkv = k.shape
+        B, M, G, H, Kq = q.shape
+        assert Lk == Kq, f"Keys have head dim {Lk} but queries have head dim {Kq}"
+
+        BLOCK_M = cls.BLOCK_M
+        BLOCK_N = cls.BLOCK_N
+        if cls.SPLIT_K is not None:
+            split_k = cls.SPLIT_K
+        else:
+            # Use heuristics
+            split_k = cls.get_split_k(B, H, Mk)
+
+        M_ceil = (M + BLOCK_M - 1) // BLOCK_M * BLOCK_M
+        o_splitk = torch.empty(
+            [B * G * H, split_k, M_ceil, Kq], dtype=torch.float32, device=q.device
+        )
+        metadata = torch.empty(
+            [B * G * H, 2, split_k, M_ceil], dtype=torch.float32, device=q.device
+        )
+        lse = torch.empty((B * G * H, M), device=q.device, dtype=torch.float32)
+        grid = (triton.cdiv(M, BLOCK_M), B * G * H, split_k)
+
+        num_warps = 2
+        split_size = (Mk + split_k - 1) // split_k
+        use_seq_len = seq_len is not None
+        _fwd_kernel_splitK_unrolled = unroll_varargs(
+            _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
+        )
+
+        _fwd_kernel_splitK_unrolled[grid](
+            Q=q,
+            K=k,
+            V=v,
+            sm_scale=inp.scale_float,
+            Out_splitK=o_splitk,
+            Metadata=metadata,
+            Seq_len=seq_len,
+            **_strides(q, "qz", "qm", "qg", "qh", "qk"),
+            **_strides(k, "kz", "kn", "kg", "kh", "kk"),
+            **_strides(v, "vz", "vn", "vg", "vh", "vk"),
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            Z=B,
+            H=H,
+            G=G,
+            N_CTX_Q=M,
+            N_CTX_K=Mk,
+            BLOCK_N_PER_SPLIT=split_size,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_DMODEL=Lk,
+            BOUNDS_CHECKS_N=(split_size % BLOCK_N) > 0 or use_seq_len,
+            USE_SEQ_LEN=use_seq_len,
+            num_warps=num_warps,
+            num_stages=1,
+            PACKED_PER_VAL=PACKED_PER_VAL,
+            N_GROUPS=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1,
+        )
+
+        if mqa_swap_seqlen_head:
+            out = torch.empty(
+                (B, H, G, M, Kq), device=q.device, dtype=q.dtype
+            ).transpose(1, 3)
+        else:
+            out = torch.empty((B, M, G, H, Kq), device=q.device, dtype=q.dtype)
+
+        # Merge together
+        grid = (B * G * H, M, 1)
+        _splitK_reduce[grid](
+            o_splitk,
+            metadata,
+            out,
+            lse,
+            split_k=split_k,
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            **_strides(out, "oz", "om", "og", "oh", "ok"),
+            **_strides(lse, "lse_zhg", "lse_m"),
+            BLOCK_SIZE=out.shape[-1],
+            G=G,
+            H=H,
+            # TODO: Tune num_warps
+        )
+        lse = lse.reshape([B, G, H, M])
+        if mqa_swap_seqlen_head:
+            # H/M dimensions have been swapped
+            out = out.transpose(1, 3)
+            lse = lse.transpose(2, 3)
+        if inp.query.ndim == 4:
+            # BMGHK -> BMHK
+            assert G == 1
+            out = out[:, :, 0]
+            lse = lse[:, 0]
+        if Mk == 0:
+            out.zero_()
+
+        return out, Context(out=out, lse=lse)
+
+
+class FwOp_S1(FwOp):
+    SPLIT_K = 1
+    NAME = "triton_splitK1"
+
+
+class FwOp_S2(FwOp):
+    SPLIT_K = 2
+    NAME = "triton_splitK2"
+
+
+class FwOp_S4(FwOp):
+    SPLIT_K = 4
+    NAME = "triton_splitK4"
+
+
+class FwOp_S8(FwOp):
+    SPLIT_K = 8
+    NAME = "triton_splitK8"
+
+
+class FwOp_S16(FwOp):
+    SPLIT_K = 16
+    NAME = "triton_splitK16"
+
+
+class FwOp_S32(FwOp):
+    SPLIT_K = 32
+    NAME = "triton_splitK32"
+
+
+class FwOp_S64(FwOp):
+    SPLIT_K = 64
+    NAME = "triton_splitK64"
+
+
+class FwOp_S128(FwOp):
+    SPLIT_K = 128
+    NAME = "triton_splitK128"

--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -784,6 +784,7 @@ def bench_flash_attention(B, Mq, Mkv, Hq, Hkv, K, causal, mode, provider, dtype=
     assert mode in ['fwd', 'bwd']
     warmup = 100
     rep = 400
+    ms = 0
     if provider == "triton":
         q = torch.randn(
             [B, Mq, Hkv, Hq // Hkv, K], device="cuda", dtype=dtype, requires_grad=False

--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -1,8 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
-#
-# This source code is licensed under the BSD license found in the
-# LICENSE file in the root directory of this source tree.
-
 
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
 import pytest

--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -466,7 +466,6 @@ def get_split_k(B: int, H: int, Mk: int) -> int:
         split_k = split_k // 2
     split_k = min(split_k, 64)
     split_k = max(split_k, 1)
-    print(f"split_k = {split_k}")
     return split_k
 
 # @register_operator

--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -5,12 +5,14 @@
 
 
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
-
+import pytest
 import torch
+import sys
 
-from ..common import _has_triton21, register_operator
-from .attn_bias import BlockDiagonalCausalWithOffsetPaddedKeysMask
-from .common import AttentionFwOpBase, Context, Inputs, check_lastdim_alignment_stride1
+import triton
+import triton.language as tl
+
+# from .attn_bias import BlockDiagonalCausalWithOffsetPaddedKeysMask
 
 
 def _strides(x: torch.Tensor, *stride_names: str):
@@ -18,464 +20,457 @@ def _strides(x: torch.Tensor, *stride_names: str):
     return {f"stride_{s}": x.stride(i) for i, s in enumerate(stride_names)}
 
 
-if TYPE_CHECKING or _has_triton21():
-    import triton
-    import triton.language as tl
+# if TYPE_CHECKING or _has_triton21():
+#     import triton
+#     import triton.language as tl
 
-    from xformers.triton.vararg_kernel import VAR_ARGS_ARRAY, unroll_varargs
+#     from xformers.triton.vararg_kernel import VAR_ARGS_ARRAY, unroll_varargs
 
-    @triton.jit
-    def _fwd_kernel_splitK(
-        Q,
-        K,
-        V,
-        sm_scale,
-        Out_splitK,  # [B, H, split_k, Mq, K]
-        Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
-        Seq_len,
-        stride_qz,
-        stride_qm,
-        stride_qg,
-        stride_qh,
-        stride_qk,
-        stride_kz,
-        stride_kn,
-        stride_kg,
-        stride_kh,
-        stride_kk,
-        stride_vz,
-        stride_vn,
-        stride_vg,
-        stride_vh,
-        stride_vk,
-        stride_osk_zhg,
-        stride_osk_s,
-        stride_osk_m,
-        stride_osk_k,
-        stride_mzhg,
-        stride_m2,
-        stride_ms,
-        stride_mm,
-        Z,
-        N_CTX_Q,
-        N_CTX_K,
-        BLOCK_N_PER_SPLIT,
-        H: tl.constexpr,
-        G: tl.constexpr,
-        BLOCK_M: tl.constexpr,
-        BLOCK_DMODEL: tl.constexpr,
-        BLOCK_N: tl.constexpr,
-        BOUNDS_CHECKS_N: tl.constexpr,
-        USE_SEQ_LEN: tl.constexpr,
-        PACKED_PER_VAL: tl.constexpr = 1,
-        N_GROUPS: tl.constexpr = 1,
-    ):
-        """This kernel can accept non-quantized or int4-quantized keys/values.
-        PACKED_PER_VAL determines the quantization type:
-            - PACKED_PER_VAL == 1 means no quantization
-            - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
-        For the quantized case K/V should be int32 tensors.
-        Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
-        Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
-        So K[B, H, M, :] has a form
-        [   quant_coef0, quant_coef1, ...|
-            group0_quant_value0, group0_quant_value1,... |
-            group1_quant_value0, group1_quant_value1,...]
-        where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
+@triton.jit
+def _fwd_kernel_splitK(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+    Seq_len,
+    stride_qz,
+    stride_qm,
+    stride_qg,
+    stride_qh,
+    stride_qk,
+    stride_kz,
+    stride_kn,
+    stride_kg,
+    stride_kh,
+    stride_kk,
+    stride_vz,
+    stride_vn,
+    stride_vg,
+    stride_vh,
+    stride_vk,
+    stride_osk_zhg,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_mzhg,
+    stride_m2,
+    stride_ms,
+    stride_mm,
+    Z,
+    N_CTX_Q,
+    N_CTX_K,
+    BLOCK_N_PER_SPLIT,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    USE_SEQ_LEN: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr = 1,
+    N_GROUPS: tl.constexpr = 1,
+):
+    """This kernel can accept non-quantized or int4-quantized keys/values.
+    PACKED_PER_VAL determines the quantization type:
+        - PACKED_PER_VAL == 1 means no quantization
+        - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
+    For the quantized case K/V should be int32 tensors.
+    Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
+    Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
+    So K[B, H, M, :] has a form
+    [   quant_coef0, quant_coef1, ...|
+        group0_quant_value0, group0_quant_value1,... |
+        group1_quant_value0, group1_quant_value1,...]
+    where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
 
-        Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
-        before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
-        See how FwOp.apply does it below.
-        """
-        tl.static_assert(
-            (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
-            or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
-            f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
-            f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
-        )
-        tl.static_assert(
-            (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
-            "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
-        )
+    Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
+    before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
+    See how FwOp.apply does it below.
+    """
+    tl.static_assert(
+        (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
+        or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
+        f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
+        f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
+    )
+    tl.static_assert(
+        (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
+        "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
+    )
 
-        QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
-        PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
-        D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
+    QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
+    PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
+    D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
 
-        start_m = tl.program_id(0)
-        off_zhg = tl.program_id(1)
-        off_z = off_zhg // (H * G)
-        off_h = (off_zhg // G) % H
-        off_g = off_zhg % G
-        splitk_idx = tl.program_id(2)
+    start_m = tl.program_id(0)
+    off_zhg = tl.program_id(1)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    splitk_idx = tl.program_id(2)
 
-        lo = splitk_idx * BLOCK_N_PER_SPLIT
-        if USE_SEQ_LEN:
-            kv_len = tl.load(Seq_len + off_z)
-        else:
-            kv_len = N_CTX_K
-        hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
+    lo = splitk_idx * BLOCK_N_PER_SPLIT
+    if USE_SEQ_LEN:
+        kv_len = tl.load(Seq_len + off_z)
+    else:
+        kv_len = N_CTX_K
+    hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
 
-        Q_block_ptr = tl.make_block_ptr(
-            base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
-            shape=(N_CTX_Q, D_PER_GROUP),
-            strides=(stride_qm, stride_qk),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, D_PER_GROUP),
-            order=(1, 0),
-        )
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
 
-        k_base = K + off_h * stride_kh + off_z * stride_kz + off_g * stride_kg
-        # Additional shift by 1 along the last dimension in the quantized case, since
-        # the first element along that dim contains packed quantization coefficients.
-        K_block_ptr = tl.make_block_ptr(
-            base=k_base + stride_kk * QUANTIZED * N_GROUPS,
-            shape=(PACKED_D_PER_GROUP, hi),
+    k_base = K + off_h * stride_kh + off_z * stride_kz + off_g * stride_kg
+    # Additional shift by 1 along the last dimension in the quantized case, since
+    # the first element along that dim contains packed quantization coefficients.
+    K_block_ptr = tl.make_block_ptr(
+        base=k_base + stride_kk * QUANTIZED * N_GROUPS,
+        shape=(PACKED_D_PER_GROUP, hi),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, lo),
+        block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+        order=(0, 1),
+    )
+    v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
+    V_block_ptr = tl.make_block_ptr(
+        base=v_base + stride_vk * QUANTIZED * N_GROUPS,
+        shape=(hi, PACKED_D_PER_GROUP),
+        strides=(stride_vn, stride_vk),
+        offsets=(lo, 0),
+        block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    if QUANTIZED:
+        # Pointers to quantization coefficients. Even those they are 1D,
+        # we have to use block pointers, since usual pointers
+        # don't support boundary checks
+        K_scale_shift_block_ptr = tl.make_block_ptr(
+            base=k_base,
+            shape=(1, hi),
             strides=(stride_kk, stride_kn),
             offsets=(0, lo),
-            block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+            block_shape=(1, BLOCK_N),
             order=(0, 1),
         )
-        v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
-        V_block_ptr = tl.make_block_ptr(
-            base=v_base + stride_vk * QUANTIZED * N_GROUPS,
-            shape=(hi, PACKED_D_PER_GROUP),
+        V_scale_shift_block_ptr = tl.make_block_ptr(
+            base=v_base,
+            shape=(hi, 1),
             strides=(stride_vn, stride_vk),
             offsets=(lo, 0),
-            block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+            block_shape=(BLOCK_N, 1),
             order=(1, 0),
         )
+    else:
+        K_scale_shift_block_ptr = None
+        V_scale_shift_block_ptr = None
 
-        if QUANTIZED:
-            # Pointers to quantization coefficients. Even those they are 1D,
-            # we have to use block pointers, since usual pointers
-            # don't support boundary checks
-            K_scale_shift_block_ptr = tl.make_block_ptr(
-                base=k_base,
-                shape=(1, hi),
-                strides=(stride_kk, stride_kn),
-                offsets=(0, lo),
-                block_shape=(1, BLOCK_N),
-                order=(0, 1),
-            )
-            V_scale_shift_block_ptr = tl.make_block_ptr(
-                base=v_base,
-                shape=(hi, 1),
-                strides=(stride_vn, stride_vk),
-                offsets=(lo, 0),
-                block_shape=(BLOCK_N, 1),
-                order=(1, 0),
-            )
-        else:
-            K_scale_shift_block_ptr = None
-            V_scale_shift_block_ptr = None
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
 
-        # initialize pointer to m and l
-        m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
-        l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
+    # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
+    # This is a solution for Triton native lack of support for lists of tensors.
+    # acc: "VAR_ARGS_ARRAY"  # noqa: F821
+    # acc = []
+    elem_num = 1
+    # for i in range(elem_num):  # noqa: F821
+    acc = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
 
-        # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
-        # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
-        # This is a solution for Triton native lack of support for lists of tensors.
-        acc: "VAR_ARGS_ARRAY"  # noqa: F821
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    # load q: it will stay in SRAM throughout
+    # q: "VAR_ARGS_ARRAY"  # noqa: F821
+    # for i in range(elem_num):  # noqa: F821
+    q = tl.load(  # noqa: F821
+        tl.advance(Q_block_ptr, (0, 0)), boundary_check=(0,)
+    )
 
-        for i in range(len(acc)):  # noqa: F821
-            acc[i] = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
-        # scale sm_scale by log_2(e) and use
-        # 2^x instead of exp in the loop because CSE and LICM
-        # don't work as expected with `exp` in the loop
-        qk_scale = sm_scale * 1.44269504
-        # load q: it will stay in SRAM throughout
-        q: "VAR_ARGS_ARRAY"  # noqa: F821
-        for i in range(len(acc)):  # noqa: F821
-            q[i] = tl.load(  # noqa: F821
-                tl.advance(Q_block_ptr, (0, i * D_PER_GROUP)), boundary_check=(0,)
-            )
-        # loop over k, v and update accumulator
-        for start_n in range(lo, hi, BLOCK_N):
-            k: "VAR_ARGS_ARRAY"  # noqa: F821
-            v: "VAR_ARGS_ARRAY"  # noqa: F821
-            for i in range(len(acc)):  # noqa: F821
-                k[i], v[i] = load_dequantize_k_v_group(  # noqa: F821
-                    K_block_ptr,
-                    V_block_ptr,
-                    K_scale_shift_block_ptr,
-                    V_scale_shift_block_ptr,
-                    BOUNDS_CHECKS_N,
-                    PACKED_PER_VAL,
-                    PACKED_D_PER_GROUP,
-                    Q.dtype.element_ty,
-                    i,
-                )
-
-            # -- compute qk ---
-            qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-            for i in range(len(acc)):  # noqa: F821
-                qk += tl.dot(q[i], k[i])  # noqa: F821
-            qk *= qk_scale
-
-            # TODO: This is slow, and only needed at the last iteration.
-            # Maybe we can unroll the last iteration instead?
-            if BOUNDS_CHECKS_N:
-                qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
-            # -- compute scaling constant ---
-            m_i_new = tl.maximum(m_i, tl.max(qk, 1))
-            alpha = tl.math.exp2(m_i - m_i_new)
-            p = tl.math.exp2(qk - m_i_new[:, None])
-
-            # -- update m_i and l_i --
-            l_i = l_i * alpha + tl.sum(p, 1)
-            m_i = m_i_new
-            p = p.to(Q.dtype.element_ty)
-
-            # -- scale and update acc --
-            for i in range(len(acc)):  # noqa: F821
-                acc[i] *= alpha[:, None]  # noqa: F821
-                acc[i] += tl.dot(p, v[i])  # noqa: F821
-            # update pointers
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            if PACKED_PER_VAL > 1:
-                K_scale_shift_block_ptr = tl.advance(
-                    K_scale_shift_block_ptr, (0, BLOCK_N)
-                )
-                V_scale_shift_block_ptr = tl.advance(
-                    V_scale_shift_block_ptr, (BLOCK_N, 0)
-                )
-
-        # write back O
-        O_block_ptr = tl.make_block_ptr(
-            base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
-            shape=(N_CTX_Q, D_PER_GROUP),
-            strides=(stride_osk_m, 1),
-            offsets=(start_m * BLOCK_M, 0),
-            block_shape=(BLOCK_M, D_PER_GROUP),
-            order=(1, 0),
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        # k: "VAR_ARGS_ARRAY"  # noqa: F821
+        # v: "VAR_ARGS_ARRAY"  # noqa: F821
+        # for i in range(len(acc)):  # noqa: F821
+        k, v = load_dequantize_k_v_group(  # noqa: F821
+            K_block_ptr,
+            V_block_ptr,
+            K_scale_shift_block_ptr,
+            V_scale_shift_block_ptr,
+            BOUNDS_CHECKS_N,
+            PACKED_PER_VAL,
+            PACKED_D_PER_GROUP,
+            Q.dtype.element_ty,
+            0,
         )
-        for i in range(len(acc)):  # noqa: F821
-            tl.store(
-                tl.advance(O_block_ptr, (0, i * D_PER_GROUP)),
-                acc[i],  # noqa: F821
-                boundary_check=(0,),
-            )
-        # Write metadata for split-K reduction
-        Metadata_ptr = (
-            Metadata
-            + off_zhg * stride_mzhg
-            + splitk_idx * stride_ms
-            + start_m * BLOCK_M
-            + tl.arange(0, BLOCK_M)
-        )
-        tl.store(Metadata_ptr, m_i)
-        tl.store(Metadata_ptr + stride_m2, l_i)
+        # k.append(k_tmp)
+        # v.append(v_tmp)
 
-    @triton.jit
-    def load_dequantize_k_v_group(
-        K_block_ptr,
-        V_block_ptr,
-        K_scale_shift_block_ptr,
-        V_scale_shift_block_ptr,
-        BOUNDS_CHECKS_N: tl.constexpr,
-        PACKED_PER_VAL: tl.constexpr,
-        PACKED_D_PER_GROUP: tl.constexpr,
-        dtype: tl.constexpr,
-        group_id: tl.constexpr,
-    ):
-        """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
-        If quantization is group-wise, use group_id to advance the pointers to the current group.
-        """
-        # Advance to the current quantization group
-        K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
-        V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        # for i in range(elem_num):  # noqa: F821
+        qk += tl.dot(q, k)  # noqa: F821
+        qk *= qk_scale
 
-        # -- load k, v --
-        k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
-        v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+        # TODO: This is slow, and only needed at the last iteration.
+        # Maybe we can unroll the last iteration instead?
+        if BOUNDS_CHECKS_N:
+            qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk - m_i_new[:, None])
 
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        p = p.to(Q.dtype.element_ty)
+
+        # -- scale and update acc --
+        # for i in range(elem_num):  # noqa: F821
+        acc *= alpha[:, None]  # noqa: F821
+        acc += tl.dot(p, v)  # noqa: F821
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
         if PACKED_PER_VAL > 1:
-            # K/V are quantized, load quantization coefficients and dequantize
-
-            K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
-            V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
-
-            k_scale_shift = tl.load(
-                K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+            K_scale_shift_block_ptr = tl.advance(
+                K_scale_shift_block_ptr, (0, BLOCK_N)
             )
-            v_scale_shift = tl.load(
-                V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+            V_scale_shift_block_ptr = tl.advance(
+                V_scale_shift_block_ptr, (BLOCK_N, 0)
             )
 
-            k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
-            v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
-            v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
-            k_t = dequantize(
-                tl.trans(k),
-                tl.trans(k_scale),
-                tl.trans(k_shift),
-                PACKED_PER_VAL,
-            ).to(dtype)
-            k = tl.trans(k_t)
-        return k, v
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_osk_m, 1),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+    # for i in range(elem_num):  # noqa: F821
+    tl.store(
+        tl.advance(O_block_ptr, (0, 0)),
+        acc,  # noqa: F821
+        boundary_check=(0,),
+    )
+    # Write metadata for split-K reduction
+    Metadata_ptr = (
+        Metadata
+        + off_zhg * stride_mzhg
+        + splitk_idx * stride_ms
+        + start_m * BLOCK_M
+        + tl.arange(0, BLOCK_M)
+    )
+    tl.store(Metadata_ptr, m_i)
+    tl.store(Metadata_ptr + stride_m2, l_i)
 
-    @triton.jit
-    def cast_uint32_to_half2(scale_shift):
-        """Extract two float16 packed into one int32"""
-        scale = scale_shift & 0xFFFF
-        shift = scale_shift >> 16
-        scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
-        shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
-        return scale, shift
-
-    @triton.jit
-    def dequantize(
-        x_,
-        scale,
-        shift,
-        PACKED_PER_VAL: tl.constexpr = 8,
-    ):
-        """PACKED_PER_VAL is the number of values packed into each element x_.
-        For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
-        """
-
-        # Axis along which offsets are applied matters here
-        # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
-        # and expand K/V to that shape before applying offsets
-        # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
-        # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
-        # on the implementation details which might change in the future.
-        # Ideally we would like to use tl.reshape, but it's not implemented yet.
-        # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
-
-        # x_ : (BLOCK_N, D // PACKED_PER_VAL)
-        # scale: (BLOCK_N, 1)
-        # offsets: (PACKED_PER_VAL,)
-        BLOCK_N: tl.constexpr = x_.shape[0]
-        BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
-        offsets = tl.arange(0, PACKED_PER_VAL) * 4
-        quant_offset = (
-            x_[:, None, :] >> offsets[None, :, None]
-        )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
-
-        quant_offset = tl.view(
-            quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
-        )
-        # Trick - instead of converting int4 to float16 we view it as float16
-        # and then multiply by 32768 * 512 == 2**24
-        quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
-        quant_offset = (quant_offset * 32768.0).to(tl.float16)
-        scale_512 = scale * 512
-
-        dequant = quant_offset * scale_512 + shift
-        return dequant
-
-    @triton.jit
-    def _splitK_reduce(
-        Out_splitK,  # [B, H, split_k, Mq, K]
-        Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
-        Out,  # [B, H, M, K]
-        LSE,  # [B, H, M]
-        split_k,
-        stride_osk_zhg,
-        stride_osk_s,
-        stride_osk_m,
-        stride_osk_k,
-        stride_mzhg,
-        stride_m2,
-        stride_ms,
-        stride_mm,
-        stride_oz,
-        stride_oh,
-        stride_og,
-        stride_om,
-        stride_ok,
-        stride_lse_zhg,
-        stride_lse_m,
-        BLOCK_SIZE: tl.constexpr,
-        H: tl.constexpr,
-        G: tl.constexpr,
-    ):
-        off_zhg = tl.program_id(0)
-        off_z = off_zhg // (H * G)
-        off_h = (off_zhg // G) % H
-        off_g = off_zhg % G
-        off_m = tl.program_id(1)
-
-        Out_splitK_ptr = (
-            Out_splitK
-            + stride_osk_zhg * off_zhg
-            + stride_osk_m * off_m
-            + tl.arange(0, BLOCK_SIZE)
-        )
-        Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
-        m = tl.load(Metadata_ptr)
-        l_sum = tl.load(Metadata_ptr + stride_m2)
-        acc = tl.load(Out_splitK_ptr)
-
-        for split_k_idx in range(1, split_k):
-            Metadata_ptr = Metadata_ptr + stride_ms
-            Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
-
-            m_k = tl.load(Metadata_ptr)
-            l_k = tl.load(Metadata_ptr + stride_m2)
-            acc_k = tl.load(Out_splitK_ptr)
-
-            m_new = tl.maximum(m, m_k)
-            if m_k < m:
-                # Scale incoming values
-                alpha = tl.math.exp2(m_k - m_new)
-                acc_k = acc_k * alpha
-                l_k = l_k * alpha
-            else:
-                # Scale our values
-                alpha = tl.math.exp2(m - m_new)
-                acc = acc * alpha
-                l_sum = l_sum * alpha
-
-            m = m_new
-            l_sum = l_sum + l_k
-            acc = acc + acc_k
-
-        acc = acc / l_sum
-        Out_ptr = (
-            Out
-            + stride_oz * off_z
-            + stride_oh * off_h
-            + stride_og * off_g
-            + stride_om * off_m
-            + tl.arange(0, BLOCK_SIZE)
-        )
-        tl.store(Out_ptr, acc)
-
-        l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
-        tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
-
-else:
-    _fwd_kernel_splitK = None
-    _splitK_reduce = None
-
-
-@register_operator
-class FwOp(AttentionFwOpBase):
-    """Flash-Attention with Split-K. Supports fused int-4 K/V quantization.
-    Quantized path will be taken if input K/V have type int32.
-
-    Quantization can be row-wise or group-wise (when cls.NUM_GROUPS > 1) along
-    the last dimension of K and V. Currently 1, 2, 4, or 8 groups per row are supported.
-    Quantization coefficients (scale and shift) are represented as two
-    float16 constants per group, packed into int32. Quantization coefficients of
-    all groups are placed at the beginning of the row. So, if unquantized K/V have head
-    dimension D, the quantized versions have head dimension D // 8 + NUM_GROUPS
-    and dtype int32.
-    Pseudocode for dequantizing one row can look like:
-    group_size = D // 8
-    for i in range(NUM_GROUPS):
-        group_start = NUM_GROUPS + i * group_size
-        group_quant = K[..., group_start: group_start + group_size]
-        scale, shift = unpack_int32_into_float16x2(group_quant[0])
-        group_dequant = group_quant[..., 1:] * scale + shift
-    ...
-
+@triton.jit
+def load_dequantize_k_v_group(
+    K_block_ptr,
+    V_block_ptr,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    PACKED_D_PER_GROUP: tl.constexpr,
+    dtype: tl.constexpr,
+    group_id: tl.constexpr,
+):
+    """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
+    If quantization is group-wise, use group_id to advance the pointers to the current group.
     """
+    # Advance to the current quantization group
+    K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
+    V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+
+    # -- load k, v --
+    k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
+    v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+
+    if PACKED_PER_VAL > 1:
+        # K/V are quantized, load quantization coefficients and dequantize
+
+        K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
+        V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
+
+        k_scale_shift = tl.load(
+            K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+        )
+        v_scale_shift = tl.load(
+            V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+        )
+
+        k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
+        v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
+        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
+        k_t = dequantize(
+            tl.trans(k),
+            tl.trans(k_scale),
+            tl.trans(k_shift),
+            PACKED_PER_VAL,
+        ).to(dtype)
+        k = tl.trans(k_t)
+    return k, v
+
+@triton.jit
+def cast_uint32_to_half2(scale_shift):
+    """Extract two float16 packed into one int32"""
+    scale = scale_shift & 0xFFFF
+    shift = scale_shift >> 16
+    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
+    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
+    return scale, shift
+
+@triton.jit
+def dequantize(
+    x_,
+    scale,
+    shift,
+    PACKED_PER_VAL: tl.constexpr = 8,
+):
+    """PACKED_PER_VAL is the number of values packed into each element x_.
+    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+    """
+
+    # Axis along which offsets are applied matters here
+    # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+    # and expand K/V to that shape before applying offsets
+    # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
+    # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
+    # on the implementation details which might change in the future.
+    # Ideally we would like to use tl.reshape, but it's not implemented yet.
+    # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
+
+    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+    # scale: (BLOCK_N, 1)
+    # offsets: (PACKED_PER_VAL,)
+    BLOCK_N: tl.constexpr = x_.shape[0]
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+    offsets = tl.arange(0, PACKED_PER_VAL) * 4
+    quant_offset = (
+        x_[:, None, :] >> offsets[None, :, None]
+    )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
+
+    quant_offset = tl.view(
+        quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+    )
+    # Trick - instead of converting int4 to float16 we view it as float16
+    # and then multiply by 32768 * 512 == 2**24
+    quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
+    quant_offset = (quant_offset * 32768.0).to(tl.float16)
+    scale_512 = scale * 512
+
+    dequant = quant_offset * scale_512 + shift
+    return dequant
+
+@triton.jit
+def _splitK_reduce(
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+    Out,  # [B, H, M, K]
+    LSE,  # [B, H, M]
+    split_k,
+    stride_osk_zhg,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_mzhg,
+    stride_m2,
+    stride_ms,
+    stride_mm,
+    stride_oz,
+    stride_oh,
+    stride_og,
+    stride_om,
+    stride_ok,
+    stride_lse_zhg,
+    stride_lse_m,
+    BLOCK_SIZE: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+):
+    off_zhg = tl.program_id(0)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    off_m = tl.program_id(1)
+
+    Out_splitK_ptr = (
+        Out_splitK
+        + stride_osk_zhg * off_zhg
+        + stride_osk_m * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
+    m = tl.load(Metadata_ptr)
+    l_sum = tl.load(Metadata_ptr + stride_m2)
+    acc = tl.load(Out_splitK_ptr)
+
+    for split_k_idx in range(1, split_k):
+        Metadata_ptr = Metadata_ptr + stride_ms
+        Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+
+        m_k = tl.load(Metadata_ptr)
+        l_k = tl.load(Metadata_ptr + stride_m2)
+        acc_k = tl.load(Out_splitK_ptr)
+
+        m_new = tl.maximum(m, m_k)
+        if m_k < m:
+            # Scale incoming values
+            alpha = tl.math.exp2(m_k - m_new)
+            acc_k = acc_k * alpha
+            l_k = l_k * alpha
+        else:
+            # Scale our values
+            alpha = tl.math.exp2(m - m_new)
+            acc = acc * alpha
+            l_sum = l_sum * alpha
+
+        m = m_new
+        l_sum = l_sum + l_k
+        acc = acc + acc_k
+
+    acc = acc / l_sum
+    Out_ptr = (
+        Out
+        + stride_oz * off_z
+        + stride_oh * off_h
+        + stride_og * off_g
+        + stride_om * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    tl.store(Out_ptr, acc)
+
+    l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
+    tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
+
+def get_split_k(B: int, H: int, Mk: int) -> int:
+    """Heuristic for the number of splits"""
+    bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+    split_k = max(Mk, 1024) // bh
+    max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+    while split_k > 0 and Mk / split_k < max_chunk_size:
+        split_k = split_k // 2
+    split_k = min(split_k, 64)
+    split_k = max(split_k, 1)
+    return split_k
+
+# @register_operator
+# class FwOp(AttentionFwOpBase):
+class _attention(torch.autograd.Function):
 
     OPERATOR = _fwd_kernel_splitK
     SUPPORTED_DEVICES = {"cuda"}
@@ -485,104 +480,98 @@ class FwOp(AttentionFwOpBase):
         torch.bfloat16,
     }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
     SUPPORTED_MAX_K = 128
-    SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
-        type(None),
-        BlockDiagonalCausalWithOffsetPaddedKeysMask,
-    }
+    # SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
+    #     type(None),
+    #     BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    # }
     SUPPORTS_DROPOUT = False
     SUPPORTS_CUSTOM_SCALE = True
     SUPPORTS_BMGHK = True
     NAME = "triton_splitKF"
 
-    SPLIT_K: Optional[int] = None
-    BLOCK_M = 16
-    BLOCK_N = 64
 
-    NUM_GROUPS = 1  # Default quantization is row-wise
+    # @classmethod
+    # def shape_not_supported_reasons(
+    #     cls, Mq: int, Mkv: int, K: int, Kv: int
+    # ) -> List[str]:
+    #     reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+    #     if K not in {16, 32, 64, 128}:
+    #         reasons.append(f"Embed dim {K} not supported")
+    #     return reasons
 
-    @classmethod
-    def shape_not_supported_reasons(
-        cls, Mq: int, Mkv: int, K: int, Kv: int
-    ) -> List[str]:
-        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
-        if K not in {16, 32, 64, 128}:
-            reasons.append(f"Embed dim {K} not supported")
-        return reasons
+    # @classmethod
+    # def not_supported_reasons(cls, d: Inputs) -> List[str]:
+    #     reasons = super(FwOp, cls).not_supported_reasons(d)
+    #     check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+    #     if d.key.dtype != torch.int32:
+    #         check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+    #         check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+    #     if cls.OPERATOR is None:
+    #         reasons.append("triton is not available")
+    #     if d.device.type == "cuda":
+    #         # Has only been tested on 8.0 / 9.0.
+    #         if torch.cuda.get_device_capability(d.device) < (8, 0):
+    #             reasons.append(
+    #                 "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+    #             )
 
-    @classmethod
-    def not_supported_reasons(cls, d: Inputs) -> List[str]:
-        reasons = super(FwOp, cls).not_supported_reasons(d)
-        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
-        if d.key.dtype != torch.int32:
-            check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
-            check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
-        if cls.OPERATOR is None:
-            reasons.append("triton is not available")
-        if d.device.type == "cuda":
-            # Has only been tested on 8.0 / 9.0.
-            if torch.cuda.get_device_capability(d.device) < (8, 0):
-                reasons.append(
-                    "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
-                )
+    #     q_len = d.query.shape[1]
+    #     if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+    #         seqinfo = d.attn_bias.q_seqinfo
+    #         if q_len != seqinfo.seqstart_py[-1]:
+    #             reasons.append(
+    #                 f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+    #             )
+    #         q_len = seqinfo.min_seqlen
+    #         if q_len != seqinfo.max_seqlen:
+    #             reasons.append(
+    #                 "Variable query len is not supported in the presence of causal mask."
+    #             )
 
-        q_len = d.query.shape[1]
-        if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
-            seqinfo = d.attn_bias.q_seqinfo
-            if q_len != seqinfo.seqstart_py[-1]:
-                reasons.append(
-                    f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
-                )
-            q_len = seqinfo.min_seqlen
-            if q_len != seqinfo.max_seqlen:
-                reasons.append(
-                    "Variable query len is not supported in the presence of causal mask."
-                )
+    #     if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
+    #         if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
+    #             reasons.append("multiquery is only supported with query seqlen=1")
 
-        if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
-            if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
-                reasons.append("multiquery is only supported with query seqlen=1")
+    #     if d.attn_bias is not None and q_len > 1:
+    #         reasons.append(
+    #             "query with seqlen > 1 is not supported in the presence of causal mask"
+    #         )
+    #     return reasons
 
-        if d.attn_bias is not None and q_len > 1:
-            reasons.append(
-                "query with seqlen > 1 is not supported in the presence of causal mask"
-            )
-        return reasons
 
-    @classmethod
-    def get_split_k(cls, B: int, H: int, Mk: int) -> int:
-        """Heuristic for the number of splits"""
-        bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
-        split_k = max(Mk, 1024) // bh
-        max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
-        while split_k > 0 and Mk / split_k < max_chunk_size:
-            split_k = split_k // 2
-        split_k = min(split_k, 64)
-        split_k = max(split_k, 1)
-        return split_k
+    # @classmethod
 
-    @classmethod
-    def apply(
-        cls, inp: Inputs, needs_gradient: bool
-    ) -> Tuple[torch.Tensor, Optional[Context]]:
-        attn_bias = inp.attn_bias
+    # def apply(
+    #     cls, inp: Inputs, needs_gradient: bool
+    # ) -> Tuple[torch.Tensor, Optional[Context]]:
+    @staticmethod
+    def forward(cls, q, k, v, scale_float):
+
+        cls.SPLIT_K: Optional[int] = None
+        cls.BLOCK_M = 16
+        cls.BLOCK_N = 64
+
+        cls.NUM_GROUPS = 1  # Default quantization is row-wise
+
+        # attn_bias = inp.attn_bias
         seq_len = None
-        q, k, v = inp.get_qkv_in_bmghk()
+        # q, k, v = inp.get_qkv_in_bmghk()
 
-        if attn_bias is not None:
-            assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
-            # TODO: do we really need to do this cast? seems fishy but
-            # I just copied it from the decoder.py
-            attn_bias.k_seqinfo.to(inp.query.device)
-            attn_bias.q_seqinfo.to(inp.query.device)
-            seq_len = attn_bias.k_seqinfo.seqlen
-            B = len(seq_len)
-            G, H, Kq = q.shape[-3:]
-            Kkv = v.shape[-1]
+        # if attn_bias is not None:
+        #     assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        #     # TODO: do we really need to do this cast? seems fishy but
+        #     # I just copied it from the decoder.py
+        #     attn_bias.k_seqinfo.to(inp.query.device)
+        #     attn_bias.q_seqinfo.to(inp.query.device)
+        #     seq_len = attn_bias.k_seqinfo.seqlen
+        #     B = len(seq_len)
+        #     G, H, Kq = q.shape[-3:]
+        #     Kkv = v.shape[-1]
 
-            # assume kv has been padded
-            q = q.reshape(B, -1, G, H, Kq)
-            k = k.reshape(B, -1, G, H, Kkv)
-            v = v.reshape(B, -1, G, H, Kkv)
+        #     # assume kv has been padded
+        #     q = q.reshape(B, -1, G, H, Kq)
+        #     k = k.reshape(B, -1, G, H, Kkv)
+        #     v = v.reshape(B, -1, G, H, Kkv)
 
         # Transpose in the case of MQA/GQA
         mqa_swap_seqlen_head = False
@@ -611,7 +600,7 @@ class FwOp(AttentionFwOpBase):
             split_k = cls.SPLIT_K
         else:
             # Use heuristics
-            split_k = cls.get_split_k(B, H, Mk)
+            split_k = get_split_k(B, H, Mk)
 
         M_ceil = (M + BLOCK_M - 1) // BLOCK_M * BLOCK_M
         o_splitk = torch.empty(
@@ -626,15 +615,15 @@ class FwOp(AttentionFwOpBase):
         num_warps = 2
         split_size = (Mk + split_k - 1) // split_k
         use_seq_len = seq_len is not None
-        _fwd_kernel_splitK_unrolled = unroll_varargs(
-            _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
-        )
+        # _fwd_kernel_splitK_unrolled = unroll_varargs(
+        #     _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
+        # )
 
-        _fwd_kernel_splitK_unrolled[grid](
+        _fwd_kernel_splitK[grid](
             Q=q,
             K=k,
             V=v,
-            sm_scale=inp.scale_float,
+            sm_scale=scale_float,
             Out_splitK=o_splitk,
             Metadata=metadata,
             Seq_len=seq_len,
@@ -689,7 +678,7 @@ class FwOp(AttentionFwOpBase):
             # H/M dimensions have been swapped
             out = out.transpose(1, 3)
             lse = lse.transpose(2, 3)
-        if inp.query.ndim == 4:
+        if q.ndim == 4:
             # BMGHK -> BMHK
             assert G == 1
             out = out[:, :, 0]
@@ -697,44 +686,140 @@ class FwOp(AttentionFwOpBase):
         if Mk == 0:
             out.zero_()
 
-        return out, Context(out=out, lse=lse)
+        return out
+
+attention = _attention.apply
+
+def get_input_shapes():
+    cases = [
+        # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
+        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+        for i in range(8, 18)
+    ] + [
+        # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
+        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
+        for i in range(8, 18)
+    ]
+    return cases
 
 
-class FwOp_S1(FwOp):
-    SPLIT_K = 1
-    NAME = "triton_splitK1"
+# @pytest.mark.parametrize('Z, H, N_CTX, D_HEAD',
+#                          [(4, 48, 1024, 64),
+#                           (4, 48, 2048, 64),
+#                           (4, 48, 4096, 64),
+#                           (4, 48, 1024, 128),
+#                           (4, 48, 2048, 128),
+#                           (4, 48, 4096, 128),
+#                           #(4, 48, 8192, 64),
+#                           #(4, 48, 16384, 64)
+#                           ])
+# def test_op_fwd(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
+#     torch.manual_seed(20)
+#     q = (
+#         torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda")
+#         .normal_(mean=0., std=0.5)
+#         .requires_grad_()
+#     )
+#     k = (
+#         torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda")
+#         .normal_(mean=0., std=0.5)
+#         .requires_grad_()
+#     )
+#     v = (
+#         torch.empty((Z, H, D_HEAD, N_CTX), dtype=dtype, device="cuda")
+#         .normal_(mean=0., std=0.5)
+#         .requires_grad_()
+#     )
+#     sm_scale = 0.5
+#     dout = torch.randn_like(q)
+#     # reference implementation
+#     M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
+#     p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+#     p = torch.softmax(p.float(), dim=-1).half()
+#     ref_out = torch.matmul(p, v.transpose(2,3))
+#     # triton implementation
+#     tri_out = attention(q, k, v, sm_scale)
+#     # compare
+#     assert torch.allclose(ref_out, tri_out, atol=1e-2, rtol=0)
 
 
-class FwOp_S2(FwOp):
-    SPLIT_K = 2
-    NAME = "triton_splitK2"
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# vary seq length for fixed head and batch=4
+configs = []
+for mode in ['fwd']:
+    # for D_HEAD in [128]:
+    for causal in [False]:
+        configs.append(triton.testing.Benchmark(
+            x_names=['B', 'Mq','Mkv', 'Hq', 'Hkv', 'K'],
+            x_vals=get_input_shapes(),
+            line_arg='provider',
+            line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+            line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
+            styles=[('red', '-'), ('blue', '-')],
+            ylabel='ms',
+            plot_name=f'fused-attention-d{128}-{mode}-causal={causal}',
+            args={
+                # 'D_HEAD': D_HEAD,
+                'dtype': torch.float16,
+                'mode': mode,
+                'causal': causal})
+        )
 
 
-class FwOp_S4(FwOp):
-    SPLIT_K = 4
-    NAME = "triton_splitK4"
+@triton.testing.perf_report(configs)
+def bench_flash_attention(B, Mq, Mkv, Hq, Hkv, K, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 100
+    rep = 400
+    if provider == "triton":
+        q = torch.randn(
+            [B, Mq, Hkv, Hq // Hkv, K], device="cuda", dtype=dtype, requires_grad=False
+        )
+        k = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+        v = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, sm_scale)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    # if provider == "flash":
+    #     qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+    #     if FLASH_VER == 1:
+    #         lengths = torch.full((BATCH,), fill_value=N_CTX, device=device)
+    #         cu_seqlens = torch.zeros((BATCH + 1,), device=device, dtype=torch.int32)
+    #         cu_seqlens[1:] = lengths.cumsum(0)
+    #         qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+    #         fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+    #     elif FLASH_VER == 2:
+    #         fn = lambda: flash_attn_func(qkv, causal=causal)
+    #     else:
+    #         raise ValueError(f'unknown {FLASH_VER = }')
+    #     ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul =  2 * B * Hq * (Mq * K * Mkv + Mq * Mkv * K)
+    total_flops = 2 * flops_per_matmul
+    totalBytes = ((B * Mkv * Hkv * K * 2) + (B * Mq * Hq * K) + (B * Mq * Hq * K)) * 2
+
+    # return totalBytes / ms * 1e-9
+    return ms * 1000
 
 
-class FwOp_S8(FwOp):
-    SPLIT_K = 8
-    NAME = "triton_splitK8"
+def main():
+    bench_flash_attention.run(save_path='.', print_data=True)
 
-
-class FwOp_S16(FwOp):
-    SPLIT_K = 16
-    NAME = "triton_splitK16"
-
-
-class FwOp_S32(FwOp):
-    SPLIT_K = 32
-    NAME = "triton_splitK32"
-
-
-class FwOp_S64(FwOp):
-    SPLIT_K = 64
-    NAME = "triton_splitK64"
-
-
-class FwOp_S128(FwOp):
-    SPLIT_K = 128
-    NAME = "triton_splitK128"
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/perf-kernels/06-attention-splitk.py
+++ b/python/perf-kernels/06-attention-splitk.py
@@ -691,12 +691,14 @@ attention = _attention.apply
 def get_input_shapes():
     cases = [
         # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
-        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
-        for i in range(8, 18)
+        #(max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+        #for i in range(8, 18)
     ] + [
         # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
-        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
-        for i in range(8, 18)
+        #(max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
+        #for i in range(8, 18)
+    ] + [
+        (2, 7, 7328, 1, 128, 128)
     ]
 
     # cases = [

--- a/python/perf-kernels/06-attention-splitk_autotune.py
+++ b/python/perf-kernels/06-attention-splitk_autotune.py
@@ -17,17 +17,17 @@ def _strides(x: torch.Tensor, *stride_names: str):
     return {f"stride_{s}": x.stride(i) for i, s in enumerate(stride_names)}
 
 
-# @triton.autotune(
-#    configs=[
-#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
-#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
-#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128, 'waves_per_eu': 2}, num_stages=1, num_warps=4),
-#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32}, num_stages=1, num_warps=2),
-#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64}, num_stages=1, num_warps=2),
-#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128}, num_stages=1, num_warps=4),
-#    ],
-#    key=['Z', 'H', 'G', 'N_CTX_Q', 'N_CTX_K', 'BLOCK_DMODEL'],        
-# )
+@triton.autotune(
+   configs=[
+    #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+    #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+    #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128, 'waves_per_eu': 2}, num_stages=1, num_warps=4),
+       triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32}, num_stages=1, num_warps=2),
+       triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64}, num_stages=1, num_warps=2),
+       triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128}, num_stages=1, num_warps=4),
+   ],
+   key=['Z', 'H', 'G', 'N_CTX_Q', 'N_CTX_K', 'BLOCK_DMODEL'],        
+)
 @triton.jit
 def _fwd_kernel_splitK(
     Q,
@@ -457,6 +457,7 @@ def _splitK_reduce(
 
     l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
     tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
 
 def get_split_k(B: int, H: int, Mk: int) -> int:
     # print(f"B = {B}, H = {H}, Mk = {Mk}")

--- a/python/perf-kernels/06-attention-splitk_autotune.py
+++ b/python/perf-kernels/06-attention-splitk_autotune.py
@@ -1,8 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
-#
-# This source code is licensed under the BSD license found in the
-# LICENSE file in the root directory of this source tree.
-
 
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
 import pytest

--- a/python/perf-kernels/06-attention-splitk_reduce.py
+++ b/python/perf-kernels/06-attention-splitk_reduce.py
@@ -1,8 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
-#
-# This source code is licensed under the BSD license found in the
-# LICENSE file in the root directory of this source tree.
-
 
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
 import pytest

--- a/python/perf-kernels/06-attention-splitk_reduce.py
+++ b/python/perf-kernels/06-attention-splitk_reduce.py
@@ -379,84 +379,112 @@ def dequantize(
 
 @triton.jit
 def _splitK_reduce(
-    Out_splitK,  # [B, H, split_k, Mq, K]
-    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
-    Out,  # [B, H, M, K]
-    LSE,  # [B, H, M]
-    split_k,
-    stride_osk_zhg,
-    stride_osk_s,
-    stride_osk_m,
-    stride_osk_k,
-    stride_mzhg,
-    stride_m2,
-    stride_ms,
-    stride_mm,
-    stride_oz,
-    stride_oh,
-    stride_og,
-    stride_om,
-    stride_ok,
-    stride_lse_zhg,
-    stride_lse_m,
-    BLOCK_SIZE: tl.constexpr,
-    H: tl.constexpr,
-    G: tl.constexpr,
+	Out_splitK,  # [B, H, split_k, Mq, K]
+	Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+	Out,  # [B, H, M, K]
+	LSE,  # [B, H, M]
+	split_k,
+	stride_osk_zhg,
+	stride_osk_s,
+	stride_osk_m,
+	stride_osk_k,
+	stride_mzhg,
+	stride_m2,
+	stride_ms,
+	stride_mm,
+	stride_oz,
+	stride_oh,
+	stride_og,
+	stride_om,
+	stride_ok,
+	stride_lse_zhg,
+	stride_lse_m,
+	BLOCK_SIZE: tl.constexpr,
+	H: tl.constexpr,
+	G: tl.constexpr,
 ):
-    off_zhg = tl.program_id(0)
-    off_z = off_zhg // (H * G)
-    off_h = (off_zhg // G) % H
-    off_g = off_zhg % G
-    off_m = tl.program_id(1)
+	off_zhg = tl.program_id(0)
+	off_z = off_zhg // (H * G)
+	off_h = (off_zhg // G) % H
+	off_g = off_zhg % G
+	off_m = tl.program_id(1)
 
-    Out_splitK_ptr = (
-        Out_splitK
-        + stride_osk_zhg * off_zhg
-        + stride_osk_m * off_m
-        + tl.arange(0, BLOCK_SIZE)
-    )
-    Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
-    m = tl.load(Metadata_ptr)
-    l_sum = tl.load(Metadata_ptr + stride_m2)
-    acc = tl.load(Out_splitK_ptr)
+	Out_splitK_ptr = (
+		Out_splitK
+		+ stride_osk_zhg * off_zhg
+		+ stride_osk_m * off_m
+		+ tl.arange(0, BLOCK_SIZE)
+	)
 
-    for split_k_idx in range(1, split_k):
-        Metadata_ptr = Metadata_ptr + stride_ms
-        Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+	Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
+	m = tl.load(Metadata_ptr)
+	l_sum = tl.load(Metadata_ptr + stride_m2)
+	acc = tl.load(Out_splitK_ptr)
 
-        m_k = tl.load(Metadata_ptr)
-        l_k = tl.load(Metadata_ptr + stride_m2)
-        acc_k = tl.load(Out_splitK_ptr)
+	Metadata_ptr = Metadata_ptr + stride_ms
+	Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+	m_k1 = tl.load(Metadata_ptr)
+	l_k1 = tl.load(Metadata_ptr + stride_m2)
+	acc_k1 = tl.load(Out_splitK_ptr)
 
-        m_new = tl.maximum(m, m_k)
-        if m_k < m:
-            # Scale incoming values
-            alpha = tl.math.exp2(m_k - m_new)
-            acc_k = acc_k * alpha
-            l_k = l_k * alpha
-        else:
-            # Scale our values
-            alpha = tl.math.exp2(m - m_new)
-            acc = acc * alpha
-            l_sum = l_sum * alpha
+	for idx in range(2, split_k):
+		Metadata_ptr = Metadata_ptr + stride_ms
+		Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
 
-        m = m_new
-        l_sum = l_sum + l_k
-        acc = acc + acc_k
+		m_k = m_k1
+		l_k = l_k1
+		acc_k = acc_k1
 
-    acc = acc / l_sum
-    Out_ptr = (
-        Out
-        + stride_oz * off_z
-        + stride_oh * off_h
-        + stride_og * off_g
-        + stride_om * off_m
-        + tl.arange(0, BLOCK_SIZE)
-    )
-    tl.store(Out_ptr, acc)
+		m_k1 = tl.load(Metadata_ptr)
+		l_k1 = tl.load(Metadata_ptr + stride_m2)
+		acc_k1 = tl.load(Out_splitK_ptr)
 
-    l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
-    tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+		m_new = tl.maximum(m, m_k)
+		if m_k < m:
+			# Scale incoming values
+			alpha = tl.math.exp2(m_k - m_new)
+			acc_k = acc_k * alpha
+			l_k = l_k * alpha
+		else:
+			# Scale our values
+			alpha = tl.math.exp2(m - m_new)
+			acc = acc * alpha
+			l_sum = l_sum * alpha
+
+		m = m_new
+		l_sum = l_sum + l_k
+		acc = acc + acc_k
+
+	m_new = tl.maximum(m, m_k1)
+	if m_k1 < m:
+		# Scale incoming values
+		alpha = tl.math.exp2(m_k1 - m_new)
+		acc_k1 = acc_k1 * alpha
+		l_k1 = l_k1 * alpha
+	else:
+		# Scale our values
+		alpha = tl.math.exp2(m - m_new)
+		acc = acc * alpha
+		l_sum = l_sum * alpha
+
+	m = m_new
+	l_sum = l_sum + l_k1
+	acc = acc + acc_k1
+
+	acc = acc / l_sum
+	Out_ptr = (
+		Out
+		+ stride_oz * off_z
+		+ stride_oh * off_h
+		+ stride_og * off_g
+		+ stride_om * off_m
+		+ tl.arange(0, BLOCK_SIZE)
+	)
+	tl.store(Out_ptr, acc)
+
+	l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
+	tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
 
 def get_split_k(B: int, H: int, Mk: int) -> int:
     # print(f"B = {B}, H = {H}, Mk = {Mk}")

--- a/python/perf-kernels/06-attention-splitk_reduce_log.py
+++ b/python/perf-kernels/06-attention-splitk_reduce_log.py
@@ -714,12 +714,12 @@ attention = _attention.apply
 def get_input_shapes():
     cases = [
         # dict(B=max(1, 1), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
-        (max(1, 1), 1, 2**i, 16, 1, 64)
-        for i in range(8, 9)
+        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+        for i in range(8, 18)
     ] + [
         # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
         (max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
-        for i in range(17, 17)
+        for i in range(8, 18)
     ]
 
     # cases = [
@@ -805,6 +805,7 @@ def bench_flash_attention(B, Mq, Mkv, Hq, Hkv, K, causal, mode, provider, dtype=
     assert mode in ['fwd', 'bwd']
     warmup = 100
     rep = 400
+    ms = 0
     if provider == "triton":
         q = torch.randn(
             [B, Mq, Hkv, Hq // Hkv, K], device="cuda", dtype=dtype, requires_grad=False

--- a/python/perf-kernels/06-attention-splitk_reduce_log.py
+++ b/python/perf-kernels/06-attention-splitk_reduce_log.py
@@ -1,0 +1,855 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
+import pytest
+import torch
+import sys
+
+import triton
+import triton.language as tl
+
+def _strides(x: torch.Tensor, *stride_names: str):
+    assert x.ndim == len(stride_names)
+    return {f"stride_{s}": x.stride(i) for i, s in enumerate(stride_names)}
+
+
+# @triton.autotune(
+#    configs=[
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128, 'waves_per_eu': 2}, num_stages=1, num_warps=4),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32}, num_stages=1, num_warps=2),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64}, num_stages=1, num_warps=2),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128}, num_stages=1, num_warps=4),
+#    ],
+#    key=['Z', 'H', 'G', 'N_CTX_Q', 'N_CTX_K', 'BLOCK_DMODEL'],        
+# )
+@triton.jit
+def _fwd_kernel_splitK(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+    Seq_len,
+    stride_qz,
+    stride_qm,
+    stride_qg,
+    stride_qh,
+    stride_qk,
+    stride_kz,
+    stride_kn,
+    stride_kg,
+    stride_kh,
+    stride_kk,
+    stride_vz,
+    stride_vn,
+    stride_vg,
+    stride_vh,
+    stride_vk,
+    stride_osk_zhg,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_mzhg,
+    stride_m2,
+    stride_ms,
+    stride_mm,
+    Z,
+    N_CTX_Q,
+    N_CTX_K,
+    BLOCK_N_PER_SPLIT,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    USE_SEQ_LEN: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr = 1,
+    N_GROUPS: tl.constexpr = 1,
+):
+    """This kernel can accept non-quantized or int4-quantized keys/values.
+    PACKED_PER_VAL determines the quantization type:
+        - PACKED_PER_VAL == 1 means no quantization
+        - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
+    For the quantized case K/V should be int32 tensors.
+    Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
+    Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
+    So K[B, H, M, :] has a form
+    [   quant_coef0, quant_coef1, ...|
+        group0_quant_value0, group0_quant_value1,... |
+        group1_quant_value0, group1_quant_value1,...]
+    where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
+
+    Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
+    before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
+    See how FwOp.apply does it below.
+    """
+    tl.static_assert(
+        (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
+        or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
+        f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
+        f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
+    )
+    tl.static_assert(
+        (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
+        "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
+    )
+
+    QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
+    PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
+    D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
+
+    start_m = tl.program_id(0)
+    off_zhg = tl.program_id(1)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    splitk_idx = tl.program_id(2)
+
+    lo = splitk_idx * BLOCK_N_PER_SPLIT
+    if USE_SEQ_LEN:
+        kv_len = tl.load(Seq_len + off_z)
+    else:
+        kv_len = N_CTX_K
+    hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
+
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    k_base = K + off_h * stride_kh + off_z * stride_kz + off_g * stride_kg
+    # Additional shift by 1 along the last dimension in the quantized case, since
+    # the first element along that dim contains packed quantization coefficients.
+    K_block_ptr = tl.make_block_ptr(
+        base=k_base + stride_kk * QUANTIZED * N_GROUPS,
+        shape=(PACKED_D_PER_GROUP, hi),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, lo),
+        block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+        order=(0, 1),
+    )
+    v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
+    V_block_ptr = tl.make_block_ptr(
+        base=v_base + stride_vk * QUANTIZED * N_GROUPS,
+        shape=(hi, PACKED_D_PER_GROUP),
+        strides=(stride_vn, stride_vk),
+        offsets=(lo, 0),
+        block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    if QUANTIZED:
+        # Pointers to quantization coefficients. Even those they are 1D,
+        # we have to use block pointers, since usual pointers
+        # don't support boundary checks
+        K_scale_shift_block_ptr = tl.make_block_ptr(
+            base=k_base,
+            shape=(1, hi),
+            strides=(stride_kk, stride_kn),
+            offsets=(0, lo),
+            block_shape=(1, BLOCK_N),
+            order=(0, 1),
+        )
+        V_scale_shift_block_ptr = tl.make_block_ptr(
+            base=v_base,
+            shape=(hi, 1),
+            strides=(stride_vn, stride_vk),
+            offsets=(lo, 0),
+            block_shape=(BLOCK_N, 1),
+            order=(1, 0),
+        )
+    else:
+        K_scale_shift_block_ptr = None
+        V_scale_shift_block_ptr = None
+
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
+    # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
+    # This is a solution for Triton native lack of support for lists of tensors.
+    # acc: "VAR_ARGS_ARRAY"  # noqa: F821
+    # acc = []
+    elem_num = 1
+    # for i in range(elem_num):  # noqa: F821
+    acc = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
+
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    # load q: it will stay in SRAM throughout
+    # q: "VAR_ARGS_ARRAY"  # noqa: F821
+    # for i in range(elem_num):  # noqa: F821
+    q = tl.load(  # noqa: F821
+        tl.advance(Q_block_ptr, (0, 0)), boundary_check=(0,)
+    )
+
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        # k: "VAR_ARGS_ARRAY"  # noqa: F821
+        # v: "VAR_ARGS_ARRAY"  # noqa: F821
+        # for i in range(len(acc)):  # noqa: F821
+        k, v = load_dequantize_k_v_group(  # noqa: F821
+            K_block_ptr,
+            V_block_ptr,
+            K_scale_shift_block_ptr,
+            V_scale_shift_block_ptr,
+            BOUNDS_CHECKS_N,
+            PACKED_PER_VAL,
+            PACKED_D_PER_GROUP,
+            Q.dtype.element_ty,
+            0,
+        )
+        # k.append(k_tmp)
+        # v.append(v_tmp)
+
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        # for i in range(elem_num):  # noqa: F821
+        qk += tl.dot(q, k)  # noqa: F821
+        qk *= qk_scale
+
+        # TODO: This is slow, and only needed at the last iteration.
+        # Maybe we can unroll the last iteration instead?
+        if BOUNDS_CHECKS_N:
+            qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk - m_i_new[:, None])
+
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        p = p.to(Q.dtype.element_ty)
+
+        # -- scale and update acc --
+        # for i in range(elem_num):  # noqa: F821
+        acc *= alpha[:, None]  # noqa: F821
+        acc += tl.dot(p, v)  # noqa: F821
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        if PACKED_PER_VAL > 1:
+            K_scale_shift_block_ptr = tl.advance(
+                K_scale_shift_block_ptr, (0, BLOCK_N)
+            )
+            V_scale_shift_block_ptr = tl.advance(
+                V_scale_shift_block_ptr, (BLOCK_N, 0)
+            )
+
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_osk_m, 1),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+    # for i in range(elem_num):  # noqa: F821
+    tl.store(
+        tl.advance(O_block_ptr, (0, 0)),
+        acc,  # noqa: F821
+        boundary_check=(0,),
+    )
+    # Write metadata for split-K reduction
+    Metadata_ptr = (
+        Metadata
+        + off_zhg * stride_mzhg
+        + splitk_idx * stride_ms
+        + start_m * BLOCK_M
+        + tl.arange(0, BLOCK_M)
+    )
+    tl.store(Metadata_ptr, m_i)
+    tl.store(Metadata_ptr + stride_m2, l_i)
+
+@triton.jit
+def load_dequantize_k_v_group(
+    K_block_ptr,
+    V_block_ptr,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    PACKED_D_PER_GROUP: tl.constexpr,
+    dtype: tl.constexpr,
+    group_id: tl.constexpr,
+):
+    """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
+    If quantization is group-wise, use group_id to advance the pointers to the current group.
+    """
+    # Advance to the current quantization group
+    K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
+    V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+
+    # -- load k, v --
+    k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
+    v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+
+    if PACKED_PER_VAL > 1:
+        # K/V are quantized, load quantization coefficients and dequantize
+
+        K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
+        V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
+
+        k_scale_shift = tl.load(
+            K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+        )
+        v_scale_shift = tl.load(
+            V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+        )
+
+        k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
+        v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
+        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
+        k_t = dequantize(
+            tl.trans(k),
+            tl.trans(k_scale),
+            tl.trans(k_shift),
+            PACKED_PER_VAL,
+        ).to(dtype)
+        k = tl.trans(k_t)
+    return k, v
+
+@triton.jit
+def cast_uint32_to_half2(scale_shift):
+    """Extract two float16 packed into one int32"""
+    scale = scale_shift & 0xFFFF
+    shift = scale_shift >> 16
+    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
+    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
+    return scale, shift
+
+@triton.jit
+def dequantize(
+    x_,
+    scale,
+    shift,
+    PACKED_PER_VAL: tl.constexpr = 8,
+):
+    """PACKED_PER_VAL is the number of values packed into each element x_.
+    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+    """
+
+    # Axis along which offsets are applied matters here
+    # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+    # and expand K/V to that shape before applying offsets
+    # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
+    # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
+    # on the implementation details which might change in the future.
+    # Ideally we would like to use tl.reshape, but it's not implemented yet.
+    # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
+
+    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+    # scale: (BLOCK_N, 1)
+    # offsets: (PACKED_PER_VAL,)
+    BLOCK_N: tl.constexpr = x_.shape[0]
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+    offsets = tl.arange(0, PACKED_PER_VAL) * 4
+    quant_offset = (
+        x_[:, None, :] >> offsets[None, :, None]
+    )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
+
+    quant_offset = tl.view(
+        quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+    )
+    # Trick - instead of converting int4 to float16 we view it as float16
+    # and then multiply by 32768 * 512 == 2**24
+    quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
+    quant_offset = (quant_offset * 32768.0).to(tl.float16)
+    scale_512 = scale * 512
+
+    dequant = quant_offset * scale_512 + shift
+    return dequant
+
+@triton.jit
+def _splitK_reduce(
+	Out_splitK,  # [B, H, split_k, Mq, K]
+	Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+	Out,  # [B, H, M, K]
+	LSE,  # [B, H, M]
+	split_k,
+	stride_osk_zhg,
+	stride_osk_s,
+	stride_osk_m,
+	stride_osk_k,
+	stride_mzhg,
+	stride_m2,
+	stride_ms,
+	stride_mm,
+	stride_oz,
+	stride_oh,
+	stride_og,
+	stride_om,
+	stride_ok,
+	stride_lse_zhg,
+	stride_lse_m,
+	BLOCK_SIZE: tl.constexpr,
+	H: tl.constexpr,
+	G: tl.constexpr,
+):
+	off_zhg = tl.program_id(0)
+	off_z = off_zhg // (H * G)
+	off_h = (off_zhg // G) % H
+	off_g = off_zhg % G
+	off_m = tl.program_id(1)
+
+	Out_splitK_ptr = (
+		Out_splitK
+		+ stride_osk_zhg * off_zhg
+		+ stride_osk_m * off_m
+		+ tl.arange(0, BLOCK_SIZE)
+	)
+
+	Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
+	m = tl.load(Metadata_ptr)
+	l_sum = tl.load(Metadata_ptr + stride_m2)
+	acc = tl.load(Out_splitK_ptr)
+
+	Metadata_ptr = Metadata_ptr + stride_ms
+	Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+	m_k1 = tl.load(Metadata_ptr)
+	l_k1 = tl.load(Metadata_ptr + stride_m2)
+	acc_k1 = tl.load(Out_splitK_ptr)
+
+	for idx in range(2, split_k):
+		Metadata_ptr = Metadata_ptr + stride_ms
+		Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+
+		m_k = m_k1
+		l_k = l_k1
+		acc_k = acc_k1
+
+		m_k1 = tl.load(Metadata_ptr)
+		l_k1 = tl.load(Metadata_ptr + stride_m2)
+		acc_k1 = tl.load(Out_splitK_ptr)
+
+		m_new = tl.maximum(m, m_k)
+		if m_k < m:
+			# Scale incoming values
+			alpha = tl.math.exp2(m_k - m_new)
+			acc_k = acc_k * alpha
+			l_k = l_k * alpha
+		else:
+			# Scale our values
+			alpha = tl.math.exp2(m - m_new)
+			acc = acc * alpha
+			l_sum = l_sum * alpha
+
+		m = m_new
+		l_sum = l_sum + l_k
+		acc = acc + acc_k
+
+	m_new = tl.maximum(m, m_k1)
+	if m_k1 < m:
+		# Scale incoming values
+		alpha = tl.math.exp2(m_k1 - m_new)
+		acc_k1 = acc_k1 * alpha
+		l_k1 = l_k1 * alpha
+	else:
+		# Scale our values
+		alpha = tl.math.exp2(m - m_new)
+		acc = acc * alpha
+		l_sum = l_sum * alpha
+
+	m = m_new
+	l_sum = l_sum + l_k1
+	acc = acc + acc_k1
+
+	acc = acc / l_sum
+	Out_ptr = (
+		Out
+		+ stride_oz * off_z
+		+ stride_oh * off_h
+		+ stride_og * off_g
+		+ stride_om * off_m
+		+ tl.arange(0, BLOCK_SIZE)
+	)
+	tl.store(Out_ptr, acc)
+
+	l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
+	tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
+
+def get_split_k(B: int, H: int, Mk: int) -> int:
+    # print(f"B = {B}, H = {H}, Mk = {Mk}")
+    """Heuristic for the number of splits"""
+    bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+    split_k = max(Mk, 1024) // bh
+    max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+    while split_k > 0 and Mk / split_k < max_chunk_size:
+        split_k = split_k // 2
+    split_k = min(split_k, 64)
+    split_k = max(split_k, 1)
+    return split_k
+
+# @register_operator
+# class FwOp(AttentionFwOpBase):
+class _attention(torch.autograd.Function):
+
+    OPERATOR = _fwd_kernel_splitK
+    SUPPORTED_DEVICES = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
+    SUPPORTED_DTYPES = {
+        torch.half,
+        torch.bfloat16,
+    }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
+    SUPPORTED_MAX_K = 128
+    # SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
+    #     type(None),
+    #     BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    # }
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    NAME = "triton_splitKF"
+
+
+    # @classmethod
+    # def shape_not_supported_reasons(
+    #     cls, Mq: int, Mkv: int, K: int, Kv: int
+    # ) -> List[str]:
+    #     reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+    #     if K not in {16, 32, 64, 128}:
+    #         reasons.append(f"Embed dim {K} not supported")
+    #     return reasons
+
+    # @classmethod
+    # def not_supported_reasons(cls, d: Inputs) -> List[str]:
+    #     reasons = super(FwOp, cls).not_supported_reasons(d)
+    #     check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+    #     if d.key.dtype != torch.int32:
+    #         check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+    #         check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+    #     if cls.OPERATOR is None:
+    #         reasons.append("triton is not available")
+    #     if d.device.type == "cuda":
+    #         # Has only been tested on 8.0 / 9.0.
+    #         if torch.cuda.get_device_capability(d.device) < (8, 0):
+    #             reasons.append(
+    #                 "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+    #             )
+
+    #     q_len = d.query.shape[1]
+    #     if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+    #         seqinfo = d.attn_bias.q_seqinfo
+    #         if q_len != seqinfo.seqstart_py[-1]:
+    #             reasons.append(
+    #                 f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+    #             )
+    #         q_len = seqinfo.min_seqlen
+    #         if q_len != seqinfo.max_seqlen:
+    #             reasons.append(
+    #                 "Variable query len is not supported in the presence of causal mask."
+    #             )
+
+    #     if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
+    #         if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
+    #             reasons.append("multiquery is only supported with query seqlen=1")
+
+    #     if d.attn_bias is not None and q_len > 1:
+    #         reasons.append(
+    #             "query with seqlen > 1 is not supported in the presence of causal mask"
+    #         )
+    #     return reasons
+
+
+    # @classmethod
+
+    # def apply(
+    #     cls, inp: Inputs, needs_gradient: bool
+    # ) -> Tuple[torch.Tensor, Optional[Context]]:
+    @staticmethod
+    def forward(cls, q, k, v, scale_float):
+
+        cls.SPLIT_K: Optional[int] = None
+        cls.BLOCK_M = 16
+        cls.BLOCK_N = 64
+
+        cls.NUM_GROUPS = 1  # Default quantization is row-wise
+
+        # attn_bias = inp.attn_bias
+        seq_len = None
+        # q, k, v = inp.get_qkv_in_bmghk()
+
+        # if attn_bias is not None:
+        #     assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        #     # TODO: do we really need to do this cast? seems fishy but
+        #     # I just copied it from the decoder.py
+        #     attn_bias.k_seqinfo.to(inp.query.device)
+        #     attn_bias.q_seqinfo.to(inp.query.device)
+        #     seq_len = attn_bias.k_seqinfo.seqlen
+        #     B = len(seq_len)
+        #     G, H, Kq = q.shape[-3:]
+        #     Kkv = v.shape[-1]
+
+        #     # assume kv has been padded
+        #     q = q.reshape(B, -1, G, H, Kq)
+        #     k = k.reshape(B, -1, G, H, Kkv)
+        #     v = v.reshape(B, -1, G, H, Kkv)
+
+        # Transpose in the case of MQA/GQA
+        mqa_swap_seqlen_head = False
+        if k.shape[3] > 1 and k.stride(3) == 0 and v.stride(3) == 0:
+            mqa_swap_seqlen_head = True
+            assert q.shape[1] == 1
+            q = q.transpose(1, 3)
+            k = k[:, :, :, :1]
+            v = v[:, :, :, :1]
+
+        if k.dtype == torch.int32:
+            # Quantized K/V
+            PACKED_PER_VAL = 8
+            Lk = (k.shape[-1] - cls.NUM_GROUPS) * 8
+        else:
+            Lk = k.shape[-1]
+            PACKED_PER_VAL = 1
+
+        B, Mk, G, H, Kkv = k.shape
+        B, M, G, H, Kq = q.shape
+        assert Lk == Kq, f"Keys have head dim {Lk} but queries have head dim {Kq}"
+
+        BLOCK_M = cls.BLOCK_M
+        BLOCK_N = cls.BLOCK_N
+        if cls.SPLIT_K is not None:
+            split_k = cls.SPLIT_K
+        else:
+            # Use heuristics
+            split_k = get_split_k(B, H, Mk)
+
+        M_ceil = (M + BLOCK_M - 1) // BLOCK_M * BLOCK_M
+        o_splitk = torch.empty(
+            [B * G * H, split_k, M_ceil, Kq], dtype=torch.float32, device=q.device
+        )
+        metadata = torch.empty(
+            [B * G * H, 2, split_k, M_ceil], dtype=torch.float32, device=q.device
+        )
+        lse = torch.empty((B * G * H, M), device=q.device, dtype=torch.float32)
+        grid = (triton.cdiv(M, BLOCK_M), B * G * H, split_k)
+
+        num_warps = 2
+        split_size = (Mk + split_k - 1) // split_k
+        use_seq_len = seq_len is not None
+        # _fwd_kernel_splitK_unrolled = unroll_varargs(
+        #     _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
+        # )
+
+        _fwd_kernel_splitK[grid](
+            Q=q,
+            K=k,
+            V=v,
+            sm_scale=scale_float,
+            Out_splitK=o_splitk,
+            Metadata=metadata,
+            Seq_len=seq_len,
+            **_strides(q, "qz", "qm", "qg", "qh", "qk"),
+            **_strides(k, "kz", "kn", "kg", "kh", "kk"),
+            **_strides(v, "vz", "vn", "vg", "vh", "vk"),
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            Z=B,
+            H=H,
+            G=G,
+            N_CTX_Q=M,
+            N_CTX_K=Mk,
+            BLOCK_N_PER_SPLIT=split_size,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_DMODEL=Lk,
+            BOUNDS_CHECKS_N=(split_size % BLOCK_N) > 0 or use_seq_len,
+            USE_SEQ_LEN=use_seq_len,
+            num_warps=num_warps,
+            num_stages=1,
+            PACKED_PER_VAL=PACKED_PER_VAL,
+            N_GROUPS=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1,
+        )
+
+        if mqa_swap_seqlen_head:
+            out = torch.empty(
+                (B, H, G, M, Kq), device=q.device, dtype=q.dtype
+            ).transpose(1, 3)
+        else:
+            out = torch.empty((B, M, G, H, Kq), device=q.device, dtype=q.dtype)
+
+        # Merge together
+        grid = (B * G * H, M, 1)
+        _splitK_reduce[grid](
+            o_splitk,
+            metadata,
+            out,
+            lse,
+            split_k=split_k,
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            **_strides(out, "oz", "om", "og", "oh", "ok"),
+            **_strides(lse, "lse_zhg", "lse_m"),
+            BLOCK_SIZE=out.shape[-1],
+            G=G,
+            H=H,
+            # TODO: Tune num_warps
+        )
+        lse = lse.reshape([B, G, H, M])
+        if mqa_swap_seqlen_head:
+            # H/M dimensions have been swapped
+            out = out.transpose(1, 3)
+            lse = lse.transpose(2, 3)
+        if q.ndim == 4:
+            # BMGHK -> BMHK
+            assert G == 1
+            out = out[:, :, 0]
+            lse = lse[:, 0]
+        if Mk == 0:
+            out.zero_()
+            
+        out = out.reshape(B, H, -1, Kq).transpose(1, 2).contiguous()
+        return out
+
+attention = _attention.apply
+
+def get_input_shapes():
+    cases = [
+        # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
+        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+        for i in range(8, 18)
+    ] + [
+        # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
+        (max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
+        for i in range(8, 18)
+    ]
+
+    # cases = [
+    #     # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
+    #     (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+    #     for i in range(17, 18)
+    # ]
+
+    return cases
+
+
+@pytest.mark.parametrize('B, Mq, Mkv, Hq, Hkv, K',
+                         get_input_shapes())
+def test_op_fwd(B, Mq, Mkv, Hq, Hkv, K, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = (
+        torch.empty((B, Mq, Hkv, Hq // Hkv, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((B, Mkv, Hkv, 1, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    ).expand(-1, -1, -1, Hq // Hkv, -1)
+    v = (
+        torch.empty((B, Mkv, Hkv, 1, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    ).expand(-1, -1, -1, Hq // Hkv, -1)
+    scale = 1 / K**0.5
+    tri_out = attention(q, k, v, scale)
+
+    q = q.reshape([B, Mq, -1, K]).permute(0, 2, 1, 3)
+    k = k.reshape([B, Mkv, -1, K]).permute(0, 2, 1, 3)
+    v = v.reshape([B, Mkv, -1, K]).permute(0, 2, 1, 3)
+    attn = (q @ k.transpose(-1, -2) * scale).softmax(-1)
+    ref_out = attn @ v
+
+    # compare
+    torch.testing.assert_close(ref_out, tri_out, atol=1e-3, rtol=0)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# vary seq length for fixed head and batch=4
+configs = []
+for mode in ['fwd']:
+    # for D_HEAD in [128]:
+    for causal in [False]:
+        configs.append(triton.testing.Benchmark(
+            x_names=['B', 'Mq','Mkv', 'Hq', 'Hkv', 'K'],
+            x_vals=get_input_shapes(),
+            line_arg='provider',
+            line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+            line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
+            styles=[('red', '-'), ('blue', '-')],
+            ylabel='ms',
+            plot_name=f'fused-attention-d{128}-{mode}-causal={causal}',
+            args={
+                # 'D_HEAD': D_HEAD,
+                'dtype': torch.float16,
+                'mode': mode,
+                'causal': causal})
+        )
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(B, Mq, Mkv, Hq, Hkv, K, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 100
+    rep = 400
+    if provider == "triton":
+        q = torch.randn(
+            [B, Mq, Hkv, Hq // Hkv, K], device="cuda", dtype=dtype, requires_grad=False
+        )
+        k = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+        v = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, sm_scale)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    # if provider == "flash":
+    #     qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+    #     if FLASH_VER == 1:
+    #         lengths = torch.full((BATCH,), fill_value=N_CTX, device=device)
+    #         cu_seqlens = torch.zeros((BATCH + 1,), device=device, dtype=torch.int32)
+    #         cu_seqlens[1:] = lengths.cumsum(0)
+    #         qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+    #         fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+    #     elif FLASH_VER == 2:
+    #         fn = lambda: flash_attn_func(qkv, causal=causal)
+    #     else:
+    #         raise ValueError(f'unknown {FLASH_VER = }')
+    #     ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul =  2 * B * Hq * (Mq * K * Mkv + Mq * Mkv * K)
+    total_flops = 2 * flops_per_matmul
+    totalBytes = ((B * Mkv * Hkv * K * 2) + (B * Mq * Hq * K) + (B * Mq * Hq * K)) * 2
+
+    # return totalBytes / ms * 1e-9
+    return ms * 1000
+
+
+def main():
+    bench_flash_attention.run(save_path='.', print_data=True)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/perf-kernels/06-attention-splitk_reduce_log.py
+++ b/python/perf-kernels/06-attention-splitk_reduce_log.py
@@ -459,27 +459,27 @@ def _splitK_reduce(
     O_block_ptr = tl.make_block_ptr(
         base=Out_splitK + off_zhg * stride_osk_zhg,
         shape=(split_k, D_PER_GROUP),
-        strides=(stride_osk_s, 1),
-        offsets=(off_m * M_ceil, 0),
+        strides=(stride_osk_s, stride_osk_k),
+        offsets=(0, off_m * stride_osk_m),
         block_shape=(split_k, D_PER_GROUP),
         order=(1, 0),
     )
     # read acc
-    acc = tl.load(O_block_ptr, boundary_check=(1, 0))
+    acc = tl.load(O_block_ptr)
     
     #read local m
     m_base = Metadata + stride_mzhg * off_zhg
     m_block_ptr = tl.make_block_ptr(
         base = m_base,
         shape=(split_k, 1),
-        strides=(stride_omzhg, 1),
-        offsets=(off_m, 0),
+        strides=(stride_omzhg, stride_mm),
+        offsets=(0, off_m * stride_mm),
         block_shape=(split_k, 1),
         order=(1, 0)
     )
     l_m = tl.load(m_block_ptr)
 
-    gm_ptr = Out_metadata + stride_mzhg * off_zhg + off_m
+    gm_ptr = Out_metadata + stride_mzhg * off_zhg + stride_omm * off_m
     g_m = tl.load(gm_ptr)
     g_sum = tl.load(gm_ptr + stride_om2)
 

--- a/python/perf-kernels/attention_split_head.py
+++ b/python/perf-kernels/attention_split_head.py
@@ -29,9 +29,8 @@ def _fwd_kernel_splitK(
     K,
     V,
     sm_scale,
-    Out_splitK,  # [B, H, split_k, Mq, K]
-    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
-    Seq_len,
+    Out,
+    lse,
     stride_qz,
     stride_qm,
     stride_qg,
@@ -47,80 +46,34 @@ def _fwd_kernel_splitK(
     stride_vg,
     stride_vh,
     stride_vk,
-    stride_osk_zhg,
-    stride_osk_s,
-    stride_osk_m,
-    stride_osk_k,
-    stride_mzhg,
-    stride_m2,
-    stride_ms,
-    stride_mm,
+    stride_oz,
+    stride_om,
+    stride_og,
+    stride_oh,
+    stride_on,
     Z,
     N_CTX_Q,
     N_CTX_K,
-    BLOCK_N_PER_SPLIT,
     H: tl.constexpr,
     G: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_N: tl.constexpr,
-    BOUNDS_CHECKS_N: tl.constexpr,
-    USE_SEQ_LEN: tl.constexpr,
-    PACKED_PER_VAL: tl.constexpr = 1,
-    N_GROUPS: tl.constexpr = 1,
 ):
-    """This kernel can accept non-quantized or int4-quantized keys/values.
-    PACKED_PER_VAL determines the quantization type:
-        - PACKED_PER_VAL == 1 means no quantization
-        - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
-    For the quantized case K/V should be int32 tensors.
-    Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
-    Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
-    So K[B, H, M, :] has a form
-    [   quant_coef0, quant_coef1, ...|
-        group0_quant_value0, group0_quant_value1,... |
-        group1_quant_value0, group1_quant_value1,...]
-    where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
-
-    Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
-    before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
-    See how FwOp.apply does it below.
-    """
-    tl.static_assert(
-        (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
-        or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
-        f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
-        f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
-    )
-    tl.static_assert(
-        (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
-        "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
-    )
-
-    QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
-    PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
-    D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
-
     start_m = tl.program_id(0)
     off_zhg = tl.program_id(1)
     off_z = off_zhg // (H * G)
     off_h = (off_zhg // G) % H
     off_g = off_zhg % G
-    splitk_idx = tl.program_id(2)
 
-    lo = splitk_idx * BLOCK_N_PER_SPLIT
-    if USE_SEQ_LEN:
-        kv_len = tl.load(Seq_len + off_z)
-    else:
-        kv_len = N_CTX_K
-    hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
+    kv_len = N_CTX_K
 
     Q_block_ptr = tl.make_block_ptr(
         base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
-        shape=(N_CTX_Q, D_PER_GROUP),
+        shape=(N_CTX_Q, BLOCK_DMODEL),
         strides=(stride_qm, stride_qk),
         offsets=(start_m * BLOCK_M, 0),
-        block_shape=(BLOCK_M, D_PER_GROUP),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
         order=(1, 0),
     )
 
@@ -128,89 +81,43 @@ def _fwd_kernel_splitK(
     # Additional shift by 1 along the last dimension in the quantized case, since
     # the first element along that dim contains packed quantization coefficients.
     K_block_ptr = tl.make_block_ptr(
-        base=k_base + stride_kk * QUANTIZED * N_GROUPS,
-        shape=(PACKED_D_PER_GROUP, hi),
+        base=k_base,
+        shape=(BLOCK_DMODEL, kv_len),
         strides=(stride_kk, stride_kn),
-        offsets=(0, lo),
-        block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+        offsets=(0, 0),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
         order=(0, 1),
     )
     v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
     V_block_ptr = tl.make_block_ptr(
-        base=v_base + stride_vk * QUANTIZED * N_GROUPS,
-        shape=(hi, PACKED_D_PER_GROUP),
+        base=v_base,
+        shape=(kv_len, BLOCK_DMODEL),
         strides=(stride_vn, stride_vk),
-        offsets=(lo, 0),
-        block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
         order=(1, 0),
     )
-
-    if QUANTIZED:
-        # Pointers to quantization coefficients. Even those they are 1D,
-        # we have to use block pointers, since usual pointers
-        # don't support boundary checks
-        K_scale_shift_block_ptr = tl.make_block_ptr(
-            base=k_base,
-            shape=(1, hi),
-            strides=(stride_kk, stride_kn),
-            offsets=(0, lo),
-            block_shape=(1, BLOCK_N),
-            order=(0, 1),
-        )
-        V_scale_shift_block_ptr = tl.make_block_ptr(
-            base=v_base,
-            shape=(hi, 1),
-            strides=(stride_vn, stride_vk),
-            offsets=(lo, 0),
-            block_shape=(BLOCK_N, 1),
-            order=(1, 0),
-        )
-    else:
-        K_scale_shift_block_ptr = None
-        V_scale_shift_block_ptr = None
 
     # initialize pointer to m and l
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
 
-    # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
-    # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
-    # This is a solution for Triton native lack of support for lists of tensors.
-    # acc: "VAR_ARGS_ARRAY"  # noqa: F821
-    # acc = []
-    elem_num = 1
-    # for i in range(elem_num):  # noqa: F821
-    acc = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
 
     # scale sm_scale by log_2(e) and use
     # 2^x instead of exp in the loop because CSE and LICM
     # don't work as expected with `exp` in the loop
     qk_scale = sm_scale * 1.44269504
     # load q: it will stay in SRAM throughout
-    # q: "VAR_ARGS_ARRAY"  # noqa: F821
-    # for i in range(elem_num):  # noqa: F821
-    q = tl.load(  # noqa: F821
-        tl.advance(Q_block_ptr, (0, 0)), boundary_check=(0,)
+    q = tl.load(
+        tl.advance(Q_block_ptr, (0, 0))
     )
 
     # loop over k, v and update accumulator
-    for start_n in range(lo, hi, BLOCK_N):
-        # k: "VAR_ARGS_ARRAY"  # noqa: F821
-        # v: "VAR_ARGS_ARRAY"  # noqa: F821
-        # for i in range(len(acc)):  # noqa: F821
-        k, v = load_dequantize_k_v_group(  # noqa: F821
-            K_block_ptr,
-            V_block_ptr,
-            K_scale_shift_block_ptr,
-            V_scale_shift_block_ptr,
-            BOUNDS_CHECKS_N,
-            PACKED_PER_VAL,
-            PACKED_D_PER_GROUP,
-            Q.dtype.element_ty,
-            0,
-        )
-        # k.append(k_tmp)
-        # v.append(v_tmp)
+    for start_n in range(0, kv_len, BLOCK_N):
+        # -- load k, v --
+        k = tl.load(K_block_ptr)
+        v = tl.load(V_block_ptr)
 
         # -- compute qk ---
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
@@ -218,10 +125,6 @@ def _fwd_kernel_splitK(
         qk += tl.dot(q, k)  # noqa: F821
         qk *= qk_scale
 
-        # TODO: This is slow, and only needed at the last iteration.
-        # Maybe we can unroll the last iteration instead?
-        if BOUNDS_CHECKS_N:
-            qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
         # -- compute scaling constant ---
         m_i_new = tl.maximum(m_i, tl.max(qk, 1))
         alpha = tl.math.exp2(m_i - m_i_new)
@@ -233,240 +136,30 @@ def _fwd_kernel_splitK(
         p = p.to(Q.dtype.element_ty)
 
         # -- scale and update acc --
-        # for i in range(elem_num):  # noqa: F821
-        acc *= alpha[:, None]  # noqa: F821
-        acc += tl.dot(p, v)  # noqa: F821
+        acc *= alpha[:, None]
+        acc += tl.dot(p, v)
         # update pointers
         K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
         V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-        if PACKED_PER_VAL > 1:
-            K_scale_shift_block_ptr = tl.advance(
-                K_scale_shift_block_ptr, (0, BLOCK_N)
-            )
-            V_scale_shift_block_ptr = tl.advance(
-                V_scale_shift_block_ptr, (BLOCK_N, 0)
-            )
 
     # write back O
     O_block_ptr = tl.make_block_ptr(
-        base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
-        shape=(N_CTX_Q, D_PER_GROUP),
-        strides=(stride_osk_m, 1),
+        base=Out + off_h * stride_oh + off_z * stride_oz + off_g * stride_og,
+        shape=(N_CTX_Q, BLOCK_DMODEL),
+        strides=(stride_om, stride_on),
         offsets=(start_m * BLOCK_M, 0),
-        block_shape=(BLOCK_M, D_PER_GROUP),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
         order=(1, 0),
     )
-    # for i in range(elem_num):  # noqa: F821
     tl.store(
         tl.advance(O_block_ptr, (0, 0)),
-        acc,  # noqa: F821
+        (acc / l_i[:, None]).to(Out.type.element_ty),
         boundary_check=(0,),
     )
-    # Write metadata for split-K reduction
-    Metadata_ptr = (
-        Metadata
-        + off_zhg * stride_mzhg
-        + splitk_idx * stride_ms
-        + start_m * BLOCK_M
-        + tl.arange(0, BLOCK_M)
-    )
-    tl.store(Metadata_ptr, m_i)
-    tl.store(Metadata_ptr + stride_m2, l_i)
 
-@triton.jit
-def load_dequantize_k_v_group(
-    K_block_ptr,
-    V_block_ptr,
-    K_scale_shift_block_ptr,
-    V_scale_shift_block_ptr,
-    BOUNDS_CHECKS_N: tl.constexpr,
-    PACKED_PER_VAL: tl.constexpr,
-    PACKED_D_PER_GROUP: tl.constexpr,
-    dtype: tl.constexpr,
-    group_id: tl.constexpr,
-):
-    """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
-    If quantization is group-wise, use group_id to advance the pointers to the current group.
-    """
-    # Advance to the current quantization group
-    K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
-    V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+    l_ptrs = lse + start_m * BLOCK_M + tl.arange(0,BLOCK_M)
+    tl.store(l_ptrs, m_i + tl.math.log2(l_i))
 
-    # -- load k, v --
-    k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
-    v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
-
-    if PACKED_PER_VAL > 1:
-        # K/V are quantized, load quantization coefficients and dequantize
-
-        K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
-        V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
-
-        k_scale_shift = tl.load(
-            K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
-        )
-        v_scale_shift = tl.load(
-            V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
-        )
-
-        k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
-        v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
-        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
-        k_t = dequantize(
-            tl.trans(k),
-            tl.trans(k_scale),
-            tl.trans(k_shift),
-            PACKED_PER_VAL,
-        ).to(dtype)
-        k = tl.trans(k_t)
-    return k, v
-
-@triton.jit
-def cast_uint32_to_half2(scale_shift):
-    """Extract two float16 packed into one int32"""
-    scale = scale_shift & 0xFFFF
-    shift = scale_shift >> 16
-    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
-    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
-    return scale, shift
-
-@triton.jit
-def dequantize(
-    x_,
-    scale,
-    shift,
-    PACKED_PER_VAL: tl.constexpr = 8,
-):
-    """PACKED_PER_VAL is the number of values packed into each element x_.
-    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
-    """
-
-    # Axis along which offsets are applied matters here
-    # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
-    # and expand K/V to that shape before applying offsets
-    # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
-    # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
-    # on the implementation details which might change in the future.
-    # Ideally we would like to use tl.reshape, but it's not implemented yet.
-    # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
-
-    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
-    # scale: (BLOCK_N, 1)
-    # offsets: (PACKED_PER_VAL,)
-    BLOCK_N: tl.constexpr = x_.shape[0]
-    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
-    offsets = tl.arange(0, PACKED_PER_VAL) * 4
-    quant_offset = (
-        x_[:, None, :] >> offsets[None, :, None]
-    )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
-
-    quant_offset = tl.view(
-        quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
-    )
-    # Trick - instead of converting int4 to float16 we view it as float16
-    # and then multiply by 32768 * 512 == 2**24
-    quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
-    quant_offset = (quant_offset * 32768.0).to(tl.float16)
-    scale_512 = scale * 512
-
-    dequant = quant_offset * scale_512 + shift
-    return dequant
-
-@triton.jit
-def _splitK_reduce(
-    Out_splitK,  # [B, H, split_k, Mq, K]
-    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
-    Out,  # [B, H, M, K]
-    LSE,  # [B, H, M]
-    split_k,
-    stride_osk_zhg,
-    stride_osk_s,
-    stride_osk_m,
-    stride_osk_k,
-    stride_mzhg,
-    stride_m2,
-    stride_ms,
-    stride_mm,
-    stride_oz,
-    stride_oh,
-    stride_og,
-    stride_om,
-    stride_ok,
-    stride_lse_zhg,
-    stride_lse_m,
-    BLOCK_SIZE: tl.constexpr,
-    H: tl.constexpr,
-    G: tl.constexpr,
-):
-    off_zhg = tl.program_id(0)
-    off_z = off_zhg // (H * G)
-    off_h = (off_zhg // G) % H
-    off_g = off_zhg % G
-    off_m = tl.program_id(1)
-
-    Out_splitK_ptr = (
-        Out_splitK
-        + stride_osk_zhg * off_zhg
-        + stride_osk_m * off_m
-        + tl.arange(0, BLOCK_SIZE)
-    )
-    Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
-    m = tl.load(Metadata_ptr)
-    l_sum = tl.load(Metadata_ptr + stride_m2)
-    acc = tl.load(Out_splitK_ptr)
-
-    for split_k_idx in range(1, split_k):
-        Metadata_ptr = Metadata_ptr + stride_ms
-        Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
-
-        m_k = tl.load(Metadata_ptr)
-        l_k = tl.load(Metadata_ptr + stride_m2)
-        acc_k = tl.load(Out_splitK_ptr)
-
-        m_new = tl.maximum(m, m_k)
-        if m_k < m:
-            # Scale incoming values
-            alpha = tl.math.exp2(m_k - m_new)
-            acc_k = acc_k * alpha
-            l_k = l_k * alpha
-        else:
-            # Scale our values
-            alpha = tl.math.exp2(m - m_new)
-            acc = acc * alpha
-            l_sum = l_sum * alpha
-
-        m = m_new
-        l_sum = l_sum + l_k
-        acc = acc + acc_k
-
-    acc = acc / l_sum
-    Out_ptr = (
-        Out
-        + stride_oz * off_z
-        + stride_oh * off_h
-        + stride_og * off_g
-        + stride_om * off_m
-        + tl.arange(0, BLOCK_SIZE)
-    )
-    tl.store(Out_ptr, acc)
-
-    l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
-    tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
-
-def get_split_k(B: int, H: int, Mk: int) -> int:
-    # print(f"B = {B}, H = {H}, Mk = {Mk}")
-    """Heuristic for the number of splits"""
-    bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
-    split_k = max(Mk, 1024) // bh
-    max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
-    while split_k > 0 and Mk / split_k < max_chunk_size:
-        split_k = split_k // 2
-    split_k = min(split_k, 64)
-    split_k = max(split_k, 1)
-    return split_k
-
-# @register_operator
-# class FwOp(AttentionFwOpBase):
 class _attention(torch.autograd.Function):
 
     OPERATOR = _fwd_kernel_splitK
@@ -486,61 +179,6 @@ class _attention(torch.autograd.Function):
     SUPPORTS_BMGHK = True
     NAME = "triton_splitKF"
 
-
-    # @classmethod
-    # def shape_not_supported_reasons(
-    #     cls, Mq: int, Mkv: int, K: int, Kv: int
-    # ) -> List[str]:
-    #     reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
-    #     if K not in {16, 32, 64, 128}:
-    #         reasons.append(f"Embed dim {K} not supported")
-    #     return reasons
-
-    # @classmethod
-    # def not_supported_reasons(cls, d: Inputs) -> List[str]:
-    #     reasons = super(FwOp, cls).not_supported_reasons(d)
-    #     check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
-    #     if d.key.dtype != torch.int32:
-    #         check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
-    #         check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
-    #     if cls.OPERATOR is None:
-    #         reasons.append("triton is not available")
-    #     if d.device.type == "cuda":
-    #         # Has only been tested on 8.0 / 9.0.
-    #         if torch.cuda.get_device_capability(d.device) < (8, 0):
-    #             reasons.append(
-    #                 "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
-    #             )
-
-    #     q_len = d.query.shape[1]
-    #     if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
-    #         seqinfo = d.attn_bias.q_seqinfo
-    #         if q_len != seqinfo.seqstart_py[-1]:
-    #             reasons.append(
-    #                 f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
-    #             )
-    #         q_len = seqinfo.min_seqlen
-    #         if q_len != seqinfo.max_seqlen:
-    #             reasons.append(
-    #                 "Variable query len is not supported in the presence of causal mask."
-    #             )
-
-    #     if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
-    #         if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
-    #             reasons.append("multiquery is only supported with query seqlen=1")
-
-    #     if d.attn_bias is not None and q_len > 1:
-    #         reasons.append(
-    #             "query with seqlen > 1 is not supported in the presence of causal mask"
-    #         )
-    #     return reasons
-
-
-    # @classmethod
-
-    # def apply(
-    #     cls, inp: Inputs, needs_gradient: bool
-    # ) -> Tuple[torch.Tensor, Optional[Context]]:
     @staticmethod
     def forward(cls, q, k, v, scale_float):
 
@@ -548,29 +186,13 @@ class _attention(torch.autograd.Function):
         cls.BLOCK_M = 16
         cls.BLOCK_N = 64
 
-        cls.NUM_GROUPS = 1  # Default quantization is row-wise
-
-        # attn_bias = inp.attn_bias
-        seq_len = None
-        # q, k, v = inp.get_qkv_in_bmghk()
-
-        # if attn_bias is not None:
-        #     assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
-        #     # TODO: do we really need to do this cast? seems fishy but
-        #     # I just copied it from the decoder.py
-        #     attn_bias.k_seqinfo.to(inp.query.device)
-        #     attn_bias.q_seqinfo.to(inp.query.device)
-        #     seq_len = attn_bias.k_seqinfo.seqlen
-        #     B = len(seq_len)
-        #     G, H, Kq = q.shape[-3:]
-        #     Kkv = v.shape[-1]
-
-        #     # assume kv has been padded
-        #     q = q.reshape(B, -1, G, H, Kq)
-        #     k = k.reshape(B, -1, G, H, Kkv)
-        #     v = v.reshape(B, -1, G, H, Kkv)
-
         # Transpose in the case of MQA/GQA
+        #print(f"q shape = {q.shape}")
+        #print(f"k shape = {k.shape}")
+        #print(f"v shape = {v.shape}")
+        #print(f"q stride = {q.stride()}")
+        #print(f"k stride = {k.stride()}")
+        #print(f"v stride = {v.stride()}")
         mqa_swap_seqlen_head = False
         if k.shape[3] > 1 and k.stride(3) == 0 and v.stride(3) == 0:
             mqa_swap_seqlen_head = True
@@ -579,119 +201,61 @@ class _attention(torch.autograd.Function):
             k = k[:, :, :, :1]
             v = v[:, :, :, :1]
 
-        if k.dtype == torch.int32:
-            # Quantized K/V
-            PACKED_PER_VAL = 8
-            Lk = (k.shape[-1] - cls.NUM_GROUPS) * 8
-        else:
-            Lk = k.shape[-1]
-            PACKED_PER_VAL = 1
-
         B, Mk, G, H, Kkv = k.shape
         B, M, G, H, Kq = q.shape
+        Lk = k.shape[-1]
         assert Lk == Kq, f"Keys have head dim {Lk} but queries have head dim {Kq}"
 
         BLOCK_M = cls.BLOCK_M
         BLOCK_N = cls.BLOCK_N
-        if cls.SPLIT_K is not None:
-            split_k = cls.SPLIT_K
-        else:
-            # Use heuristics
-            split_k = 1 #get_split_k(B, H, Mk)
 
         M_ceil = (M + BLOCK_M - 1) // BLOCK_M * BLOCK_M
-        o_splitk = torch.empty(
-            [B * G * H, split_k, M_ceil, Kq], dtype=torch.float32, device=q.device
-        )
-        metadata = torch.empty(
-            [B * G * H, 2, split_k, M_ceil], dtype=torch.float32, device=q.device
-        )
+        o = torch.empty_like(q)
         lse = torch.empty((B * G * H, M), device=q.device, dtype=torch.float32)
-        grid = (triton.cdiv(M, BLOCK_M), B * G * H, split_k)
+        grid = (triton.cdiv(M, BLOCK_M), B * G * H)
 
-        num_warps = 1
-        split_size = (Mk + split_k - 1) // split_k
-        use_seq_len = seq_len is not None
-        # _fwd_kernel_splitK_unrolled = unroll_varargs(
-        #     _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
-        # )
+        num_warps = 4
+        #print(f"q shape after = {q.shape}")
+        #print(f"k shape after = {k.shape}")
+        #print(f"v shape after = {v.shape}")
+        #print(f"q stride after = {q.stride()}")
+        #print(f"k stride after = {k.stride()}")
+        #print(f"v stride after = {v.stride()}")
 
         _fwd_kernel_splitK[grid](
             Q=q,
             K=k,
             V=v,
             sm_scale=scale_float,
-            Out_splitK=o_splitk,
-            Metadata=metadata,
-            Seq_len=seq_len,
+            Out=o,
+            lse=lse,
             **_strides(q, "qz", "qm", "qg", "qh", "qk"),
             **_strides(k, "kz", "kn", "kg", "kh", "kk"),
             **_strides(v, "vz", "vn", "vg", "vh", "vk"),
-            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
-            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            **_strides(o, "oz", "om", "og", "oh", "on"),
             Z=B,
             H=H,
             G=G,
             N_CTX_Q=M,
             N_CTX_K=Mk,
-            BLOCK_N_PER_SPLIT=split_size,
             BLOCK_M=BLOCK_M,
             BLOCK_N=BLOCK_N,
             BLOCK_DMODEL=Lk,
-            BOUNDS_CHECKS_N=(split_size % BLOCK_N) > 0 or use_seq_len,
-            USE_SEQ_LEN=use_seq_len,
             num_warps=num_warps,
             num_stages=1,
-            PACKED_PER_VAL=PACKED_PER_VAL,
-            N_GROUPS=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1,
         )
 
         if mqa_swap_seqlen_head:
-            out = torch.empty(
-                (B, H, G, M, Kq), device=q.device, dtype=q.dtype
-            ).transpose(1, 3)
-        else:
-            out = torch.empty((B, M, G, H, Kq), device=q.device, dtype=q.dtype)
-
-        # Merge together
-        grid = (B * G * H, M, 1)
-        _splitK_reduce[grid](
-            o_splitk,
-            metadata,
-            out,
-            lse,
-            split_k=split_k,
-            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
-            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
-            **_strides(out, "oz", "om", "og", "oh", "ok"),
-            **_strides(lse, "lse_zhg", "lse_m"),
-            BLOCK_SIZE=out.shape[-1],
-            G=G,
-            H=H,
-            # TODO: Tune num_warps
-        )
-        lse = lse.reshape([B, G, H, M])
-        if mqa_swap_seqlen_head:
-            # H/M dimensions have been swapped
-            out = out.transpose(1, 3)
-            lse = lse.transpose(2, 3)
-        if q.ndim == 4:
-            # BMGHK -> BMHK
-            assert G == 1
-            out = out[:, :, 0]
-            lse = lse[:, 0]
-        if Mk == 0:
-            out.zero_()
-            
-        out = out.reshape(B, H, -1, Kq).transpose(1, 2).contiguous()
-        return out
+            o.transpose(1, 3)
+        o = o.reshape(B, H, -1, Kq).transpose(1, 2).contiguous()
+        return o
 
 attention = _attention.apply
 
 def get_input_shapes():
     cases = [
         # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
-        (1, 1, 2**i, 64, 1, 128)
+        (1, 1, 2**i, 48, 1, 128)
         for i in [13] # Mkv = 2048 and 8192
     ]# + [
     #    # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)

--- a/python/perf-kernels/attention_split_head.py
+++ b/python/perf-kernels/attention_split_head.py
@@ -1,0 +1,824 @@
+#!/usr/bin/env python
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
+import pytest
+import torch
+import sys
+
+import triton
+import triton.language as tl
+
+def _strides(x: torch.Tensor, *stride_names: str):
+    assert x.ndim == len(stride_names)
+    return {f"stride_{s}": x.stride(i) for i, s in enumerate(stride_names)}
+
+
+# @triton.autotune(
+#    configs=[
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64, 'waves_per_eu': 2}, num_stages=1, num_warps=2),
+#     #    triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128, 'waves_per_eu': 2}, num_stages=1, num_warps=4),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 32}, num_stages=1, num_warps=2),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 64}, num_stages=1, num_warps=2),
+#        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 128}, num_stages=1, num_warps=4),
+#    ],
+#    key=['Z', 'H', 'G', 'N_CTX_Q', 'N_CTX_K', 'BLOCK_DMODEL'],        
+# )
+@triton.jit
+def _fwd_kernel_splitK(
+    Q,
+    K,
+    V,
+    sm_scale,
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+    Seq_len,
+    stride_qz,
+    stride_qm,
+    stride_qg,
+    stride_qh,
+    stride_qk,
+    stride_kz,
+    stride_kn,
+    stride_kg,
+    stride_kh,
+    stride_kk,
+    stride_vz,
+    stride_vn,
+    stride_vg,
+    stride_vh,
+    stride_vk,
+    stride_osk_zhg,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_mzhg,
+    stride_m2,
+    stride_ms,
+    stride_mm,
+    Z,
+    N_CTX_Q,
+    N_CTX_K,
+    BLOCK_N_PER_SPLIT,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    USE_SEQ_LEN: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr = 1,
+    N_GROUPS: tl.constexpr = 1,
+):
+    """This kernel can accept non-quantized or int4-quantized keys/values.
+    PACKED_PER_VAL determines the quantization type:
+        - PACKED_PER_VAL == 1 means no quantization
+        - PACKED_PER_VAL == 8 means 4-bit quantization (8 packed quantized values inside one int32)
+    For the quantized case K/V should be int32 tensors.
+    Quantization can be row-wise (when N_GROUPS = 1) or group-wise with N_GROUPS = 2, 4, or 8.
+    Quantization coefficients are stored at the beginning of the row along the last dimension of K/V
+    So K[B, H, M, :] has a form
+    [   quant_coef0, quant_coef1, ...|
+        group0_quant_value0, group0_quant_value1,... |
+        group1_quant_value0, group1_quant_value1,...]
+    where each quant_coef is an int32 which should be interpreted as 2 packed float16: scale and offset.
+
+    Note: this kernel needs to be processed by xformers.triton.vararg_kernel.unroll_varargs
+    before compilation. That will unroll variables marked with "VAR_ARGS_ARRAY" into lists.
+    See how FwOp.apply does it below.
+    """
+    tl.static_assert(
+        (PACKED_PER_VAL == 1 and tl.constexpr(K.dtype.element_ty != tl.int32))
+        or (PACKED_PER_VAL == 8 and tl.constexpr(K.dtype.element_ty == tl.int32)),
+        f"Only 4-bit quantization is supported, K/V should have dtype int32 in "
+        f"the quantized case: {PACKED_PER_VAL=} {tl.constexpr(K.dtype)=} {tl.constexpr(K.dtype.element_ty)=}",
+    )
+    tl.static_assert(
+        (((N_GROUPS == 1 or N_GROUPS == 2) or N_GROUPS == 4) or N_GROUPS == 8),
+        "Number of quantization groups can be 1 (row-wise quantization), 2, 4, or 8.",
+    )
+
+    QUANTIZED: tl.constexpr = PACKED_PER_VAL > 1
+    PACKED_D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // PACKED_PER_VAL // N_GROUPS
+    D_PER_GROUP: tl.constexpr = BLOCK_DMODEL // N_GROUPS
+
+    start_m = tl.program_id(0)
+    off_zhg = tl.program_id(1)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    splitk_idx = tl.program_id(2)
+
+    lo = splitk_idx * BLOCK_N_PER_SPLIT
+    if USE_SEQ_LEN:
+        kv_len = tl.load(Seq_len + off_z)
+    else:
+        kv_len = N_CTX_K
+    hi = tl.minimum((splitk_idx + 1) * BLOCK_N_PER_SPLIT, kv_len)
+
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + off_h * stride_qh + off_z * stride_qz + off_g * stride_qg,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    k_base = K + off_h * stride_kh + off_z * stride_kz + off_g * stride_kg
+    # Additional shift by 1 along the last dimension in the quantized case, since
+    # the first element along that dim contains packed quantization coefficients.
+    K_block_ptr = tl.make_block_ptr(
+        base=k_base + stride_kk * QUANTIZED * N_GROUPS,
+        shape=(PACKED_D_PER_GROUP, hi),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, lo),
+        block_shape=(PACKED_D_PER_GROUP, BLOCK_N),
+        order=(0, 1),
+    )
+    v_base = V + off_h * stride_vh + off_z * stride_vz + off_g * stride_vg
+    V_block_ptr = tl.make_block_ptr(
+        base=v_base + stride_vk * QUANTIZED * N_GROUPS,
+        shape=(hi, PACKED_D_PER_GROUP),
+        strides=(stride_vn, stride_vk),
+        offsets=(lo, 0),
+        block_shape=(BLOCK_N, PACKED_D_PER_GROUP),
+        order=(1, 0),
+    )
+
+    if QUANTIZED:
+        # Pointers to quantization coefficients. Even those they are 1D,
+        # we have to use block pointers, since usual pointers
+        # don't support boundary checks
+        K_scale_shift_block_ptr = tl.make_block_ptr(
+            base=k_base,
+            shape=(1, hi),
+            strides=(stride_kk, stride_kn),
+            offsets=(0, lo),
+            block_shape=(1, BLOCK_N),
+            order=(0, 1),
+        )
+        V_scale_shift_block_ptr = tl.make_block_ptr(
+            base=v_base,
+            shape=(hi, 1),
+            strides=(stride_vn, stride_vk),
+            offsets=(lo, 0),
+            block_shape=(BLOCK_N, 1),
+            order=(1, 0),
+        )
+    else:
+        K_scale_shift_block_ptr = None
+        V_scale_shift_block_ptr = None
+
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    # Before compilation, this kernel will be processed by xformers.triton.vararg_kernel.unroll_varargs.
+    # That turns tensors annotated as the one below into lists of tensors of length N_GROUPS.
+    # This is a solution for Triton native lack of support for lists of tensors.
+    # acc: "VAR_ARGS_ARRAY"  # noqa: F821
+    # acc = []
+    elem_num = 1
+    # for i in range(elem_num):  # noqa: F821
+    acc = tl.zeros([BLOCK_M, D_PER_GROUP], dtype=tl.float32)  # noqa: F821
+
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    # load q: it will stay in SRAM throughout
+    # q: "VAR_ARGS_ARRAY"  # noqa: F821
+    # for i in range(elem_num):  # noqa: F821
+    q = tl.load(  # noqa: F821
+        tl.advance(Q_block_ptr, (0, 0)), boundary_check=(0,)
+    )
+
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        # k: "VAR_ARGS_ARRAY"  # noqa: F821
+        # v: "VAR_ARGS_ARRAY"  # noqa: F821
+        # for i in range(len(acc)):  # noqa: F821
+        k, v = load_dequantize_k_v_group(  # noqa: F821
+            K_block_ptr,
+            V_block_ptr,
+            K_scale_shift_block_ptr,
+            V_scale_shift_block_ptr,
+            BOUNDS_CHECKS_N,
+            PACKED_PER_VAL,
+            PACKED_D_PER_GROUP,
+            Q.dtype.element_ty,
+            0,
+        )
+        # k.append(k_tmp)
+        # v.append(v_tmp)
+
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        # for i in range(elem_num):  # noqa: F821
+        qk += tl.dot(q, k)  # noqa: F821
+        qk *= qk_scale
+
+        # TODO: This is slow, and only needed at the last iteration.
+        # Maybe we can unroll the last iteration instead?
+        if BOUNDS_CHECKS_N:
+            qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk - m_i_new[:, None])
+
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        p = p.to(Q.dtype.element_ty)
+
+        # -- scale and update acc --
+        # for i in range(elem_num):  # noqa: F821
+        acc *= alpha[:, None]  # noqa: F821
+        acc += tl.dot(p, v)  # noqa: F821
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        if PACKED_PER_VAL > 1:
+            K_scale_shift_block_ptr = tl.advance(
+                K_scale_shift_block_ptr, (0, BLOCK_N)
+            )
+            V_scale_shift_block_ptr = tl.advance(
+                V_scale_shift_block_ptr, (BLOCK_N, 0)
+            )
+
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out_splitK + off_zhg * stride_osk_zhg + splitk_idx * stride_osk_s,
+        shape=(N_CTX_Q, D_PER_GROUP),
+        strides=(stride_osk_m, 1),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, D_PER_GROUP),
+        order=(1, 0),
+    )
+    # for i in range(elem_num):  # noqa: F821
+    tl.store(
+        tl.advance(O_block_ptr, (0, 0)),
+        acc,  # noqa: F821
+        boundary_check=(0,),
+    )
+    # Write metadata for split-K reduction
+    Metadata_ptr = (
+        Metadata
+        + off_zhg * stride_mzhg
+        + splitk_idx * stride_ms
+        + start_m * BLOCK_M
+        + tl.arange(0, BLOCK_M)
+    )
+    tl.store(Metadata_ptr, m_i)
+    tl.store(Metadata_ptr + stride_m2, l_i)
+
+@triton.jit
+def load_dequantize_k_v_group(
+    K_block_ptr,
+    V_block_ptr,
+    K_scale_shift_block_ptr,
+    V_scale_shift_block_ptr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    PACKED_PER_VAL: tl.constexpr,
+    PACKED_D_PER_GROUP: tl.constexpr,
+    dtype: tl.constexpr,
+    group_id: tl.constexpr,
+):
+    """Load K/V for a given block. In case of int4-quantized K/V, dequantize them after loading.
+    If quantization is group-wise, use group_id to advance the pointers to the current group.
+    """
+    # Advance to the current quantization group
+    K_block_ptr = tl.advance(K_block_ptr, (PACKED_D_PER_GROUP * group_id, 0))
+    V_block_ptr = tl.advance(V_block_ptr, (0, PACKED_D_PER_GROUP * group_id))
+
+    # -- load k, v --
+    k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ())
+    v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ())
+
+    if PACKED_PER_VAL > 1:
+        # K/V are quantized, load quantization coefficients and dequantize
+
+        K_scale_shift_block_ptr = tl.advance(K_scale_shift_block_ptr, (group_id, 0))
+        V_scale_shift_block_ptr = tl.advance(V_scale_shift_block_ptr, (0, group_id))
+
+        k_scale_shift = tl.load(
+            K_scale_shift_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_N else ()
+        )
+        v_scale_shift = tl.load(
+            V_scale_shift_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_N else ()
+        )
+
+        k_scale, k_shift = cast_uint32_to_half2(k_scale_shift)
+        v_scale, v_shift = cast_uint32_to_half2(v_scale_shift)
+        v = dequantize(v, v_scale, v_shift, PACKED_PER_VAL).to(dtype)
+        k_t = dequantize(
+            tl.trans(k),
+            tl.trans(k_scale),
+            tl.trans(k_shift),
+            PACKED_PER_VAL,
+        ).to(dtype)
+        k = tl.trans(k_t)
+    return k, v
+
+@triton.jit
+def cast_uint32_to_half2(scale_shift):
+    """Extract two float16 packed into one int32"""
+    scale = scale_shift & 0xFFFF
+    shift = scale_shift >> 16
+    scale = scale.to(tl.uint16).to(tl.float16, bitcast=True)
+    shift = shift.to(tl.uint16).to(tl.float16, bitcast=True)
+    return scale, shift
+
+@triton.jit
+def dequantize(
+    x_,
+    scale,
+    shift,
+    PACKED_PER_VAL: tl.constexpr = 8,
+):
+    """PACKED_PER_VAL is the number of values packed into each element x_.
+    For example, for int4 quantization and x_ of type int32, PACKED_PER_VAL is 8.
+    """
+
+    # Axis along which offsets are applied matters here
+    # It would be natural to have offsets in shape (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
+    # and expand K/V to that shape before applying offsets
+    # However, Triton for some reason considers dim=1 as contiguous when doing tl.view below, and not dim=2
+    # Note that tl.view doesn't guarantee the order of elements in the result - thus the code below depends
+    # on the implementation details which might change in the future.
+    # Ideally we would like to use tl.reshape, but it's not implemented yet.
+    # See https://github.com/openai/triton/blob/9055af1a5dadc576804b38dd77ee91dc42af0bf7/python/triton/language/semantic.py#L541 # noqa: E501
+
+    # x_ : (BLOCK_N, D // PACKED_PER_VAL)
+    # scale: (BLOCK_N, 1)
+    # offsets: (PACKED_PER_VAL,)
+    BLOCK_N: tl.constexpr = x_.shape[0]
+    BLOCK_DMODEL_PACKED: tl.constexpr = x_.shape[1]
+    offsets = tl.arange(0, PACKED_PER_VAL) * 4
+    quant_offset = (
+        x_[:, None, :] >> offsets[None, :, None]
+    )  # (BLOCK_N, PACKED_PER_VAL, D // PACKED_PER_VAL)
+
+    quant_offset = tl.view(
+        quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
+    )
+    # Trick - instead of converting int4 to float16 we view it as float16
+    # and then multiply by 32768 * 512 == 2**24
+    quant_offset = (quant_offset & 0xF).to(tl.uint16).to(tl.float16, bitcast=True)
+    quant_offset = (quant_offset * 32768.0).to(tl.float16)
+    scale_512 = scale * 512
+
+    dequant = quant_offset * scale_512 + shift
+    return dequant
+
+@triton.jit
+def _splitK_reduce(
+    Out_splitK,  # [B, H, split_k, Mq, K]
+    Metadata,  # [B, H, 2, split_k, M_ceil] contains [mi, li]
+    Out,  # [B, H, M, K]
+    LSE,  # [B, H, M]
+    split_k,
+    stride_osk_zhg,
+    stride_osk_s,
+    stride_osk_m,
+    stride_osk_k,
+    stride_mzhg,
+    stride_m2,
+    stride_ms,
+    stride_mm,
+    stride_oz,
+    stride_oh,
+    stride_og,
+    stride_om,
+    stride_ok,
+    stride_lse_zhg,
+    stride_lse_m,
+    BLOCK_SIZE: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+):
+    off_zhg = tl.program_id(0)
+    off_z = off_zhg // (H * G)
+    off_h = (off_zhg // G) % H
+    off_g = off_zhg % G
+    off_m = tl.program_id(1)
+
+    Out_splitK_ptr = (
+        Out_splitK
+        + stride_osk_zhg * off_zhg
+        + stride_osk_m * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    Metadata_ptr = Metadata + stride_mzhg * off_zhg + off_m
+    m = tl.load(Metadata_ptr)
+    l_sum = tl.load(Metadata_ptr + stride_m2)
+    acc = tl.load(Out_splitK_ptr)
+
+    for split_k_idx in range(1, split_k):
+        Metadata_ptr = Metadata_ptr + stride_ms
+        Out_splitK_ptr = Out_splitK_ptr + stride_osk_s
+
+        m_k = tl.load(Metadata_ptr)
+        l_k = tl.load(Metadata_ptr + stride_m2)
+        acc_k = tl.load(Out_splitK_ptr)
+
+        m_new = tl.maximum(m, m_k)
+        if m_k < m:
+            # Scale incoming values
+            alpha = tl.math.exp2(m_k - m_new)
+            acc_k = acc_k * alpha
+            l_k = l_k * alpha
+        else:
+            # Scale our values
+            alpha = tl.math.exp2(m - m_new)
+            acc = acc * alpha
+            l_sum = l_sum * alpha
+
+        m = m_new
+        l_sum = l_sum + l_k
+        acc = acc + acc_k
+
+    acc = acc / l_sum
+    Out_ptr = (
+        Out
+        + stride_oz * off_z
+        + stride_oh * off_h
+        + stride_og * off_g
+        + stride_om * off_m
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    tl.store(Out_ptr, acc)
+
+    l_ptrs = LSE + off_zhg * stride_lse_zhg + off_m
+    tl.store(l_ptrs, (m + tl.math.log2(l_sum)) / 1.44269504)
+
+def get_split_k(B: int, H: int, Mk: int) -> int:
+    # print(f"B = {B}, H = {H}, Mk = {Mk}")
+    """Heuristic for the number of splits"""
+    bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+    split_k = max(Mk, 1024) // bh
+    max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
+    while split_k > 0 and Mk / split_k < max_chunk_size:
+        split_k = split_k // 2
+    split_k = min(split_k, 64)
+    split_k = max(split_k, 1)
+    return split_k
+
+# @register_operator
+# class FwOp(AttentionFwOpBase):
+class _attention(torch.autograd.Function):
+
+    OPERATOR = _fwd_kernel_splitK
+    SUPPORTED_DEVICES = {"cuda"}
+    CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
+    SUPPORTED_DTYPES = {
+        torch.half,
+        torch.bfloat16,
+    }  # Those are dtypes of Q. In the quantized case K/V has dtype int32
+    SUPPORTED_MAX_K = 128
+    # SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
+    #     type(None),
+    #     BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    # }
+    SUPPORTS_DROPOUT = False
+    SUPPORTS_CUSTOM_SCALE = True
+    SUPPORTS_BMGHK = True
+    NAME = "triton_splitKF"
+
+
+    # @classmethod
+    # def shape_not_supported_reasons(
+    #     cls, Mq: int, Mkv: int, K: int, Kv: int
+    # ) -> List[str]:
+    #     reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+    #     if K not in {16, 32, 64, 128}:
+    #         reasons.append(f"Embed dim {K} not supported")
+    #     return reasons
+
+    # @classmethod
+    # def not_supported_reasons(cls, d: Inputs) -> List[str]:
+    #     reasons = super(FwOp, cls).not_supported_reasons(d)
+    #     check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
+    #     if d.key.dtype != torch.int32:
+    #         check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
+    #         check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
+    #     if cls.OPERATOR is None:
+    #         reasons.append("triton is not available")
+    #     if d.device.type == "cuda":
+    #         # Has only been tested on 8.0 / 9.0.
+    #         if torch.cuda.get_device_capability(d.device) < (8, 0):
+    #             reasons.append(
+    #                 "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
+    #             )
+
+    #     q_len = d.query.shape[1]
+    #     if isinstance(d.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+    #         seqinfo = d.attn_bias.q_seqinfo
+    #         if q_len != seqinfo.seqstart_py[-1]:
+    #             reasons.append(
+    #                 f"Expected total {seqinfo.seqstart_py[-1]} queries not {q_len}"
+    #             )
+    #         q_len = seqinfo.min_seqlen
+    #         if q_len != seqinfo.max_seqlen:
+    #             reasons.append(
+    #                 "Variable query len is not supported in the presence of causal mask."
+    #             )
+
+    #     if d.key.ndim in [4, 5] and d.key.shape[-2] != 1:
+    #         if d.key.stride(-2) == 0 and d.value.stride(-2) == 0 and q_len > 1:
+    #             reasons.append("multiquery is only supported with query seqlen=1")
+
+    #     if d.attn_bias is not None and q_len > 1:
+    #         reasons.append(
+    #             "query with seqlen > 1 is not supported in the presence of causal mask"
+    #         )
+    #     return reasons
+
+
+    # @classmethod
+
+    # def apply(
+    #     cls, inp: Inputs, needs_gradient: bool
+    # ) -> Tuple[torch.Tensor, Optional[Context]]:
+    @staticmethod
+    def forward(cls, q, k, v, scale_float):
+
+        cls.SPLIT_K: Optional[int] = None
+        cls.BLOCK_M = 16
+        cls.BLOCK_N = 64
+
+        cls.NUM_GROUPS = 1  # Default quantization is row-wise
+
+        # attn_bias = inp.attn_bias
+        seq_len = None
+        # q, k, v = inp.get_qkv_in_bmghk()
+
+        # if attn_bias is not None:
+        #     assert isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
+        #     # TODO: do we really need to do this cast? seems fishy but
+        #     # I just copied it from the decoder.py
+        #     attn_bias.k_seqinfo.to(inp.query.device)
+        #     attn_bias.q_seqinfo.to(inp.query.device)
+        #     seq_len = attn_bias.k_seqinfo.seqlen
+        #     B = len(seq_len)
+        #     G, H, Kq = q.shape[-3:]
+        #     Kkv = v.shape[-1]
+
+        #     # assume kv has been padded
+        #     q = q.reshape(B, -1, G, H, Kq)
+        #     k = k.reshape(B, -1, G, H, Kkv)
+        #     v = v.reshape(B, -1, G, H, Kkv)
+
+        # Transpose in the case of MQA/GQA
+        mqa_swap_seqlen_head = False
+        if k.shape[3] > 1 and k.stride(3) == 0 and v.stride(3) == 0:
+            mqa_swap_seqlen_head = True
+            assert q.shape[1] == 1
+            q = q.transpose(1, 3)
+            k = k[:, :, :, :1]
+            v = v[:, :, :, :1]
+
+        if k.dtype == torch.int32:
+            # Quantized K/V
+            PACKED_PER_VAL = 8
+            Lk = (k.shape[-1] - cls.NUM_GROUPS) * 8
+        else:
+            Lk = k.shape[-1]
+            PACKED_PER_VAL = 1
+
+        B, Mk, G, H, Kkv = k.shape
+        B, M, G, H, Kq = q.shape
+        assert Lk == Kq, f"Keys have head dim {Lk} but queries have head dim {Kq}"
+
+        BLOCK_M = cls.BLOCK_M
+        BLOCK_N = cls.BLOCK_N
+        if cls.SPLIT_K is not None:
+            split_k = cls.SPLIT_K
+        else:
+            # Use heuristics
+            split_k = 1 #get_split_k(B, H, Mk)
+
+        M_ceil = (M + BLOCK_M - 1) // BLOCK_M * BLOCK_M
+        o_splitk = torch.empty(
+            [B * G * H, split_k, M_ceil, Kq], dtype=torch.float32, device=q.device
+        )
+        metadata = torch.empty(
+            [B * G * H, 2, split_k, M_ceil], dtype=torch.float32, device=q.device
+        )
+        lse = torch.empty((B * G * H, M), device=q.device, dtype=torch.float32)
+        grid = (triton.cdiv(M, BLOCK_M), B * G * H, split_k)
+
+        num_warps = 1
+        split_size = (Mk + split_k - 1) // split_k
+        use_seq_len = seq_len is not None
+        # _fwd_kernel_splitK_unrolled = unroll_varargs(
+        #     _fwd_kernel_splitK, N=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1
+        # )
+
+        _fwd_kernel_splitK[grid](
+            Q=q,
+            K=k,
+            V=v,
+            sm_scale=scale_float,
+            Out_splitK=o_splitk,
+            Metadata=metadata,
+            Seq_len=seq_len,
+            **_strides(q, "qz", "qm", "qg", "qh", "qk"),
+            **_strides(k, "kz", "kn", "kg", "kh", "kk"),
+            **_strides(v, "vz", "vn", "vg", "vh", "vk"),
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            Z=B,
+            H=H,
+            G=G,
+            N_CTX_Q=M,
+            N_CTX_K=Mk,
+            BLOCK_N_PER_SPLIT=split_size,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_DMODEL=Lk,
+            BOUNDS_CHECKS_N=(split_size % BLOCK_N) > 0 or use_seq_len,
+            USE_SEQ_LEN=use_seq_len,
+            num_warps=num_warps,
+            num_stages=1,
+            PACKED_PER_VAL=PACKED_PER_VAL,
+            N_GROUPS=cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1,
+        )
+
+        if mqa_swap_seqlen_head:
+            out = torch.empty(
+                (B, H, G, M, Kq), device=q.device, dtype=q.dtype
+            ).transpose(1, 3)
+        else:
+            out = torch.empty((B, M, G, H, Kq), device=q.device, dtype=q.dtype)
+
+        # Merge together
+        grid = (B * G * H, M, 1)
+        _splitK_reduce[grid](
+            o_splitk,
+            metadata,
+            out,
+            lse,
+            split_k=split_k,
+            **_strides(o_splitk, "osk_zhg", "osk_s", "osk_m", "osk_k"),
+            **_strides(metadata, "mzhg", "m2", "ms", "mm"),
+            **_strides(out, "oz", "om", "og", "oh", "ok"),
+            **_strides(lse, "lse_zhg", "lse_m"),
+            BLOCK_SIZE=out.shape[-1],
+            G=G,
+            H=H,
+            # TODO: Tune num_warps
+        )
+        lse = lse.reshape([B, G, H, M])
+        if mqa_swap_seqlen_head:
+            # H/M dimensions have been swapped
+            out = out.transpose(1, 3)
+            lse = lse.transpose(2, 3)
+        if q.ndim == 4:
+            # BMGHK -> BMHK
+            assert G == 1
+            out = out[:, :, 0]
+            lse = lse[:, 0]
+        if Mk == 0:
+            out.zero_()
+            
+        out = out.reshape(B, H, -1, Kq).transpose(1, 2).contiguous()
+        return out
+
+attention = _attention.apply
+
+def get_input_shapes():
+    cases = [
+        # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
+        (1, 1, 2**i, 64, 1, 128)
+        for i in [13] # Mkv = 2048 and 8192
+    ]# + [
+    #    # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
+    #    (max(1, 2 ** (16 - i)), 1, 2**i, 16, 2, 128)
+    #    for i in range(8, 18)
+    #]
+
+    # cases = [
+    #     # dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
+    #     (max(1, 2 ** (16 - i)), 1, 2**i, 16, 1, 128)
+    #     for i in range(17, 18)
+    # ]
+
+    return cases
+
+
+@pytest.mark.parametrize('B, Mq, Mkv, Hq, Hkv, K',
+                         get_input_shapes())
+def test_op_fwd(B, Mq, Mkv, Hq, Hkv, K, dtype=torch.float16):
+    torch.manual_seed(20)
+    q = (
+        torch.empty((B, Mq, Hkv, Hq // Hkv, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    )
+    k = (
+        torch.empty((B, Mkv, Hkv, 1, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    ).expand(-1, -1, -1, Hq // Hkv, -1)
+    v = (
+        torch.empty((B, Mkv, Hkv, 1, K), dtype=dtype, device="cuda")
+        .normal_(mean=0., std=0.5)
+        .requires_grad_()
+    ).expand(-1, -1, -1, Hq // Hkv, -1)
+    scale = 1 / K**0.5
+    tri_out = attention(q, k, v, scale)
+
+    q = q.reshape([B, Mq, -1, K]).permute(0, 2, 1, 3)
+    k = k.reshape([B, Mkv, -1, K]).permute(0, 2, 1, 3)
+    v = v.reshape([B, Mkv, -1, K]).permute(0, 2, 1, 3)
+    attn = (q @ k.transpose(-1, -2) * scale).softmax(-1)
+    ref_out = attn @ v
+
+    # compare
+    torch.testing.assert_close(ref_out, tri_out, atol=1e-3, rtol=0)
+
+
+try:
+    from flash_attn.flash_attn_interface import \
+        flash_attn_qkvpacked_func as flash_attn_func
+    FLASH_VER = 2
+except BaseException:
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_func
+        FLASH_VER = 1
+    except BaseException:
+        FLASH_VER = None
+HAS_FLASH = FLASH_VER is not None
+
+# vary seq length for fixed head and batch=4
+configs = []
+for mode in ['fwd']:
+    # for D_HEAD in [128]:
+    for causal in [False]:
+        configs.append(triton.testing.Benchmark(
+            x_names=['B', 'Mq','Mkv', 'Hq', 'Hkv', 'K'],
+            x_vals=get_input_shapes(),
+            line_arg='provider',
+            line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+            line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
+            styles=[('red', '-'), ('blue', '-')],
+            ylabel='ms',
+            plot_name=f'fused-attention-d{128}-{mode}-causal={causal}',
+            args={
+                # 'D_HEAD': D_HEAD,
+                'dtype': torch.float16,
+                'mode': mode,
+                'causal': causal})
+        )
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(B, Mq, Mkv, Hq, Hkv, K, causal, mode, provider, dtype=torch.float16, device="cuda"):
+    assert mode in ['fwd', 'bwd']
+    warmup = 100
+    rep = 400
+    ms = 0
+    if provider == "triton":
+        q = torch.randn(
+            [B, Mq, Hkv, Hq // Hkv, K], device="cuda", dtype=dtype, requires_grad=False
+        )
+        k = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+        v = torch.randn(
+            [B, Mkv, Hkv, 1, K], device="cuda", dtype=dtype, requires_grad=False
+        ).expand(-1, -1, -1, Hq // Hkv, -1)
+
+        sm_scale = 1.3
+        fn = lambda: attention(q, k, v, sm_scale)
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    # if provider == "flash":
+    #     qkv = torch.randn((BATCH, N_CTX, 3, H, D_HEAD), dtype=dtype, device=device, requires_grad=True)
+    #     if FLASH_VER == 1:
+    #         lengths = torch.full((BATCH,), fill_value=N_CTX, device=device)
+    #         cu_seqlens = torch.zeros((BATCH + 1,), device=device, dtype=torch.int32)
+    #         cu_seqlens[1:] = lengths.cumsum(0)
+    #         qkv = qkv.reshape(BATCH * N_CTX, 3, H, D_HEAD)
+    #         fn = lambda: flash_attn_func(qkv, cu_seqlens, 0., N_CTX, causal=causal)
+    #     elif FLASH_VER == 2:
+    #         fn = lambda: flash_attn_func(qkv, causal=causal)
+    #     else:
+    #         raise ValueError(f'unknown {FLASH_VER = }')
+    #     ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    flops_per_matmul =  2 * B * Hq * (Mq * K * Mkv + Mq * Mkv * K)
+    total_flops = 2 * flops_per_matmul
+    totalBytes = ((B * Mkv * Hkv * K * 2) + (B * Mq * Hq * K) + (B * Mq * Hq * K)) * 2
+
+    # return totalBytes / ms * 1e-9
+    return ms * 1000
+
+
+def main():
+    bench_flash_attention.run(save_path='.', print_data=True)
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/python/perf-kernels/hbm-bw-test.py
+++ b/python/perf-kernels/hbm-bw-test.py
@@ -1,0 +1,123 @@
+"""
+Simple test to measure achieved HBM bandwidth.
+This kernel moves N bytes of data from one region in HBM to another, using Triton.
+"""
+
+# %%
+# Compute Kernel
+# --------------
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def copy_kernel(
+    input_ptr,  # *Pointer* to input vector.
+    output_ptr,  # *Pointer* to output vector.
+    n_elements: tl.constexpr,  # Total elements to move.
+    BLOCK_SIZE: tl.constexpr,  # Elements to load / store per iteration
+    vector_size: tl.constexpr, # Size of the entire vector being moved.
+
+):
+    # There are multiple 'programs' processing different data. We identify which program
+    # we are here:
+    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    # This program will process inputs that are offset from the initial data.
+    # For instance, if you had a vector of length 256 and block_size of 64, the programs
+    # would each access the elements [0:64, 64:128, 128:192, 192:256].
+    # Note that offsets is a list of pointers:
+    
+    lo = pid * n_elements
+    hi = lo + n_elements
+    for idx in range(lo, hi, BLOCK_SIZE):
+        offsets = idx + tl.arange(0, BLOCK_SIZE)
+        # Create a mask to guard memory operations against out-of-bounds accesses.
+        #mask = offsets < vector_size
+        in_vals = tl.load(input_ptr + offsets)
+        tl.store(output_ptr + offsets, in_vals)
+
+
+# %%
+# Let's also declare a helper function to (1) allocate the `z` tensor
+# and (2) enqueue the above kernel with appropriate grid/block sizes:
+
+
+def copy(x: torch.Tensor, wgs=512):
+    # We need to preallocate the output.
+    output = torch.empty_like(x)
+    assert x.is_cuda
+    vector_size = output.numel()
+    BLOCK_SIZE = 4096
+    grid = (wgs, 1, 1)
+    # Each WG will move these many elements
+    n_elements = triton.cdiv(vector_size, wgs)
+    copy_kernel[grid](x, output, n_elements, BLOCK_SIZE=BLOCK_SIZE, vector_size=vector_size, num_warps=1)
+    # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
+    # running asynchronously at this point.
+    return output
+
+
+# %%
+# We can now use the above function to compute the element-wise sum of two `torch.tensor` objects and test its correctness:
+
+torch.manual_seed(0)
+size = 2**30
+#x = torch.rand(size, device='cuda')
+#output_torch = x
+#output_triton = copy(x)
+#print(output_torch)
+#print(output_triton)
+#print(
+#    f'The maximum difference between torch and triton is '
+#    f'{torch.max(torch.abs(output_torch - output_triton))}'
+#)
+
+# %%
+# Seems like we're good to go!
+
+# %%
+# Benchmark
+# ---------
+#
+# We can now benchmark our custom op on vectors of increasing sizes to get a sense of how it does relative to PyTorch.
+# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
+# for different problem sizes.
+
+configs = []
+for wgs in [2 ** i for i in range(0, 12)]:
+    configs.append(triton.testing.Benchmark(
+        x_names=['size'],  # Argument names to use as an x-axis for the plot.
+        x_vals=[
+            2**30
+        ],  # Different possible values for `x_name`.
+        x_log=True,  # x axis is logarithmic.
+        line_arg='provider',  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=['triton', 'torch'],  # Possible values for `line_arg`.
+        line_names=['Triton', 'Torch'],  # Label name for the lines.
+        styles=[('blue', '-'), ('green', '-')],  # Line styles.
+        ylabel='GB/s',  # Label name for the y-axis.
+        plot_name=f'wgs={wgs}',  # Name for the plot. Used also as a file name for saving the plot.
+        args={'wgs':wgs},  # Values for function arguments not in `x_names` and `y_name`.
+    )
+    )
+
+@triton.testing.perf_report(configs)
+def benchmark(size, provider, wgs):
+    x = torch.rand(size, device='cuda', dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.clone(x), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: copy(x, wgs), quantiles=quantiles)
+    # 8 because 4 bytes from load, 4 from store.
+    gbps = lambda ms: 8 * size / ms * 1e-6
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+# %%
+# We can now run the decorated function above. Pass `print_data=True` to see the performance number, `show_plots=True` to plot them, and/or
+# `save_path='/path/to/results/' to save them to disk along with raw CSV data:
+benchmark.run(print_data=True, show_plots=True)


### PR DESCRIPTION
The kernel moves 2^32 bytes of data from one part of HBM to another. Num WGs are swept and there is a way to switch the grid size and block size being moved per WG.