### PR TITLE
Fix vecSize for fp8 and int8 on MI300

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -156,10 +156,13 @@ compared to 1*64 when the hasLeadingOffset is false.
             //
             // maxPhase is set to SIMDWidth / perPhase
             int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
-            int maxPhase = SIMDWidth / perPhase;
+            // On MI300, fp8 nd int8 mfma is assigned to VGPRs for the operands
+            if (3 == mfmaEnc.getVersionMajor() && 8 == typeWidthInBit)
+              vecSize = 8;
+            int maxPhase = std::min(SIMDWidth / perPhase, innerDimLength / vecSize);
             // TODO (zhanglx): figure out better parameters for mfma4
-            if (mfmaEnc.getMDim() == 4 )
-               maxPhase = 4;
+            if (4 == mfmaEnc.getMDim())
+              maxPhase = 4;
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
           } else {

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -156,7 +156,7 @@ compared to 1*64 when the hasLeadingOffset is false.
             //
             // maxPhase is set to SIMDWidth / perPhase
             int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
-            // On MI300, fp8 nd int8 mfma is assigned to VGPRs for the operands
+            // On MI300, fp8 and int8 mfma is assigned to VGPRs for the operands
             if (3 == mfmaEnc.getVersionMajor() && 8 == typeWidthInBit)
               vecSize = 8;
             int maxPhase = std::min(SIMDWidth / perPhase, innerDimLength / vecSize);

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -163,6 +163,7 @@ compared to 1*64 when the hasLeadingOffset is false.
             // TODO (zhanglx): figure out better parameters for mfma4
             if (4 == mfmaEnc.getMDim())
               maxPhase = 4;
+            assert(maxPhase > 0);
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
           } else {


### PR DESCRIPTION
This PR is actually doing more than I expected
- 2% ~ 4% improvement for large gemm on MI300X when using mfma**32**
- 130% improvement for large gemm on MI300X when using mfma**16**

Therefore, using mfma16 now has better performance on MI300X