### PR TITLE
Use full-vectorized load instructions for load vectorization

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -146,7 +146,7 @@ struct LoadOpConversion
       // TODO: optimization when ptr is GEP with constant offset
       size_t in_off = 0;
 
-      const size_t maxWordWidth = std::max<size_t>(128, valueElemNBits);
+      const size_t maxWordWidth = std::max<size_t>(32, valueElemNBits);
       const size_t totalWidth = valueElemNBits * vec;
       const size_t width = std::min(totalWidth, maxWordWidth);
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
@@ -156,41 +156,51 @@ struct LoadOpConversion
 
 #ifdef USE_ROCM
       Value pred = mask ? maskElems[vecStart] : int_val(1, 1);
-      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-        size_t elemOffset = vecStart + wordIdx * wordNElems;
-        auto vecType = LLVM::getFixedVectorType(valueElemTy, wordNElems);
-        Value ptr = addrspacecast(ptrElems[elemOffset], ptr_ty(vecType));
-        auto loaded = rewriter.create<scf::IfOp>(
-            loc,
-            pred,
-            [&](OpBuilder& builder, Location loc) {
-              // Todo alignment
-              auto loadVal = builder.create<LLVM::LoadOp>(loc, ptr);
-              //auto loadVal = builder.create<LLVM::LoadOp>(loc, ptr, 4);
-              builder.create<mlir::scf::YieldOp>(loc, ValueRange({loadVal}));
-            },
-            [&](OpBuilder& builder, Location loc) {
-              auto vecTy = LLVM::getFixedVectorType(valueElemTy, wordNElems);
-              auto denseValue =
-                  DenseElementsAttr::get(vecTy.cast<mlir::ShapedType>(), 0);
-              Value zeroVal = rewriter.create<LLVM::ConstantOp>(
-                  loc, vecTy, denseValue);
+      auto loaded = rewriter.create<scf::IfOp>(
+          loc,
+          pred,
+          [&](OpBuilder& builder, Location loc) {
+            SmallVector<Value> thenLoadValues;
+            for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
+              size_t elemOffset = vecStart + wordIdx * wordNElems;
+              Value ptr = addrspacecast(
+                  ptrElems[elemOffset],
+                  ptr_ty(IntegerType::get(getContext(), width)));
+              auto loadVal = rewriter.create<LLVM::LoadOp>(loc, ptr);
+              thenLoadValues.push_back(loadVal);
+            }
+            builder.create<mlir::scf::YieldOp>(loc, thenLoadValues);
+          },
+          [&](OpBuilder& builder, Location loc) {
+            SmallVector<Value> elseLoadValues;
+            for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
+              size_t elemOffset = vecStart + wordIdx * wordNElems;
+              Value zeroVal = int_val(width, 0);
               Value otherVal;
               if (other) {
+                auto vecTy = LLVM::getFixedVectorType(valueElemTy, wordNElems);
                 Value v = undef(vecTy);
                 for (size_t s = 0; s < wordNElems; ++s) {
                   Value falseVal = otherElems[elemOffset + s];
                   Value sVal = createIndexAttrConstant(
-                      rewriter, loc, this->getTypeConverter()->getIndexType(),
+                      rewriter,
+                      loc,
+                      this->getTypeConverter()->getIndexType(),
                       s);
                   v = insert_element(vecTy, v, falseVal, sVal);
                 }
-                otherVal = v;
+                otherVal = bitcast(v, IntegerType::get(getContext(), width));
               }
               Value falseVal = other ? otherVal : zeroVal;
-              builder.create<mlir::scf::YieldOp>(loc, ValueRange({falseVal}));
-            });
-        Value loadVal = loaded->getResult(0);
+              elseLoadValues.push_back(falseVal);
+            }
+            builder.create<mlir::scf::YieldOp>(loc, elseLoadValues);
+          });
+
+      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
+        Value loadVal = bitcast(
+            loaded->getResult(wordIdx),
+            LLVM::getFixedVectorType(valueElemTy, wordNElems));
         for (size_t ii = 0; ii < wordNElems; ++ii) {
           Value vecIdx = createIndexAttrConstant(
               rewriter, loc, this->getTypeConverter()->getIndexType(), ii % wordNElems);

--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -156,57 +156,46 @@ struct LoadOpConversion
 
 #ifdef USE_ROCM
       Value pred = mask ? maskElems[vecStart] : int_val(1, 1);
+      auto vecTy = LLVM::getFixedVectorType(valueElemTy, vec);
       auto loaded = rewriter.create<scf::IfOp>(
           loc,
           pred,
           [&](OpBuilder& builder, Location loc) {
-            SmallVector<Value> thenLoadValues;
-            for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-              size_t elemOffset = vecStart + wordIdx * wordNElems;
-              Value ptr = addrspacecast(
-                  ptrElems[elemOffset],
-                  ptr_ty(IntegerType::get(getContext(), width)));
-              auto loadVal = rewriter.create<LLVM::LoadOp>(loc, ptr);
-              thenLoadValues.push_back(loadVal);
-            }
-            builder.create<mlir::scf::YieldOp>(loc, thenLoadValues);
+
+            Value ptr = addrspacecast(ptrElems[vecStart], ptr_ty(vecTy));
+            auto loadVal = rewriter.create<LLVM::LoadOp>(loc, ptr);
+            builder.create<mlir::scf::YieldOp>(loc, ValueRange({loadVal}));
           },
           [&](OpBuilder& builder, Location loc) {
-            SmallVector<Value> elseLoadValues;
-            for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-              size_t elemOffset = vecStart + wordIdx * wordNElems;
-              Value zeroVal = int_val(width, 0);
-              Value otherVal;
-              if (other) {
-                auto vecTy = LLVM::getFixedVectorType(valueElemTy, wordNElems);
-                Value v = undef(vecTy);
-                for (size_t s = 0; s < wordNElems; ++s) {
-                  Value falseVal = otherElems[elemOffset + s];
-                  Value sVal = createIndexAttrConstant(
-                      rewriter,
-                      loc,
-                      this->getTypeConverter()->getIndexType(),
-                      s);
-                  v = insert_element(vecTy, v, falseVal, sVal);
-                }
-                otherVal = bitcast(v, IntegerType::get(getContext(), width));
+            mlir::Attribute zero = builder.getZeroAttr(valueElemTy);
+            auto denseValue =
+                DenseElementsAttr::get(vecTy.cast<mlir::ShapedType>(), zero);
+            Value zeroVal =
+                rewriter.create<LLVM::ConstantOp>(loc, vecTy, denseValue);
+            Value otherVal;
+            if (other) {
+              Value v = undef(vecTy);
+              for (size_t s = 0; s < vec; ++s) {
+                Value falseVal = otherElems[vecStart + s];
+                Value sVal = createIndexAttrConstant(
+                    rewriter, loc, this->getTypeConverter()->getIndexType(), s);
+                v = insert_element(vecTy, v, falseVal, sVal);
               }
-              Value falseVal = other ? otherVal : zeroVal;
-              elseLoadValues.push_back(falseVal);
+              otherVal = v;
             }
-            builder.create<mlir::scf::YieldOp>(loc, elseLoadValues);
+            Value falseVal = other ? otherVal : zeroVal;
+            builder.create<mlir::scf::YieldOp>(loc, ValueRange({falseVal}));
           });
 
-      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-        Value loadVal = bitcast(
-            loaded->getResult(wordIdx),
-            LLVM::getFixedVectorType(valueElemTy, wordNElems));
-        for (size_t ii = 0; ii < wordNElems; ++ii) {
-          Value vecIdx = createIndexAttrConstant(
-              rewriter, loc, this->getTypeConverter()->getIndexType(), ii % wordNElems);
-          Value loaded = extract_element(valueElemTy, loadVal, vecIdx);
-          loadedVals.push_back(loaded);
-        }
+      Value loadVal = bitcast(loaded->getResult(0), vecTy);
+      for (size_t ii = 0; ii < vec; ++ii) {
+        Value vecIdx = createIndexAttrConstant(
+            rewriter,
+            loc,
+            this->getTypeConverter()->getIndexType(),
+            ii % vec);
+        Value loaded = extract_element(valueElemTy, loadVal, vecIdx);
+        loadedVals.push_back(loaded);
       }
 #else
       // TODO(Superjomn) Add cache policy fields to StoreOp.

--- a/test/Conversion/AMDGPU/load_store.mlir
+++ b/test/Conversion/AMDGPU/load_store.mlir
@@ -10,9 +10,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     %2 = tt.load %1 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : f16
     // GCN-NOT: llvm.bitcast {{.*}} : {{.*}}32{{.*}}16
     // GCN-NOT: llvm.bitcast {{.*}} : {{.*}}16{{.*}}32
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>
     // GCN: llvm.bitcast {{.*}} : f16 to f16
     // GCN: llvm.bitcast {{.*}} : vector<1xf16> to i16
     // GCN: llvm.store {{.*}} : !llvm.ptr<f16, 1>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -20,12 +20,12 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm
 
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast %6 : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: [[MASK:%.*]] = llvm.extractvalue %arg1[0] : !llvm.struct<(i1, i1)>
+    // GCN: scf.if [[MASK]]
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast %6 : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>
     %1 = tt.load %a_ptr_init, %cst, %cst_0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32, #blocked0>
     tt.return
   }
