### PR TITLE
[MFMA] Support 64x4 and 4x64 tile size

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -158,7 +158,10 @@ compared to 1*64 when the hasLeadingOffset is false.
             int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
             int maxPhase = SIMDWidth / perPhase;
             // TODO (zhanglx): figure out better parameters for mfma4
-            if (mfmaEnc.getNonKDim() == 4 )
+            auto mDim = mfmaEnc.getMDim();
+            auto nDim = mfmaEnc.getNDim();
+            auto nonKDim = dotOpEnc.getOpIdx() == 0 ? mDim : nDim;
+            if (nonKDim == 4 )
                maxPhase = 4;
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
@@ -765,7 +768,8 @@ V [ 0,4,8...60   1,5...61     2,6...62     3,7...63    ]   [ 128,132...188  129,
 
   let parameters = (
     ins
-    "unsigned":$nonKDim,
+    "unsigned":$MDim,
+    "unsigned":$NDim,
     ArrayRefParameter<"unsigned">:$warpsPerCTA,
     "bool":$isTransposed
   );

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -426,10 +426,11 @@ bool supportMMA(triton::DotOp op, int version) {
 #ifdef USE_ROCM
 static bool supportMFMAGranularity(int m, int n, int k) {
   // these limitations are dtype dependent, in future we may relax them
-  const static std::pair<int, int> mfmaTypes[] = {{32, 8}, {16, 16}, {4, 64}};
+  const static std::tuple<int, int, int> mfmaTypes[] = {
+      {32, 32, 8}, {16, 16, 16}, {4, 4, 64}, {64, 4, 4}, {4, 64, 4}};
   for (const auto &mfmaType : mfmaTypes) {
-    auto [granularityMN, granularityK] = mfmaType;
-    if (m % granularityMN != 0 || n % granularityMN != 0)
+    auto [granularityM, granularityN, granularityK] = mfmaType;
+    if (m % granularityM != 0 || n % granularityN != 0)
       continue;
     if (k % granularityK != 0)
       continue;
@@ -612,7 +613,8 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
          dotOperandLayout.getOpIdx() == 0 &&
          dotOperandLayout.getKWidth() == 4 &&
          dotOperandLayout.getParent() == mfmaLayout &&
-         (mfmaLayout.getNonKDim() == 32 || mfmaLayout.getNonKDim() == 16) && mfmaLayout.getIsTransposed() &&
+         (mfmaLayout.getMDim() == 32 || mfmaLayout.getMDim() == 16) &&
+         mfmaLayout.getIsTransposed() &&
          (srcTy.getElementType().isF16() || srcTy.getElementType().isBF16());
 }
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -132,6 +132,7 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
  * @param smemStrides strides in LDS tensor
  * @param loadVecSize number of elements loaded by one operation
  * @param iNonKDim non-K dimension of dot operand
+ * @param iKDim non-K dimension of dot operand
  * @return vector (i-th element corresponds to i-th load instruction) of
  * 2-element vectors(tensor row and col).
  */
@@ -140,7 +141,7 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                          Value laneId, int warpsPerGroup, int numOfElems,
                          ArrayRef<int64_t> reps, ArrayRef<Value> smemOffsets,
-                         int loadVecSize, unsigned iNonKDim) {
+                         int loadVecSize, unsigned iNonKDim, unsigned iKDim) {
   auto numM = reps[0];
   auto numK = reps[1];
   const int loadsPerThread = numOfElems / loadVecSize;
@@ -159,8 +160,16 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
     Value laneHOffset;
     if (iNonKDim == 32)
       laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
-    else
-      laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
+    else {
+      // In this configuration wave contains 16 copies of same data
+      if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4) {
+        laneHOffset = i32_val(0);
+      } else {
+        assert(iKDim * iNonKDim / numOfElems == 64 &&
+               "seems no all threads in wave contain unique elements");
+        laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
+      }
+    }
 
     for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
       Value elemVOffset = _0;
@@ -197,7 +206,8 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   SmallVector<Value> strides{smemObj.strides[0], smemObj.strides[1]};
   SmallVector<Value> offsets{smemObj.offsets[0], smemObj.offsets[1]};
 
@@ -209,9 +219,9 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          reps, offsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, elemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      reps, offsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> aOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     Value row = mapping[i][0];
@@ -226,7 +236,8 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   // transpose reps and offsets, because operand B has layout equal to
   // transposed operand A layout
   SmallVector<int64_t> tElemsPerInstr{elemsPerInstr[1], elemsPerInstr[0]};
@@ -241,9 +252,9 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          tReps, toffsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, tElemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      tReps, toffsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> bOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     // swap row and col, because operand B layout is a transposed operand A
@@ -333,7 +344,8 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj,
 // Computes offsets for operand B or transposed operand A
 // @param rewriter
 // @param loc
-// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
+// @param elemsPerInstr operand tile shape [K, nonK] consumed by one MFMA
+// instruction
 // @param waveId wave id for the "non K" axis
 // @param laneId lane id in warp [0..63]
 // @param warpsPerGroup number of warps per horizontal axis
@@ -349,18 +361,36 @@ fastPathComputeOffsets(ConversionPatternRewriter &rewriter, Location loc,
   auto numN = reps[1];
   SmallVector<Value> offsets(numK * numN * numOfElems);
 
-  int lineSize = warpsPerGroup * elemsPerInstr[1] * numN;
-  Value _nonKDim = i32_val(elemsPerInstr[1]);
-  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[1]));
+  auto iKDim = elemsPerInstr[0];
+  auto iNonKDim = elemsPerInstr[1];
+  int lineSize = warpsPerGroup * iNonKDim * numN;
+  Value _nonKDim = i32_val(iNonKDim);
+  Value waveOffset = mul(waveId, i32_val(iNonKDim));
   Value colOffset = urem(laneId, _nonKDim);
 
   for (int block = 0; block < numN; ++block) {
-    Value blockOffset = i32_val(block * elemsPerInstr[1] * warpsPerGroup);
+    Value blockOffset = i32_val(block * iNonKDim * warpsPerGroup);
     for (int tile = 0; tile < numK; ++tile) {
-      Value tileOffset = i32_val(tile * elemsPerInstr[0] * lineSize);
+      Value tileOffset = i32_val(tile * iKDim * lineSize);
       for (int elem = 0; elem < numOfElems; ++elem) {
-        Value halfOffset =
-            mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
+        // halfOffset is an offset related to wrapping of wave in the tile.
+        // for example, mfma 32 case (mapping of tensor elements to lane ids in
+        // wave):
+        //
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        // 32 33 34 35 ... 63  <- at this point wave is wrapping
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        Value halfOffset;
+        if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4)
+          halfOffset = i32_val(0);
+        else
+          halfOffset =
+              mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
         Value rowOffset = add(i32_val(elem * lineSize), halfOffset);
         Value elemOffset = add(rowOffset, colOffset);
         Value offset =
@@ -395,8 +425,10 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   int nonKDimIdx = opIdx == 0 ? 0 : 1;
 
   auto mfmaLayout = encoding.getParent().cast<MfmaEncodingAttr>();
-  auto nonKDim = mfmaLayout.getNonKDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
 
   auto aTensorTy = tensor.getType().cast<RankedTensorType>();
@@ -422,7 +454,12 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value spatialWaveId =
       getWaveIdInBlock(rewriter, loc, linearWaveId, warpsPerCTA, mfmaInstrNonK,
                        shape[nonKDimIdx], nonKDimIdx);
-  int numOfElems = mfmaInstrNonK * mfmaInstrK / iWaveSize;
+  // number of duplicates of elements in wave
+  // In case of 64x4 x 4x4 multiplication, 4x4 B operand is duplicated 16 times
+  int numSubBlocks = 1;
+  if ((mfmaInstrK == 4 || mfmaInstrK == 1) && mfmaInstrNonK == 4)
+    numSubBlocks = 16;
+  int numOfElems = mfmaInstrNonK * mfmaInstrK * numSubBlocks / iWaveSize;
   assert(numOfElems >= 1);
 
   unsigned int maxNumWarps = shape[nonKDimIdx] / mfmaInstrNonK;
@@ -465,14 +502,14 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
     // Normal path handles tensors that are k-major, in which case swizzling
     // is enabled and it requires a 2-step method to compute the offsets.
     if (opIdx == 0) {
-      offsets = computeOffsetsAType(rewriter, loc, elemsPerInstr, spatialWaveId,
-                                    lane, warpsPerGroupNonK, numOfElems,
-                                    numReps, smemObj, sharedLayout, nonKDim);
+      offsets = computeOffsetsAType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, mDim, mfmaInstrK);
     } else {
       assert(opIdx == 1);
-      offsets = computeOffsetsBType(rewriter, loc, elemsPerInstr, spatialWaveId,
-                                    lane, warpsPerGroupNonK, numOfElems,
-                                    numReps, smemObj, sharedLayout, nonKDim);
+      offsets = computeOffsetsBType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, nDim, mfmaInstrK);
     }
     smemBase = computeBasePtr(rewriter, loc, smemObj);
   }
