### PR TITLE
[Backend] Refactor sharedToDotOperandMFMA lowering

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -157,6 +157,9 @@ compared to 1*64 when the hasLeadingOffset is false.
             // maxPhase is set to SIMDWidth / perPhase
             int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
             int maxPhase = SIMDWidth / perPhase;
+            // TODO (zhanglx): figure out better parameters for mfma4
+            if (mfmaEnc.getNonKDim() == 4 )
+               maxPhase = 4;
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
           } else {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -378,6 +378,13 @@ bool isColMajor(::llvm::ArrayRef<unsigned> order) {
   return order[0] == 0;
 }
 
+bool isKMajor(::llvm::ArrayRef<unsigned> order, int opIdx) {
+  if (order[0] + opIdx == 1)
+    return true;
+  else
+    return false;
+}
+
 Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                     Location loc, Value tensor, DotOperandEncodingAttr encoding,
                     const SharedMemoryObject &smemObj,
@@ -426,7 +433,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   SmallVector<Value> offsets;
   Value smemBase;
   bool isFastPath = fastPathAvailable(smemObj, sharedLayout, mfmaLayout);
-  if (isFastPath) {
+  if (!isKMajor(order, opIdx) && isFastPath) {
     // fast path handles tensors that are not k-major, in which case swizzling
     // is disabled and offsets computation can be simplified
     // TODO (zhanglx): later when we enable vector access to LDS for non k-major

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -109,13 +109,17 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
  * elemsPerInstr[1].
  *
  * Total offset of element is a sum of following values:
- * 1. Offset of wave block in tensor
- * 2. Offset of wave inside one wave block
+ * 1. Offset of wave-block in tensor
+ * 2. Offset of wave inside one wave-block
  * 3. Offset of tile in one wave
  * 4. Offset of one lane data in a tile
  * 5. Offset of particular element of tensor processed by one lane
  *
  * This function computes these offsets for axies independently
+ * Note that this function returns the offsets of elements in the first
+ * wave-block. The offsets of elements in later wave-blocks can be computed
+ * by adding a constant stride to the xor-ed offsets of elements in the
+ * first wave-block.
  *
  * @param rewriter
  * @param loc
@@ -311,8 +315,6 @@ std::optional<int> findConstValue(Value val) {
 bool fastPathAvailable(const SharedMemoryObject &smemObj,
                        const SharedEncodingAttr &srcEncoding,
                        const MfmaEncodingAttr &dstEncoding) {
-  if (dstEncoding.getNonKDim() != 32)
-    return false;
   if (srcEncoding.getMaxPhase() > 1)
     return false;
   auto stride0 = findConstValue(smemObj.strides[0]);
@@ -338,6 +340,8 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj,
 // @param numOfElems number of elements accessed by thread per repetition
 // @param reps number of instructions repretition to fully cover dot operand
 // @param cSwizzleOffset
+// TODO (zhanglx): We should never call this function because we always have
+// swizzling enabled for k-major matrices.
 llvm::SmallVector<Value>
 fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
                           const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
@@ -396,10 +400,9 @@ fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
   SmallVector<Value> offsets(numK * numN * numOfElems);
 
   int lineSize = warpsPerGroup * elemsPerInstr[1] * numN;
-  Value _0 = i32_val(0);
-  Value _32 = i32_val(32);
+  Value _nonKDim = i32_val(elemsPerInstr[1]);
   Value waveOffset = mul(waveId, i32_val(elemsPerInstr[1]));
-  Value colOffset = urem(laneId, _32);
+  Value colOffset = urem(laneId, _nonKDim);
 
   for (int block = 0; block < numN; ++block) {
     Value blockOffset = i32_val(block * elemsPerInstr[1] * warpsPerGroup);
@@ -407,7 +410,7 @@ fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
       Value tileOffset = i32_val(tile * elemsPerInstr[0] * lineSize);
       for (int elem = 0; elem < numOfElems; ++elem) {
         Value halfOffset =
-            select(icmp_uge(laneId, _32), i32_val(numOfElems * lineSize), _0);
+            mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
         Value rowOffset = add(i32_val(elem * lineSize), halfOffset);
         Value elemOffset = add(rowOffset, colOffset);
         Value offset =
@@ -419,7 +422,7 @@ fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
   return offsets;
 }
 
-bool isTransposed(::llvm::ArrayRef<unsigned> order) {
+bool isColMajor(::llvm::ArrayRef<unsigned> order) {
   assert(order.size() == 2 && (order[0] & ~1ul) == 0 &&
          order[0] + order[1] == 1);
   return order[0] == 0;
@@ -474,21 +477,29 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value smemBase;
   bool isFastPath = fastPathAvailable(smemObj, sharedLayout, mfmaLayout);
   if (isFastPath) {
+    // fast path handles tensors that are not k-major, in which case swizzling
+    // is disabled and offsets computation can be simplified
+    // TODO (zhanglx): later when we enable vector access to LDS for non k-major
+    // tensors, we'll refactor the scope of fast and normal path
     Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
     if (opIdx == 0) {
-      if (isTransposed(order)) { // HERE
+      if (isColMajor(order)) {
         SmallVector<int64_t> elemsPerInstr{mfmaInstrK, mfmaInstrNonK};
         SmallVector<int64_t> reps{numReps[1], numReps[0]};
         offsets = fastPathComputeOffsetsTy2(
             rewriter, loc, elemsPerInstr, spatialWaveId, lane,
             warpsPerGroupNonK, numOfElems, reps, cSwizzleOffset);
       } else {
+        llvm_unreachable(
+            "row major operand A should be handled in the normal path");
         offsets = fastPathComputeOffsetsTy1(
             rewriter, loc, elemsPerInstr, spatialWaveId, lane,
             warpsPerGroupNonK, numOfElems, numReps, cSwizzleOffset);
       }
     } else {
-      if (isTransposed(order)) {
+      if (isColMajor(order)) {
+        llvm_unreachable(
+            "col major operand B should be handled in the normal path");
         SmallVector<int64_t> elemsPerInstr{mfmaInstrNonK, mfmaInstrK};
         SmallVector<int64_t> reps{numReps[1], numReps[0]};
         offsets = fastPathComputeOffsetsTy1(
@@ -502,6 +513,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
     }
     smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
   } else { // normal path
+    // Normal path handles tensor that k-major, in which case swizzling
+    // is enabled and it requires a 2-step method to compute the offsets.
     if (opIdx == 0) {
       offsets = computeOffsetsAType(rewriter, loc, elemsPerInstr, spatialWaveId,
                                     lane, warpsPerGroupNonK, numOfElems,
@@ -535,6 +548,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
           loadOffset = offsets[nonK * loadsPerThread * numRepK +
                                k * loadsPerThread + loadId];
         else
+          // In the normal path, we only computed the offsets of elements
+          // in the first wave-block. Therefore, we update the offsets
+          // of elements in later wave-blocks by adding a constant stride
           loadOffset = add(offAdjust, offsets[k * loadsPerThread + loadId]);
         Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset),
                                     getShemPtrTy(loadVecTy));

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -140,46 +140,36 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
   auto numM = reps[0];
   auto numK = reps[1];
   const int loadsPerThread = numOfElems / loadVecSize;
-  llvm::SmallVector<llvm::SmallVector<Value>> mapping(numM * numK *
-                                                      loadsPerThread);
+  llvm::SmallVector<llvm::SmallVector<Value>> mapping(numK * loadsPerThread);
 
   Value _0 = i32_val(0);
   Value _32 = i32_val(32);
   Value nonKDim = i32_val(iNonKDim);
+  Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
 
-  for (int block = 0; block < numM; ++block) {
-    Value blockVOffset = i32_val(block * elemsPerInstr[0] * warpsPerGroup);
-    Value blockHOffset = _0;
-    Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
-    Value waveHOffset = _0;
-    for (int tile = 0; tile < numK; ++tile) {
-      Value tileVOffset = _0;
-      Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
+  for (int tile = 0; tile < numK; ++tile) {
+    Value tileVOffset = _0;
+    Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
 
-      Value laneVOffset = urem(laneId, nonKDim);
-      Value laneHOffset;
-      if (iNonKDim == 32)
-        laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
-      else
-        laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
+    Value laneVOffset = urem(laneId, nonKDim);
+    Value laneHOffset;
+    if (iNonKDim == 32)
+      laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
+    else
+      laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
 
-      for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
-        Value elemVOffset = _0;
-        Value elemHOffset = i32_val(loadId * loadVecSize);
+    for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
+      Value elemVOffset = _0;
+      Value elemHOffset = i32_val(loadId * loadVecSize);
 
-        Value sliceVOffset = add(
-            add(add(add(blockVOffset, waveVOffset), tileVOffset), laneVOffset),
-            elemVOffset);
-        Value sliceHOffset = add(
-            add(add(add(blockHOffset, waveHOffset), tileHOffset), laneHOffset),
-            elemHOffset);
+      Value sliceVOffset =
+          add(add(add(tileVOffset, laneVOffset), elemVOffset), waveVOffset);
+      Value sliceHOffset = add(add(tileHOffset, laneHOffset), elemHOffset);
 
-        Value row = add(sliceVOffset, smemOffsets[0]);
-        Value col = add(sliceHOffset, smemOffsets[1]);
+      Value row = add(sliceVOffset, smemOffsets[0]);
+      Value col = add(sliceHOffset, smemOffsets[1]);
 
-        mapping[numK * loadsPerThread * block + loadsPerThread * tile +
-                loadId] = {row, col};
-      }
+      mapping[loadsPerThread * tile + loadId] = {row, col};
     }
   }
   return mapping;
@@ -350,11 +340,12 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj,
 // @param cSwizzleOffset
 llvm::SmallVector<Value>
 fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
-                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                  Value laneId, int warpsPerGroup, int numOfElems,
-                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
+                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                          Value laneId, int warpsPerGroup, int numOfElems,
+                          ArrayRef<int64_t> reps, Value cSwizzleOffset) {
   const int loadVecSize = numOfElems;
-  const int loadsPerThread = 1; // 1 is just in case if we decide to use different loadVecSize
+  const int loadsPerThread =
+      1; // 1 is just in case if we decide to use different loadVecSize
   auto numM = reps[0];
   auto numK = reps[1];
   SmallVector<Value> offsets(numM * numK * loadsPerThread);
@@ -372,12 +363,13 @@ fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
     for (int tile = 0; tile < numK; ++tile) {
       Value tileOffset = i32_val(tile * elemsPerInstr[1]);
       for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
-        Value rowOffset =
-            add(mul(urem(laneId, _32), i32_val(lineSize)), i32_val(loadId * loadVecSize));
+        Value rowOffset = add(mul(urem(laneId, _32), i32_val(lineSize)),
+                              i32_val(loadId * loadVecSize));
         Value elemOffset = add(rowOffset, colOffset);
         Value offset =
             add(add(add(waveOffset, blockOffset), tileOffset), elemOffset);
-        offsets[numK * loadsPerThread * block + loadsPerThread * tile + loadId] = offset;
+        offsets[numK * loadsPerThread * block + loadsPerThread * tile +
+                loadId] = offset;
       }
     }
   }
@@ -480,7 +472,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
   Value smemBase;
-  if (fastPathAvailable(smemObj, sharedLayout, mfmaLayout)) {
+  bool isFastPath = fastPathAvailable(smemObj, sharedLayout, mfmaLayout);
+  if (isFastPath) {
     Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
     if (opIdx == 0) {
       if (isTransposed(order)) { // HERE
@@ -525,18 +518,24 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Type resElemTy = typeConverter->convertType(elemTy);
   Type smemPtrTy = getShemPtrTy(elemTy);
 
-  int loadsPerThread = offsets.size() / (numRepNonK * numRepK);
+  int loadsPerThread = offsets.size() / numRepK / (isFastPath ? numRepNonK : 1);
   int elemsPerLoad = numOfElems / loadsPerThread;
   assert(numOfElems % loadsPerThread == 0);
 
   for (int nonK = 0; nonK < numRepNonK; ++nonK) {
+    Value blockVOffset = i32_val(nonK * mfmaInstrNonK * warpsPerGroupNonK);
+    Value offAdjust = mul(blockVOffset, i32_val(shape[order[0]]));
     for (int k = 0; k < numRepK; ++k) {
       auto vecTy = vec_ty(resElemTy, numOfElems);
       Value valVec = undef(vecTy);
       for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
         auto loadVecTy = vec_ty(elemTy, elemsPerLoad);
-        Value loadOffset = offsets[nonK * loadsPerThread * numRepK +
-                                   k * loadsPerThread + loadId];
+        Value loadOffset;
+        if (isFastPath)
+          loadOffset = offsets[nonK * loadsPerThread * numRepK +
+                               k * loadsPerThread + loadId];
+        else
+          loadOffset = add(offAdjust, offsets[k * loadsPerThread + loadId]);
         Value loadAddress = bitcast(gep(smemPtrTy, smemBase, loadOffset),
                                     getShemPtrTy(loadVecTy));
         Value loadedValue = load(loadAddress);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
@@ -94,8 +94,9 @@ warpsPerTile(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
 }
 
 SmallVector<unsigned, 2>
-warpsPerTileMFMA(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps) {
-  return warpsPerTile(dotOp, shape, numWarps, {32, 32});
+warpsPerTileMFMA(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
+                 SmallVector<int64_t, 2> shapePerWarp) {
+  return warpsPerTile(dotOp, shape, numWarps, shapePerWarp);
 }
 
 SmallVector<unsigned, 2>
@@ -263,7 +264,8 @@ public:
 
     auto [nonKDim, kDim] = chooseMfmaDimensions(dotOp);
 
-    auto warpsPerTile = warpsPerTileMFMA(dotOp, retShape, numWarps);
+    auto warpsPerTile =
+        warpsPerTileMFMA(dotOp, retShape, numWarps, {nonKDim, nonKDim});
 
     bool isTransposed = isChainDot(dotOp);
     mfmaEnc = ttg::MfmaEncodingAttr::get(oldRetType.getContext(), nonKDim,

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1714,7 +1714,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
         if non_k_dim == 4 and (K < 64):
             pytest.skip("incompatible non_k_dim == 4 with K size")
         if non_k_dim == 4 and (M > 16 or N > 16):
-            pytest.skip("skipping lage matrices for non_k_dim == 4 to speedup testing")
+            pytest.skip("skipping large matrices for non_k_dim == 4 to speedup testing")
 
     if capability[0] < 7:
         pytest.skip("Only test tl.dot() on devices with sm >= 70")

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2746,6 +2746,10 @@ def test_dot_mfma_vector_load(vec_size, swizzle, transposeA, transposeB):
     if transposeA and not transposeB:
         pytest.skip()
 
+    # We skip for the case when swizzle is disabled for k-major opA or opB
+    if not swizzle and (not transposeA or transposeB):
+        pytest.skip()
+
     if triton.common.backend.get_backend("hip").get_matrix_core_version() == 0:
         pytest.skip("mfma is not available on hardware")
 

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -2746,10 +2746,6 @@ def test_dot_mfma_vector_load(vec_size, swizzle, transposeA, transposeB):
     if transposeA and not transposeB:
         pytest.skip()
 
-    # We skip for the case when swizzle is disabled for k-major opA or opB
-    if not swizzle and (not transposeA or transposeB):
-        pytest.skip()
-
     if triton.common.backend.get_backend("hip").get_matrix_core_version() == 0:
         pytest.skip("mfma is not available on hardware")
 


### PR DESCRIPTION
This PR
- Implements https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/5237
- Supports mfma16 and mfma4 in the fast path
- sets `maxPhase=4` for mfma4. This is because the nonKDim of mfma4 is less than 16.
- Choose warpsPerTile according to mfmaLayout's nonKDim
- cleans up format

Before we enable vector access to LDS for non k-major tensors, here are our conventions about LDS accesses:
- LDS write
  - For k-major tensors, swizzling is enabled, i.e. a vector of elements are swizzled in LDS. ds_write are vectorized
  - For non k-major tensors, a.k.a. mn-major tensors, swizzling is disabled, i.e. elements are written to LDS in their original order. The LLVM backend usually vectorizes ds_write for us, though we write one element at a time.
- LDS read
  - For k-major tensors, **normal path** is taken since swizzling is enabled.
  - For non k-major tensors, **fast path** is taken, since the mapping from an element's coordinates in the tensor to its offsets in the LDS is linear.

Note
- If the tensor is k-major, we assume swizzling is enabled. Therefore, we don't allow/test the case where swizzling is disabled for k-major tensors.