@@ -38,13 +38,11 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
   // CHECK-LABEL: vectorized_load
   tt.func @vectorized_load(%a_ptr_init : tensor<256x!tt.ptr<f32>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf32, #blocked0>) {
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32)>
     // PTX: llvm.inline_asm
@@ -63,30 +61,22 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
   // CHECK-LABEL: vectorized_load_f16
   tt.func @vectorized_load_f16(%a_ptr_init: tensor<256x!tt.ptr<f16>, #blocked0>, %cst : tensor<256xi1, #blocked0>, %cst_0 : tensor<256xf16, #blocked0>) {
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<i16>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i16>
-    // GCN: llvm.bitcast {{.*}} : i16 to vector<1xf16>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f16, 1> to !llvm.ptr<vector<1xf16>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf16>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
@@ -172,18 +162,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
     // PTX: mov.u32 $0, 0x0
     // PTX: @${{.*}} ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -199,18 +185,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
     // PTX: mov.u32 $0, 0x0
     // PTX: @${{.*}} ld.global.b32 { ${{.*}} }, [ ${{.*}} + 0 ];
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -256,18 +238,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from A with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -276,18 +248,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from B with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -334,9 +296,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
     %10 = arith.cmpi "slt", %4, %9 : tensor<64xi32, #blocked>
     // load op has a vector width = 1 due to the %mask's alignment
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // PTX: ld.global.b32
     %11 = tt.load %6, %10 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64xf32, #blocked>
     %12 = tt.load %8, %10 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64xf32, #blocked>
@@ -367,30 +328,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -406,30 +351,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -488,30 +417,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -527,30 +440,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<2xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<2xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -609,30 +506,10 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -646,30 +523,10 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -891,30 +748,22 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 :
     // PTX-NEXT: cp.async.ca.shared.global [ ${{.*}} + 0 ], [ ${{.*}} + 0 ], 0x8, 0x8
     // PTX-NEXT: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<1xi64>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<i64, 1> to !llvm.ptr<vector<1xi64>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xi64>>
     // GCN-COUNT-8: llvm.store {{.*}} : !llvm.ptr<vector<1xi64>, 3>
 
     %73 = triton_gpu.insert_slice_async %66, %71, %c0_i32 {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x!tt.ptr<i64, 1>, #slice1d0> -> tensor<2x64xi64, #shared>
@@ -1001,30 +850,10 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm has_side_effects asm_dialect = att
     // PTX-SAME: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<4xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
     // GCN: llvm.store {{.*}} : !llvm.ptr<vector<8xf32>, 3>
     %a = triton_gpu.insert_slice_async %a_ptr, %tensor, %index {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<16x64x!tt.ptr<f32>, #AL> -> tensor<2x16x64xf32, #A>
     triton_gpu.async_commit_group
@@ -1075,18 +904,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm
     // PTX-SAME: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN-COUNT-4: llvm.store {{.*}} : !llvm.ptr<vector<1xf32>, 3>
     %a = triton_gpu.insert_slice_async %a_ptr, %tensor, %index {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<16x32x!tt.ptr<f32>, #AL> -> tensor<2x16x32xf32, #A>
     triton_gpu.async_commit_group
@@ -1148,30 +973,22 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm
     // PTX-SAME: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<vector<1xf32>>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<vector<1xf32>>
     // GCN-COUNT-8: llvm.store {{.*}} : !llvm.ptr<vector<1xf32>, 3>
     %a = triton_gpu.insert_slice_async %a_ptr, %tensor, %index {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x32x!tt.ptr<f32>, #AL> -> tensor<2x32x32xf32, #A>
     triton_gpu.async_commit_group

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -256,9 +256,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from A with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -267,9 +276,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from B with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -349,19 +367,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -377,18 +406,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -447,18 +488,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -474,18 +527,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
-    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -544,12 +609,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -563,12 +646,30 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -900,12 +1001,31 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm has_side_effects asm_dialect = att
     // PTX-SAME: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
-    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
+    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.store {{.*}} : !llvm.ptr<vector<8xf32>, 3>
     %a = triton_gpu.insert_slice_async %a_ptr, %tensor, %index {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<16x64x!tt.ptr<f32>, #AL> -> tensor<2x16x64xf32, #A>
     triton_gpu.async_commit_group
     tt.return

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -256,18 +256,9 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from A with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -276,18 +267,9 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 :
 
     // Load 4 elements from B with single one vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32)>
@@ -367,30 +349,19 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -406,30 +377,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -488,30 +447,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -527,30 +474,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with four vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i64>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i64>
+    // GCN: llvm.bitcast {{.*}} : i64 to vector<2xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -609,30 +544,12 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from A with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -646,30 +563,12 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
 
     // Load 8 elements from B with two vectorized load instruction
     // GCN-NOT: llvm.inline_asm
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
     // GCN: llvm.insertvalue {{.*}}[0] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[1] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GCN: llvm.insertvalue {{.*}}[2] : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
@@ -1001,31 +900,12 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // PTX: llvm.inline_asm has_side_effects asm_dialect = att
     // PTX-SAME: cp.async.commit_group
 
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i32>
-    // GCN: llvm.load {{.*}} : !llvm.ptr<i32>
-    // GCN: llvm.bitcast {{.*}} : i32 to vector<1xf32>
-    // GCN: llvm.store {{.*}} : !llvm.ptr<vector<8xf32>, 3>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
+    // GCN: llvm.addrspacecast {{.*}} : !llvm.ptr<f32, 1> to !llvm.ptr<i128>
+    // GCN: llvm.load {{.*}} : !llvm.ptr<i128>
+    // GCN: llvm.bitcast {{.*}} : i128 to vector<4xf32>
     %a = triton_gpu.insert_slice_async %a_ptr, %tensor, %index {axis = 0 : i32, cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<16x64x!tt.ptr<f32>, #AL> -> tensor<2x16x64xf32, #A>
     triton_gpu.async_commit_group
     tt.return


### PR DESCRIPTION
I'm not quite sure why the existing code for load vectorization is using segmented short-vectorized loads instead of using a full 128-bit load. Using multiple copies of shorter load seems to create a dependency on the LLVM backend (esp. the load and store vectorizer) for full vectorization. This might be fragile as I saw in some cases the vector combine pass and the jump threading pass screwed it up and resulted in non-ideal vectorization.