@@ -485,8 +522,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   assert(numOfElems % loadsPerThread == 0);
 
   for (int nonK = 0; nonK < numRepNonK; ++nonK) {
-    Value blockVOffset = i32_val(nonK * mfmaInstrNonK * warpsPerGroupNonK);
-    Value offAdjust = mul(blockVOffset, i32_val(shape[order[0]]));
+    int blockNonKOffset = nonK * mfmaInstrNonK * warpsPerGroupNonK;
+    Value offAdjust = i32_val(blockNonKOffset * shape[order[0]]);
     for (int k = 0; k < numRepK; ++k) {
       auto vecTy = vec_ty(resElemTy, numOfElems);
       Value valVec = undef(vecTy);

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -772,11 +772,14 @@ public:
   void emitMfmaOffsetForCTA(const MfmaEncodingAttr &mfmaLayout,
                             SmallVector<SmallVector<unsigned>> &offsets,
                             unsigned ctaOffsetX, unsigned ctaOffsetY) const {
-    auto nonKDim = mfmaLayout.getNonKDim();
+    auto mDim = mfmaLayout.getMDim();
+    auto nDim = mfmaLayout.getNDim();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
     // MFMA output tile consists of repeated "dot operand B" layout groups along
     // row axis. This variable defines number of these groups.
     DenseMap<int, int> groups{{4, 1}, {16, 1}, {32, 4}};
-    unsigned numGroups = groups.at(nonKDim);
+    unsigned numGroups = groups.at(std::min(mDim, nDim));
 
     const unsigned elemsPerThreadPerGroup = 4;
     auto warpSize = getWarpSize(mfmaLayout);
@@ -784,7 +787,7 @@ public:
     auto shapePerCta = getShapePerCTATile(mfmaLayout);
     for (unsigned block = 0; block < numGroups; block++) {
       unsigned rowOrColOffset =
-          block * elemsPerThreadPerGroup * warpSize / nonKDim;
+          block * elemsPerThreadPerGroup * warpSize / std::min(mDim, nDim);
       for (unsigned elem = 0; elem < elemsPerThreadPerGroup; elem++) {
         if (mfmaLayout.getIsTransposed()) {
           offsets.push_back(
@@ -1191,12 +1194,15 @@ private:
     assert(_warpsPerCTA.size() == 2);
     SmallVector<Value> warpsPerCTA = {i32_val(_warpsPerCTA[0]),
                                       i32_val(_warpsPerCTA[1])};
-    int nonKDim = mfmaLayout.getNonKDim();
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
 
     Value threadId = getThreadId(rewriter, loc);
     Value warpSize = i32_val(triton::gpu::getWarpSize(mfmaLayout));
     Value effectiveWarpSize = warpSize;
-    if (nonKDim == 4) {
+    if (mDim == 4 && nDim == 4) {
       const int uniqueValuesPerWarp = 4;
       effectiveWarpSize = i32_val(uniqueValuesPerWarp);
     }
@@ -1204,22 +1210,22 @@ private:
 
     Value warpId = udiv(threadId, warpSize);
     Value warpId0 =
-        urem(urem(warpId, warpsPerCTA[0]), i32_val(shape[0] / nonKDim));
+        urem(urem(warpId, warpsPerCTA[0]), i32_val(shape[0] / mDim));
     Value warpId1 = urem(urem(udiv(warpId, warpsPerCTA[0]), warpsPerCTA[1]),
-                         i32_val(shape[1] / nonKDim));
+                         i32_val(shape[1] / nDim));
 
-    Value offWarp0 = mul(warpId0, i32_val(nonKDim));
-    Value offWarp1 = mul(warpId1, i32_val(nonKDim));
+    Value offWarp0 = mul(warpId0, i32_val(mDim));
+    Value offWarp1 = mul(warpId1, i32_val(nDim));
 
     SmallVector<Value> multiDimBase(2);
     if (mfmaLayout.getIsTransposed()) {
       multiDimBase[1] =
-          add(mul(i32_val(4), udiv(laneId, i32_val(nonKDim))), offWarp1);
-      multiDimBase[0] = add(urem(laneId, i32_val(nonKDim)), offWarp0);
+          add(mul(i32_val(4), udiv(laneId, i32_val(mDim))), offWarp1);
+      multiDimBase[0] = add(urem(laneId, i32_val(nDim)), offWarp0);
     } else {
       multiDimBase[0] =
-          add(mul(i32_val(4), udiv(laneId, i32_val(nonKDim))), offWarp0);
-      multiDimBase[1] = add(urem(laneId, i32_val(nonKDim)), offWarp1);
+          add(mul(i32_val(4), udiv(laneId, i32_val(nDim))), offWarp0);
+      multiDimBase[1] = add(urem(laneId, i32_val(nDim)), offWarp1);
     }
     return multiDimBase;
   }
@@ -1233,10 +1239,15 @@ private:
     auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
 
     SmallVector<unsigned> numWarpsPerDim(2);
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+    unsigned tileShape[] = {mDim, nDim};
     for (unsigned d = 0; d < 2; ++d) {
       unsigned inPerCTA = std::min<unsigned>(tensorShape[d], shapePerCTA[d]);
       unsigned inPerWarp = ceil<unsigned>(inPerCTA, warpsPerCTA[d]);
-      numWarpsPerDim[d] = ceil<unsigned>(inPerWarp, mfmaLayout.getNonKDim());
+      numWarpsPerDim[d] = ceil<unsigned>(inPerWarp, tileShape[d]);
     }
 
     for (unsigned i = 0; i < numWarpsPerDim[0]; ++i) {

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -771,8 +771,8 @@ private:
     auto srcMfma =
         srcType.getEncoding().dyn_cast<triton::gpu::MfmaEncodingAttr>();
     auto newMfmaEnc = triton::gpu::MfmaEncodingAttr::get(
-        mod.getContext(), srcMfma.getNonKDim(), {warpsPerCtaX, warpsPerCtaY},
-        srcMfma.getIsTransposed());
+        mod.getContext(), srcMfma.getMDim(), srcMfma.getNDim(),
+        {warpsPerCtaX, warpsPerCtaY}, srcMfma.getIsTransposed());
 
     auto newDstType = RankedTensorType::get(
         dstType.getShape(), dstType.getElementType(), dstType.getEncoding());

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -103,13 +103,28 @@ SmallVector<unsigned> getThreadsPerWarp(Attribute layout) {
       return {8, 4};
   }
   if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    unsigned rows, cols;
-    if (mfmaLayout.getNonKDim() == 32) {
-      cols = 2;
-      rows = 32;
+    unsigned rows = -1, cols = -1;
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    if (mDim == nDim) {
+      if (mDim == 32) {
+        cols = 2;
+        rows = 32;
+      } else if (mDim == 16) {
+        cols = 4;
+        rows = 16;
+      } else if (mDim == 4) {
+        cols = 4;
+        rows = 16;
+      }
     } else {
-      cols = 4;
-      rows = 16;
+      if (mDim == 64 && nDim == 4) {
+        cols = 16;
+        rows = 4;
+      } else if (mDim == 4 && nDim == 64) {
+        cols = 4;
+        rows = 16;
+      }
     }
 
     if (mfmaLayout.getIsTransposed()) {
@@ -240,7 +255,11 @@ SmallVector<unsigned> getSizePerThread(Attribute layout) {
     }
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
     unsigned rows, cols;
-    switch (mfmaLayout.getNonKDim()) {
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+    switch (std::min(mDim, nDim)) {
     case 32:
       rows = 16;
       cols = 1;
@@ -349,7 +368,10 @@ SmallVector<unsigned> getThreadsPerCTA(Attribute layout) {
     } else
       llvm::report_fatal_error("Unimplemented usage of MmaEncodingAttr");
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    if (mfmaLayout.getNonKDim() == 32) {
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert(mDim == nDim);
+    if (mDim == 32) {
       threads = {32 * mfmaLayout.getWarpsPerCTA()[0],
                  2 * mfmaLayout.getWarpsPerCTA()[1]};
     } else {
@@ -393,9 +415,10 @@ SmallVector<unsigned> getShapePerCTATile(Attribute layout,
     }
     llvm::report_fatal_error("Unexpected MMA layout version found");
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    auto nonKDim = mfmaLayout.getNonKDim();
-    return {nonKDim * mfmaLayout.getWarpsPerCTA()[0],
-            nonKDim * mfmaLayout.getWarpsPerCTA()[1]};
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    return {mDim * mfmaLayout.getWarpsPerCTA()[0],
+            nDim * mfmaLayout.getWarpsPerCTA()[1]};
   } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
     auto parentLayout = dotLayout.getParent();
     assert(parentLayout && "DotOperandEncodingAttr must have a parent");
@@ -719,15 +742,17 @@ bool sameBlockedEncodings(BlockedEncodingAttr blockedA,
 }
 
 bool sameMfmaEncodings(MfmaEncodingAttr mfmaA, MfmaEncodingAttr mfmaB) {
-  auto nonKDimA = mfmaA.getNonKDim();
+  auto mDimA = mfmaA.getMDim();
+  auto nDimA = mfmaA.getNDim();
   auto warpsPerCTAA = mfmaA.getWarpsPerCTA();
   auto isTransposedA = mfmaA.getIsTransposed();
 
-  auto nonKDimB = mfmaB.getNonKDim();
+  auto mDimB = mfmaB.getMDim();
+  auto nDimB = mfmaB.getNDim();
   auto warpsPerCTAB = mfmaB.getWarpsPerCTA();
   auto isTransposedB = mfmaB.getIsTransposed();
 
-  if (nonKDimA != nonKDimB || isTransposedA != isTransposedB) {
+  if (mDimA != mDimB || nDimA != nDimB || isTransposedA != isTransposedB) {
     return false;
   }
 
@@ -912,25 +937,22 @@ MfmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
   size_t rank = shape.size();
   assert(rank == 2 && "Unexpected rank of mfma layout");
 
-  SmallVector<unsigned> elemsPerThread(rank);
-  auto nonKDim = getNonKDim();
-  auto elemsPerThreadPerTile = (nonKDim == 16 ? 4 : 16);
+  unsigned mDim = getMDim();
+  unsigned nDim = getNDim();
+  constexpr int waveSize = 64;
+  unsigned duplicates = (mDim == 4 && nDim == 4) ? 16 : 1;
+  auto elemsPerThreadPerTile = mDim * nDim * duplicates / waveSize;
+  unsigned elemsCol = 0, elemsRow = 0;
   if (getIsTransposed()) {
-    unsigned elemsCol =
-        ceil<unsigned>(shape[1], nonKDim * getWarpsPerCTA()[1]) *
-        elemsPerThreadPerTile;
-    unsigned elemsRow = ceil<unsigned>(shape[0], nonKDim * getWarpsPerCTA()[0]);
-    elemsPerThread[0] = elemsRow;
-    elemsPerThread[1] = elemsCol;
+    elemsCol = ceil<unsigned>(shape[1], nDim * getWarpsPerCTA()[1]) *
+               elemsPerThreadPerTile;
+    elemsRow = ceil<unsigned>(shape[0], mDim * getWarpsPerCTA()[0]);
   } else {
-    unsigned elemsCol = ceil<unsigned>(shape[1], nonKDim * getWarpsPerCTA()[1]);
-    unsigned elemsRow =
-        ceil<unsigned>(shape[0], nonKDim * getWarpsPerCTA()[0]) *
-        elemsPerThreadPerTile;
-    elemsPerThread[0] = elemsRow;
-    elemsPerThread[1] = elemsCol;
+    elemsCol = ceil<unsigned>(shape[1], nDim * getWarpsPerCTA()[1]);
+    elemsRow = ceil<unsigned>(shape[0], mDim * getWarpsPerCTA()[0]) *
+               elemsPerThreadPerTile;
   }
-  return elemsPerThread;
+  return {elemsRow, elemsCol};
 }
 
 SmallVector<unsigned>
@@ -1052,17 +1074,23 @@ DotOperandEncodingAttr::getMMAv2Rep(ArrayRef<int64_t> shape,
 
 SmallVector<int64_t>
 DotOperandEncodingAttr::getMFMAElemsPerInstr() const {
-  auto mfmaEncoding = getParent().cast<MfmaEncodingAttr>();
-  int64_t nonKDim = mfmaEncoding.getNonKDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
+  auto mfmaLayout = getParent().cast<MfmaEncodingAttr>();
+  unsigned mDim = mfmaLayout.getMDim();
+  unsigned nDim = mfmaLayout.getNDim();
+  assert((mDim == nDim) && (mDim == 32 || mDim == 16 || mDim == 4) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   int64_t kWidth = getKWidth();
   constexpr int waveSize = 64; // MFMA is used on wave64 architectures only
-  int kGroups = waveSize / nonKDim;
+  int kGroups = -1;
+  if (mDim == nDim)
+    kGroups = waveSize / mDim;
+  if (mDim == 64 && nDim == 4 || mDim == 4 && nDim == 64)
+    kGroups = 1;
   int64_t kDim = kWidth * kGroups;
   if (getOpIdx() == 0)
-    return {nonKDim, kDim};
+    return {mDim, kDim};
   else
-    return {kDim, nonKDim};
+    return {kDim, nDim};
 }
 
 SmallVector<int64_t>
@@ -1367,13 +1395,18 @@ Attribute MfmaEncodingAttr::parse(AsmParser &parser, Type type) {
   if (parser.parseGreater().failed())
     return {};
 
-  unsigned nonKDim = 0;
+  unsigned mDim = 0;
+  unsigned nDim = 0;
   SmallVector<unsigned> warpsPerCTA;
   bool isTransposed;
 
   for (const NamedAttribute &attr : dict) {
-    if (attr.getName() == "nonKDim") {
-      if (parseUInt(parser, attr, nonKDim, "nonKDim").failed())
+    if (attr.getName() == "mDim") {
+      if (parseUInt(parser, attr, mDim, "mDim").failed())
+        return {};
+    }
+    if (attr.getName() == "nDim") {
+      if (parseUInt(parser, attr, nDim, "nDim").failed())
         return {};
     }
     if (attr.getName() == "warpsPerCTA") {
@@ -1385,13 +1418,14 @@ Attribute MfmaEncodingAttr::parse(AsmParser &parser, Type type) {
     }
   }
 
-  return parser.getChecked<MfmaEncodingAttr>(parser.getContext(), nonKDim,
+  return parser.getChecked<MfmaEncodingAttr>(parser.getContext(), mDim, nDim,
                                              warpsPerCTA, isTransposed);
 }
 
 void MfmaEncodingAttr::print(AsmPrinter &printer) const {
   printer << "<{"
-          << "nonKDim = " << getNonKDim() << ", "
+          << "mDim = " << getMDim() << ", "
+          << "nDim = " << getNDim() << ", "
           << "warpsPerCTA = [" << getWarpsPerCTA() << "], "
           << "isTransposed = " << getIsTransposed() << "}>";
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
@@ -133,7 +133,8 @@ public:
   /// @brief Choose MFMA instruction parameters
   /// @param dot target dot operation
   /// @return pair {nonKDim, kDim} sizes of one MFMA instruction arguments
-  std::pair<int64_t, int64_t> chooseMfmaDimensions(tt::DotOp dot) const {
+  std::tuple<int64_t, int64_t, int64_t>
+  chooseMfmaDimensions(tt::DotOp dot) const {
     // number of matrix elements along k dim per one MFMA intruction
     int64_t kDim = -1;
     auto opType = dot.getA().getType().cast<RankedTensorType>();
@@ -142,22 +143,40 @@ public:
     auto resType = dot.getD().getType().cast<RankedTensorType>();
     auto resShape = resType.getShape();
 
-    int64_t nonKDim = -1;
+    int64_t mDim = -1;
+    int64_t nDim = -1;
     if (enforcedNonKDim != 0) {
-      nonKDim = enforcedNonKDim;
+      mDim = enforcedNonKDim;
+      nDim = enforcedNonKDim;
     } else {
-      nonKDim = -1;
       int minSize = std::min(resShape[0], resShape[1]);
-      if (minSize >= 32)
-        nonKDim = 32;
-      if (minSize >= 16 && minSize < 32)
-        nonKDim = 16;
-      if (minSize < 16)
-        nonKDim = 4;
-      assert(nonKDim != -1);
+      if (minSize >= 32) {
+        mDim = 32;
+        nDim = 32;
+      }
+      if (minSize >= 16 && minSize < 32) {
+        mDim = 16;
+        nDim = 16;
+      }
+      if (minSize < 16) {
+        if (resShape[0] < 16 && resShape[1] >= 64) {
+          mDim = 4;
+          nDim = 64;
+        } else if (resShape[0] >= 64 && resShape[1] < 16) {
+          mDim = 64;
+          nDim = 4;
+        } else {
+          assert(opType.getShape()[1] >= 64 &&
+                 "k should be at least 64 to use this layout");
+          mDim = 4;
+          nDim = 4;
+        }
+      }
+      assert(mDim != -1);
+      assert(nDim != -1);
     }
-    switch (nonKDim) {
-    case 32:
+
+    if (mDim == 32 && nDim == 32) {
       if (elemType.isF32())
         kDim = 2;
       if (elemType.isF16())
@@ -173,15 +192,13 @@ public:
         kDim = 16;
       }
       if (elemType.isInteger(8)) {
-        if (mfmaVersion == 3) {
+        if (mfmaVersion == 3)
           kDim = 16;
-        }
-        else {
+        else
           kDim = 8;
-        }
       }
-      break;
-    case 16:
+    }
+    if (mDim == 16 && nDim == 16) {
       if (elemType.isF32())
         kDim = 4;
       if (elemType.isF16())
@@ -197,15 +214,13 @@ public:
         kDim = 32;
       }
       if (elemType.isInteger(8)) {
-        if (mfmaVersion == 3) {
+        if (mfmaVersion == 3)
           kDim = 32;
-        }
-        else {
+        else
           kDim = 16;
-        }
       }
-      break;
-    case 4:
+    }
+    if (mDim == 4 && nDim == 4) {
       if (elemType.isF32())
         kDim = 16;
       if (elemType.isF16())
@@ -216,18 +231,44 @@ public:
         if (mfmaVersion >= 2)
           kDim = 64;
       }
-      if (elemType.isInteger(8)) {
+      if (elemType.isInteger(8))
         kDim = 64;
-      }
-      break;
-    default:
-      llvm::report_fatal_error("unsupported nonKDim size in MFMA dot");
     }
+    if (mDim == 64 && nDim == 4) {
+      if (elemType.isF32())
+        kDim = 1;
+      if (elemType.isF16())
+        kDim = 4;
+      if (elemType.isBF16()) {
+        if (mfmaVersion == 1)
+          kDim = 2;
+        if (mfmaVersion >= 2)
+          kDim = 4;
+      }
+      if (elemType.isInteger(8))
+        kDim = 4;
+    }
+    if (mDim == 4 && nDim == 64) {
+      if (elemType.isF32())
+        kDim = 1;
+      if (elemType.isF16())
+        kDim = 4;
+      if (elemType.isBF16()) {
+        if (mfmaVersion == 1)
+          kDim = 2;
+        if (mfmaVersion >= 2)
+          kDim = 4;
+      }
+      if (elemType.isInteger(8))
+        kDim = 4;
+    }
+
     assert(kDim != -1);
-    assert(nonKDim != -1);
-    assert(resShape[0] % nonKDim == 0 && resShape[1] % nonKDim == 0);
+    assert(mDim != -1);
+    assert(nDim != -1);
+    assert(resShape[0] % mDim == 0 && resShape[1] % nDim == 0);
     assert(opType.getShape()[1] % kDim == 0);
-    return {nonKDim, kDim};
+    return {mDim, nDim, kDim};
   }
 
   mlir::LogicalResult
@@ -262,13 +303,13 @@ public:
 
     ttg::MfmaEncodingAttr mfmaEnc;
 
-    auto [nonKDim, kDim] = chooseMfmaDimensions(dotOp);
+    auto [mDim, nDim, kDim] = chooseMfmaDimensions(dotOp);
 
     auto warpsPerTile =
-        warpsPerTileMFMA(dotOp, retShape, numWarps, {nonKDim, nonKDim});
+        warpsPerTileMFMA(dotOp, retShape, numWarps, {mDim, nDim});
 
     bool isTransposed = isChainDot(dotOp);
-    mfmaEnc = ttg::MfmaEncodingAttr::get(oldRetType.getContext(), nonKDim,
+    mfmaEnc = ttg::MfmaEncodingAttr::get(oldRetType.getContext(), mDim, nDim,
                                          warpsPerTile, isTransposed);
 
     auto newRetType =
@@ -291,23 +332,19 @@ public:
 
     // kWidth is a number of consecutive elements per one instruction per one
     // thread
-    auto kWidth = kDim;
+    auto kWidth = -1;
     // in mfma 32x32 case argument matrix groups elements in 2 groups
     // in mfma 16x16 case argument matrix groups elements in 4 groups
-    // in mfma 4x4 case arguemnt matrix groups in 16 groups
-    switch (nonKDim) {
-    case 32:
-      kWidth /= 2;
-      break;
-    case 16:
-      kWidth /= 4;
-      break;
-    case 4:
-      kWidth /= 16;
-      break;
-    default:
-      llvm::report_fatal_error("unsupported kDim in mfma dot");
-    }
+    // in mfma 4x4 case argument matrix groups in 16 groups
+    if (mDim == 32 && nDim == 32)
+      kWidth = kDim / 2;
+    if (mDim == 16 && nDim == 16)
+      kWidth = kDim / 4;
+    if (mDim == 4 && nDim == 4)
+      kWidth = kDim / 16;
+    if (mDim == 4 && nDim == 64 || mDim == 64 && nDim == 4)
+      kWidth = kDim;
+    assert(kWidth != -1);
     auto newAType = RankedTensorType::get(
         oldAType.getShape(), oldAType.getElementType(),
         ttg::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, kWidth));

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1681,7 +1681,9 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                                            [8, 32, 128, 2],
                                            [4, 32, 64, 4],
                                            [32, 4, 64, 2],
-                                           [16, 4, 64, 8]
+                                           [16, 4, 64, 8],
+                                           [64, 4, 16, 1],
+                                           [4, 64, 16, 1],
                                            ]
                           for allow_tf32 in [False, True]
                           for col_a in [True, False]
@@ -1904,12 +1906,24 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
         backend = triton.common.backend.get_backend("hip")
         if backend.get_matrix_core_version() > 0:
             ttgir = pgm.asm['ttgir']
-            if non_k_dim == 16:
-                assert "#triton_gpu.mfma<{nonKDim = 16" in ttgir
-                assert "#triton_gpu.mfma<{nonKDim = 32" not in ttgir
+            if non_k_dim == 0 and ((M == 4 and N == 64) or (M == 64 and N == 4)):
+                m64n4 = "#triton_gpu.mfma<{mDim = 64, nDim = 4"
+                m4n64 = "#triton_gpu.mfma<{mDim = 4, nDim = 64"
+                assert (m64n4 in ttgir) or (m4n64 in ttgir)
+                assert "#triton_gpu.mfma<{mDim = 16, nDim = 16" not in ttgir
+                assert "#triton_gpu.mfma<{mDim = 32, nDim = 32" not in ttgir
+            if non_k_dim == 4:
+                assert "#triton_gpu.mfma<{mDim = 4, nDim = 4" in ttgir
+                assert "#triton_gpu.mfma<{mDim = 16, nDim = 16" not in ttgir
+                assert "#triton_gpu.mfma<{mDim = 32, nDim = 32" not in ttgir
+            elif non_k_dim == 16:
+                assert "#triton_gpu.mfma<{mDim = 4, nDim = 4" not in ttgir
+                assert "#triton_gpu.mfma<{mDim = 16, nDim = 16" in ttgir
+                assert "#triton_gpu.mfma<{mDim = 32, nDim = 32" not in ttgir
             elif non_k_dim == 32:
-                assert "#triton_gpu.mfma<{nonKDim = 32" in ttgir
-                assert "#triton_gpu.mfma<{nonKDim = 16" not in ttgir
+                assert "#triton_gpu.mfma<{mDim = 4, nDim = 4" not in ttgir
+                assert "#triton_gpu.mfma<{mDim = 32, nDim = 32" in ttgir
+                assert "#triton_gpu.mfma<{mDim = 16, nDim = 16" not in ttgir
         gcn = pgm.asm['amdgcn']
         if backend.get_matrix_core_version() == 3 and effective_in_dtype == tl.float8e5b16:
             assert "v_mfma_f32_32x32x16_bf8_bf8" in gcn or "v_mfma_f32_16x16x32_bf8_bf8" in gcn
@@ -2706,7 +2720,7 @@ class MfmaLayout:
         self.is_transposed = str(is_transposed).lower()
 
     def __str__(self):
-        return f"#{GPU_DIALECT}.mfma<{{nonKDim = {self.non_k_dim}, warpsPerCTA = {self.warps_per_cta}, isTransposed = {self.is_transposed}}}>"
+        return f"#{GPU_DIALECT}.mfma<{{mDim = {self.non_k_dim}, nDim = {self.non_k_dim}, warpsPerCTA = {self.warps_per_cta}, isTransposed = {self.is_transposed}}}>"
 
 
 class BlockedLayout:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1190,10 +1190,10 @@ def is_hip():
 
 def mfma_supported_granularity(m, n, k) -> bool:
     # todo make this gran_type matrix element type sensitive
-    for gran_type in [(32, 8), (16, 16), (4, 64)]:
-        granularity_mn, granularity_k = gran_type
+    for gran_type in [(32, 32, 8), (16, 16, 16), (4, 4, 64), (64, 4, 4), (4, 64, 4)]:
+        granularity_m, granularity_n, granularity_k = gran_type
 
-        if m % granularity_mn != 0 or n % granularity_mn != 0:
+        if m % granularity_m != 0 or n % granularity_n != 0:
             continue
         if k % granularity_k != 0:
             continue

--- a/test/Conversion/AMDGPU/mfma_variants.mlir
+++ b/test/Conversion/AMDGPU/mfma_variants.mlir
@@ -5,7 +5,7 @@
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -25,7 +25,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -45,7 +45,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -65,7 +65,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -85,7 +85,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -105,7 +105,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 2
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -125,7 +125,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -145,7 +145,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 1
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -165,7 +165,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = i32
 #k_width = 4
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -185,7 +185,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = i32
 #k_width = 8
 #non_k_dim = 32
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -205,7 +205,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -225,7 +225,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -245,7 +245,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -265,7 +265,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 8
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -285,7 +285,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -305,7 +305,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 2
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -325,7 +325,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -345,7 +345,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 1
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -365,7 +365,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = i32
 #k_width = 4
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -385,7 +385,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = i32
 #k_width = 8
 #non_k_dim = 16
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -405,7 +405,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 4
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -425,7 +425,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 2
 #non_k_dim = 4
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -445,7 +445,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 4
 #non_k_dim = 4
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -465,7 +465,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = f32
 #k_width = 1
 #non_k_dim = 4
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -485,7 +485,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 !c_ty = i32
 #k_width = 4
 #non_k_dim = 4
-#mfma = #triton_gpu.mfma<{nonKDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = #non_k_dim, nDim = #non_k_dim, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = #k_width}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = #k_width}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {

--- a/test/Conversion/minimize_alloc.mlir
+++ b/test/Conversion/minimize_alloc.mlir
@@ -5,7 +5,7 @@
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 4, perPhase = 2, maxPhase = 8, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared1 = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
+#mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
   tt.func public @matmul_kernel_0d1d2d3d4d5d6d7c8d9c10d11c(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mfma>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1356,7 +1356,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared0 = #triton_gpu.shared<{vec = 4, perPhase=2, maxPhase=8, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared1 = #triton_gpu.shared<{vec = 1, perPhase=1, maxPhase=1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
-#mfma0 = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
+#mfma0 = #triton_gpu.mfma<{mDim = 32, nDim = 32, warpsPerCTA=[1,1], isTranspose=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma0, kWidth = 4}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma0, kWidth = 4}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
@@ -1380,7 +1380,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 // -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
+#mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32, warpsPerCTA = [2, 2], isTranspose=false}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
   // CHECK: llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
   // CHECK-LABEL: convert_layout_mfma_block
@@ -1530,7 +1530,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 32], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
-#mfma = #triton_gpu.mfma<{nonKDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
+#mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32, warpsPerCTA = [2, 2], isTransposed=false}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mfma, kWidth = 4}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mfma, kWidth = 4}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {

--- a/test/TritonGPU/accelerate-matmul-cdna1.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna1.mlir
@@ -1,0 +1,800 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx908 --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+

--- a/test/TritonGPU/accelerate-matmul-cdna2.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna2.mlir
@@ -1,0 +1,800 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx90a --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+

--- a/test/TritonGPU/accelerate-matmul-cdna3.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna3.mlir
@@ -1,0 +1,816 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx940 --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 32, nDim = 32,
+// CHECK: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 16, nDim = 16,
+// CHECK: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 4,
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 64, nDim = 4,
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{mDim = 4, nDim = 64,
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+


### PR DESCRIPTION
This PR enables two new MxN tile sizes: 64 x 4 and 4 x 64.
Both of them uses mfma 4x4 instructions.