### PR TITLE
[AMD backend] Treat metadata as a tuple instead of a dict

### DIFF
--- a/.github/workflows/amd-offline-tests.yml
+++ b/.github/workflows/amd-offline-tests.yml
@@ -111,6 +111,7 @@ jobs:
           cd $UPSTREAM_REPO_DIR/third_party
           rm -rf amd
           git clone --branch $BRANCH_NAME https://github.com/ROCmSoftwarePlatform/triton amd
+          git add .
           git log -1 --pretty=format:"%H, %an, %ad, %s"
           
           # build upstream with this branch as a backend

--- a/backend/driver.py
+++ b/backend/driver.py
@@ -245,8 +245,8 @@ class HIPLauncher(object):
     
     def __init__(self, src, metadata):
         ids = {
-            "ids_of_folded_args": metadata.get("ids_of_folded_args", tuple()), "ids_of_const_exprs":
-            src.fn.constexprs if hasattr(src, "fn") else tuple()
+            "ids_of_folded_args": metadata.ids_of_folded_args,
+            "ids_of_const_exprs": src.fn.constexprs if hasattr(src, "fn") else tuple()
         }
         constants = src.constants if hasattr(src, "constants") else dict()
         src = make_launcher(constants, src.signature, ids)


### PR DESCRIPTION
Due to recent upstream changes: https://github.com/openai/triton/pull/2929

Also after we update the amd backend in the upstream repo, we need to stage the change.