### PR TITLE
[MFMA] Support 64x4 and 4x64 tile size

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -161,8 +161,11 @@ compared to 1*64 when the hasLeadingOffset is false.
               vecSize = 8;
             int maxPhase = std::min(SIMDWidth / perPhase, innerDimLength / vecSize);
             // TODO (zhanglx): figure out better parameters for mfma4
-            if (4 == mfmaEnc.getMDim())
-              maxPhase = 4;
+            auto mDim = mfmaEnc.getMDim();
+            auto nDim = mfmaEnc.getNDim();
+            auto nonKDim = dotOpEnc.getOpIdx() == 0 ? mDim : nDim;
+            if (4 == nonKDim)
+               maxPhase = 4;
             assert(maxPhase > 0);
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -426,10 +426,11 @@ bool supportMMA(triton::DotOp op, int version) {
 #ifdef USE_ROCM
 static bool supportMFMAGranularity(int m, int n, int k) {
   // these limitations are dtype dependent, in future we may relax them
-  const static std::pair<int, int> mfmaTypes[] = {{32, 8}, {16, 16}, {4, 64}};
+  const static std::tuple<int, int, int> mfmaTypes[] = {
+      {32, 32, 8}, {16, 16, 16}, {4, 4, 64}, {64, 4, 4}, {4, 64, 4}};
   for (const auto &mfmaType : mfmaTypes) {
-    auto [granularityMN, granularityK] = mfmaType;
-    if (m % granularityMN != 0 || n % granularityMN != 0)
+    auto [granularityM, granularityN, granularityK] = mfmaType;
+    if (m % granularityM != 0 || n % granularityN != 0)
       continue;
     if (k % granularityK != 0)
       continue;

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -132,6 +132,7 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
  * @param smemStrides strides in LDS tensor
  * @param loadVecSize number of elements loaded by one operation
  * @param iNonKDim non-K dimension of dot operand
+ * @param iKDim non-K dimension of dot operand
  * @return vector (i-th element corresponds to i-th load instruction) of
  * 2-element vectors(tensor row and col).
  */
@@ -140,7 +141,7 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                          Value laneId, int warpsPerGroup, int numOfElems,
                          ArrayRef<int64_t> reps, ArrayRef<Value> smemOffsets,
-                         int loadVecSize, unsigned iNonKDim) {
+                         int loadVecSize, unsigned iNonKDim, unsigned iKDim) {
   auto numM = reps[0];
   auto numK = reps[1];
   const int loadsPerThread = numOfElems / loadVecSize;
@@ -159,8 +160,16 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
     Value laneHOffset;
     if (iNonKDim == 32)
       laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
-    else
-      laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
+    else {
+      // In this configuration wave contains 16 copies of same data
+      if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4) {
+        laneHOffset = i32_val(0);
+      } else {
+        assert(iKDim * iNonKDim / numOfElems == 64 &&
+               "seems no all threads in wave contain unique elements");
+        laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
+      }
+    }
 
     for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
       Value elemVOffset = _0;
@@ -197,7 +206,8 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   SmallVector<Value> strides{smemObj.strides[0], smemObj.strides[1]};
   SmallVector<Value> offsets{smemObj.offsets[0], smemObj.offsets[1]};
 
@@ -209,9 +219,9 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          reps, offsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, elemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      reps, offsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> aOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     Value row = mapping[i][0];
@@ -226,7 +236,8 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   // transpose reps and offsets, because operand B has layout equal to
   // transposed operand A layout
   SmallVector<int64_t> tElemsPerInstr{elemsPerInstr[1], elemsPerInstr[0]};
@@ -241,9 +252,9 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          tReps, toffsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, tElemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      tReps, toffsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> bOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     // swap row and col, because operand B layout is a transposed operand A
@@ -333,7 +344,8 @@ bool fastPathAvailable(const SharedMemoryObject &smemObj,
 // Computes offsets for operand B or transposed operand A
 // @param rewriter
 // @param loc
-// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
+// @param elemsPerInstr operand tile shape [K, nonK] consumed by one MFMA
+// instruction
 // @param waveId wave id for the "non K" axis
 // @param laneId lane id in warp [0..63]
 // @param warpsPerGroup number of warps per horizontal axis
@@ -349,18 +361,36 @@ fastPathComputeOffsets(ConversionPatternRewriter &rewriter, Location loc,
   auto numN = reps[1];
   SmallVector<Value> offsets(numK * numN * numOfElems);
 
-  int lineSize = warpsPerGroup * elemsPerInstr[1] * numN;
-  Value _nonKDim = i32_val(elemsPerInstr[1]);
-  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[1]));
+  auto iKDim = elemsPerInstr[0];
+  auto iNonKDim = elemsPerInstr[1];
+  int lineSize = warpsPerGroup * iNonKDim * numN;
+  Value _nonKDim = i32_val(iNonKDim);
+  Value waveOffset = mul(waveId, i32_val(iNonKDim));
   Value colOffset = urem(laneId, _nonKDim);
 
   for (int block = 0; block < numN; ++block) {
-    Value blockOffset = i32_val(block * elemsPerInstr[1] * warpsPerGroup);
+    Value blockOffset = i32_val(block * iNonKDim * warpsPerGroup);
     for (int tile = 0; tile < numK; ++tile) {
-      Value tileOffset = i32_val(tile * elemsPerInstr[0] * lineSize);
+      Value tileOffset = i32_val(tile * iKDim * lineSize);
       for (int elem = 0; elem < numOfElems; ++elem) {
-        Value halfOffset =
-            mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
+        // halfOffset is an offset related to wrapping of wave in the tile.
+        // for example, mfma 32 case (mapping of tensor elements to lane ids in
+        // wave):
+        //
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        // 32 33 34 35 ... 63  <- at this point wave is wrapping
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        Value halfOffset;
+        if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4)
+          halfOffset = i32_val(0);
+        else
+          halfOffset =
+              mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
         Value rowOffset = add(i32_val(elem * lineSize), halfOffset);
         Value elemOffset = add(rowOffset, colOffset);
         Value offset =
@@ -395,8 +425,10 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   int nonKDimIdx = opIdx == 0 ? 0 : 1;
 
   auto mfmaLayout = encoding.getParent().cast<MfmaEncodingAttr>();
-  int nonKDim = mfmaLayout.getMDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
 
   auto aTensorTy = tensor.getType().cast<RankedTensorType>();
@@ -422,7 +454,12 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value spatialWaveId =
       getWaveIdInBlock(rewriter, loc, linearWaveId, warpsPerCTA, mfmaInstrNonK,
                        shape[nonKDimIdx], nonKDimIdx);
-  int numOfElems = mfmaInstrNonK * mfmaInstrK / iWaveSize;
+  // number of duplicates of elements in wave
+  // In case of 64x4 x 4x4 multiplication, 4x4 B operand is duplicated 16 times
+  int numSubBlocks = 1;
+  if ((mfmaInstrK == 4 || mfmaInstrK == 1) && mfmaInstrNonK == 4)
+    numSubBlocks = 16;
+  int numOfElems = mfmaInstrNonK * mfmaInstrK * numSubBlocks / iWaveSize;
   assert(numOfElems >= 1);
 
   unsigned int maxNumWarps = shape[nonKDimIdx] / mfmaInstrNonK;
@@ -465,14 +502,14 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
     // Normal path handles tensors that are k-major, in which case swizzling
     // is enabled and it requires a 2-step method to compute the offsets.
     if (opIdx == 0) {
-      offsets = computeOffsetsAType(rewriter, loc, elemsPerInstr, spatialWaveId,
-                                    lane, warpsPerGroupNonK, numOfElems,
-                                    numReps, smemObj, sharedLayout, nonKDim);
+      offsets = computeOffsetsAType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, mDim, mfmaInstrK);
     } else {
       assert(opIdx == 1);
-      offsets = computeOffsetsBType(rewriter, loc, elemsPerInstr, spatialWaveId,
-                                    lane, warpsPerGroupNonK, numOfElems,
-                                    numReps, smemObj, sharedLayout, nonKDim);
+      offsets = computeOffsetsBType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, nDim, mfmaInstrK);
     }
     smemBase = computeBasePtr(rewriter, loc, smemObj);
   }
@@ -485,8 +522,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   assert(numOfElems % loadsPerThread == 0);
 
   for (int nonK = 0; nonK < numRepNonK; ++nonK) {
-    Value blockVOffset = i32_val(nonK * mfmaInstrNonK * warpsPerGroupNonK);
-    Value offAdjust = mul(blockVOffset, i32_val(shape[order[0]]));
+    int blockNonKOffset = nonK * mfmaInstrNonK * warpsPerGroupNonK;
+    Value offAdjust = i32_val(blockNonKOffset * shape[order[0]]);
     for (int k = 0; k < numRepK; ++k) {
       auto vecTy = vec_ty(resElemTy, numOfElems);
       Value valVec = undef(vecTy);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -103,14 +103,28 @@ SmallVector<unsigned> getThreadsPerWarp(Attribute layout) {
       return {8, 4};
   }
   if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    unsigned rows, cols;
-    int mfmaMDim = mfmaLayout.getMDim();
-    if (32 == mfmaMDim) {
-      cols = 2;
-      rows = 32;
+    unsigned rows = -1, cols = -1;
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    if (mDim == nDim) {
+      if (mDim == 32) {
+        cols = 2;
+        rows = 32;
+      } else if (mDim == 16) {
+        cols = 4;
+        rows = 16;
+      } else if (mDim == 4) {
+        cols = 4;
+        rows = 16;
+      }
     } else {
-      cols = 4;
-      rows = 16;
+      if (mDim == 64 && nDim == 4) {
+        cols = 16;
+        rows = 4;
+      } else if (mDim == 4 && nDim == 64) {
+        cols = 4;
+        rows = 16;
+      }
     }
 
     if (mfmaLayout.getIsTransposed()) {
@@ -241,7 +255,11 @@ SmallVector<unsigned> getSizePerThread(Attribute layout) {
     }
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
     unsigned rows, cols;
-    switch (mfmaLayout.getMDim()) {
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+           (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+    switch (std::min(mDim, nDim)) {
     case 32:
       rows = 16;
       cols = 1;
@@ -350,9 +368,11 @@ SmallVector<unsigned> getThreadsPerCTA(Attribute layout) {
     } else
       llvm::report_fatal_error("Unimplemented usage of MmaEncodingAttr");
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    int mfmaMDim = mfmaLayout.getMDim();
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    assert(mDim == nDim);
     SmallVector<unsigned> threadsPerWarp;
-    if (32 == mfmaMDim) {
+    if (32 == mDim) {
       threadsPerWarp = {2, 32};
     } else {
       threadsPerWarp = {4, 16};
@@ -400,10 +420,10 @@ SmallVector<unsigned> getShapePerCTATile(Attribute layout,
     }
     llvm::report_fatal_error("Unexpected MMA layout version found");
   } else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>()) {
-    auto mfmaMDim = mfmaLayout.getMDim();
-    auto mfmaNDim = mfmaLayout.getNDim();
-    return {mfmaMDim * mfmaLayout.getWarpsPerCTA()[0],
-            mfmaNDim * mfmaLayout.getWarpsPerCTA()[1]};
+    unsigned mDim = mfmaLayout.getMDim();
+    unsigned nDim = mfmaLayout.getNDim();
+    return {mDim * mfmaLayout.getWarpsPerCTA()[0],
+            nDim * mfmaLayout.getWarpsPerCTA()[1]};
   } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
     auto parentLayout = dotLayout.getParent();
     assert(parentLayout && "DotOperandEncodingAttr must have a parent");
@@ -727,15 +747,17 @@ bool sameBlockedEncodings(BlockedEncodingAttr blockedA,
 }
 
 bool sameMfmaEncodings(MfmaEncodingAttr mfmaA, MfmaEncodingAttr mfmaB) {
-  auto nonKDimA = mfmaA.getMDim();
+  auto mDimA = mfmaA.getMDim();
+  auto nDimA = mfmaA.getNDim();
   auto warpsPerCTAA = mfmaA.getWarpsPerCTA();
   auto isTransposedA = mfmaA.getIsTransposed();
 
-  auto nonKDimB = mfmaB.getMDim();
+  auto mDimB = mfmaB.getMDim();
+  auto nDimB = mfmaB.getNDim();
   auto warpsPerCTAB = mfmaB.getWarpsPerCTA();
   auto isTransposedB = mfmaB.getIsTransposed();
 
-  if (nonKDimA != nonKDimB || isTransposedA != isTransposedB) {
+  if (mDimA != mDimB || nDimA != nDimB || isTransposedA != isTransposedB) {
     return false;
   }
 
@@ -920,28 +942,20 @@ MfmaEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
   size_t rank = shape.size();
   assert(rank == 2 && "Unexpected rank of mfma layout");
 
-  SmallVector<unsigned> elemsPerThread(rank);
   auto mfmaMDim = getMDim();
   auto mfmaNDim = getNDim();
   auto elemsPerThreadPerTile = (mfmaMDim == 32 ? 16 : 4);
+  unsigned elemsCol = 0, elemsRow = 0;
   if (getIsTransposed()) {
-    unsigned elemsCol =
-        ceil<unsigned>(shape[1], mfmaNDim * getWarpsPerCTA()[1]) *
-        elemsPerThreadPerTile;
-    unsigned elemsRow =
-        ceil<unsigned>(shape[0], mfmaMDim * getWarpsPerCTA()[0]);
-    elemsPerThread[0] = elemsRow;
-    elemsPerThread[1] = elemsCol;
+    elemsCol = ceil<unsigned>(shape[1], mfmaNDim * getWarpsPerCTA()[1]) *
+               elemsPerThreadPerTile;
+    elemsRow = ceil<unsigned>(shape[0], mfmaMDim * getWarpsPerCTA()[0]);
   } else {
-    unsigned elemsCol =
-        ceil<unsigned>(shape[1], mfmaNDim * getWarpsPerCTA()[1]);
-    unsigned elemsRow =
-        ceil<unsigned>(shape[0], mfmaMDim * getWarpsPerCTA()[0]) *
-        elemsPerThreadPerTile;
-    elemsPerThread[0] = elemsRow;
-    elemsPerThread[1] = elemsCol;
+    elemsCol = ceil<unsigned>(shape[1], mfmaNDim * getWarpsPerCTA()[1]);
+    elemsRow = ceil<unsigned>(shape[0], mfmaMDim * getWarpsPerCTA()[0]) *
+               elemsPerThreadPerTile;
   }
-  return elemsPerThread;
+  return {elemsRow, elemsCol};
 }
 
 SmallVector<unsigned>
@@ -1063,17 +1077,23 @@ DotOperandEncodingAttr::getMMAv2Rep(ArrayRef<int64_t> shape,
 
 SmallVector<int64_t>
 DotOperandEncodingAttr::getMFMAElemsPerInstr() const {
-  auto mfmaEncoding = getParent().cast<MfmaEncodingAttr>();
-  int64_t nonKDim = mfmaEncoding.getMDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
+  auto mfmaLayout = getParent().cast<MfmaEncodingAttr>();
+  unsigned mDim = mfmaLayout.getMDim();
+  unsigned nDim = mfmaLayout.getNDim();
+  assert((mDim == nDim) && (mDim == 32 || mDim == 16 || mDim == 4) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   int64_t kWidth = getKWidth();
   constexpr int waveSize = 64; // MFMA is used on wave64 architectures only
-  int kGroups = waveSize / nonKDim;
+  int kGroups = -1;
+  if (mDim == nDim)
+    kGroups = waveSize / mDim;
+  if (mDim == 64 && nDim == 4 || mDim == 4 && nDim == 64)
+    kGroups = 1;
   int64_t kDim = kWidth * kGroups;
   if (getOpIdx() == 0)
-    return {nonKDim, kDim};
+    return {mDim, kDim};
   else
-    return {kDim, nonKDim};
+    return {kDim, nDim};
 }
 
 SmallVector<int64_t>

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -671,131 +671,180 @@ auto getMfmaInsnGroupAttrMap = []() -> const MfmaInsnGroupMap & {
   static MfmaInsnGroupMap MfmaInsnMap{
       // f32
       // mfma_f32_32x32x2f32
-      {{32, MfmaTypeId::Fp32TyId, 1},
+      {{32, 32, MfmaTypeId::Fp32TyId, 1},
        {32, 32, 2, 1, ROCDL::mfma_f32_32x32x2f32::getOperationName()}},
-      {{32, MfmaTypeId::Fp32TyId, 2},
+      {{32, 32, MfmaTypeId::Fp32TyId, 2},
        {32, 32, 2, 1, ROCDL::mfma_f32_32x32x2f32::getOperationName()}},
-      {{32, MfmaTypeId::Fp32TyId, 3},
+      {{32, 32, MfmaTypeId::Fp32TyId, 3},
        {32, 32, 2, 1, ROCDL::mfma_f32_32x32x2f32::getOperationName()}},
       // mfma_f32_16x16x4f32
-      {{16, MfmaTypeId::Fp32TyId, 1},
+      {{16, 16, MfmaTypeId::Fp32TyId, 1},
        {16, 16, 4, 1, ROCDL::mfma_f32_16x16x4f32::getOperationName()}},
-      {{16, MfmaTypeId::Fp32TyId, 2},
+      {{16, 16, MfmaTypeId::Fp32TyId, 2},
        {16, 16, 4, 1, ROCDL::mfma_f32_16x16x4f32::getOperationName()}},
-      {{16, MfmaTypeId::Fp32TyId, 3},
+      {{16, 16, MfmaTypeId::Fp32TyId, 3},
        {16, 16, 4, 1, ROCDL::mfma_f32_16x16x4f32::getOperationName()}},
       // mfma_f32_4x4x1f32
-      {{4, MfmaTypeId::Fp32TyId, 1},
+      {{4, 4, MfmaTypeId::Fp32TyId, 1},
        {4, 4, 16, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
-      {{4, MfmaTypeId::Fp32TyId, 2},
+      {{4, 4, MfmaTypeId::Fp32TyId, 2},
        {4, 4, 16, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp32TyId, 1},
+       {4, 64, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp32TyId, 2},
+       {4, 64, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp32TyId, 1},
+       {64, 4, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp32TyId, 2},
+       {64, 4, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
       // mfma_f32_4x4x1_16B_f32
-      {{4, MfmaTypeId::Fp32TyId, 3},
+      {{4, 4, MfmaTypeId::Fp32TyId, 3},
        {4, 4, 16, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp32TyId, 3},
+       {4, 64, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp32TyId, 3},
+       {64, 4, 1, 1, ROCDL::mfma_f32_4x4x1f32::getOperationName()}},
       // f16
       // mfma_f32_32x32x8f16
-      {{32, MfmaTypeId::Fp16TyId, 1},
+      {{32, 32, MfmaTypeId::Fp16TyId, 1},
        {32, 32, 8, 4, ROCDL::mfma_f32_32x32x8f16::getOperationName()}},
-      {{32, MfmaTypeId::Fp16TyId, 2},
+      {{32, 32, MfmaTypeId::Fp16TyId, 2},
        {32, 32, 8, 4, ROCDL::mfma_f32_32x32x8f16::getOperationName()}},
-      {{32, MfmaTypeId::Fp16TyId, 3},
+      {{32, 32, MfmaTypeId::Fp16TyId, 3},
        {32, 32, 8, 4, ROCDL::mfma_f32_32x32x8f16::getOperationName()}},
       // mfma_f32_16x16x16xf16
-      {{16, MfmaTypeId::Fp16TyId, 1},
+      {{16, 16, MfmaTypeId::Fp16TyId, 1},
        {16, 16, 16, 4, ROCDL::mfma_f32_16x16x16f16::getOperationName()}},
-      {{16, MfmaTypeId::Fp16TyId, 2},
+      {{16, 16, MfmaTypeId::Fp16TyId, 2},
        {16, 16, 16, 4, ROCDL::mfma_f32_16x16x16f16::getOperationName()}},
-      {{16, MfmaTypeId::Fp16TyId, 3},
+      {{16, 16, MfmaTypeId::Fp16TyId, 3},
        {16, 16, 16, 4, ROCDL::mfma_f32_16x16x16f16::getOperationName()}},
       // mfma_f32_4x4x4f16
-      {{4, MfmaTypeId::Fp16TyId, 1},
+      {{4, 4, MfmaTypeId::Fp16TyId, 1},
        {4, 4, 64, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
-      {{4, MfmaTypeId::Fp16TyId, 2},
+      {{4, 4, MfmaTypeId::Fp16TyId, 2},
        {4, 4, 64, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
-      {{4, MfmaTypeId::Fp16TyId, 3},
+      {{4, 4, MfmaTypeId::Fp16TyId, 3},
        {4, 4, 64, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp16TyId, 1},
+       {4, 64, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp16TyId, 2},
+       {4, 64, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{4, 64, MfmaTypeId::Fp16TyId, 3},
+       {4, 64, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp16TyId, 1},
+       {64, 4, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp16TyId, 2},
+       {64, 4, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
+      {{64, 4, MfmaTypeId::Fp16TyId, 3},
+       {64, 4, 4, 4, ROCDL::mfma_f32_4x4x4f16::getOperationName()}},
       // bf16
       // mfma_f32_32x32x4_bf16
-      {{32, MfmaTypeId::Bf16TyId, 1},
+      {{32, 32, MfmaTypeId::Bf16TyId, 1},
        {32, 32, 4, 2, ROCDL::mfma_f32_32x32x4bf16::getOperationName()}},
       // mfma_f32_32x32x8_bf16_1K
-      {{32, MfmaTypeId::Bf16TyId, 2},
+      {{32, 32, MfmaTypeId::Bf16TyId, 2},
        {32, 32, 8, 4, ROCDL::mfma_f32_32x32x8bf16_1k::getOperationName()}},
-      {{32, MfmaTypeId::Bf16TyId, 3},
+      {{32, 32, MfmaTypeId::Bf16TyId, 3},
        {32, 32, 8, 4, ROCDL::mfma_f32_32x32x8bf16_1k::getOperationName()}},
       // mfma_f32_16x16x8_bf16
-      {{16, MfmaTypeId::Bf16TyId, 1},
+      {{16, 16, MfmaTypeId::Bf16TyId, 1},
        {16, 16, 8, 2, ROCDL::mfma_f32_16x16x8bf16::getOperationName()}},
       // mfma_f32_16x16x16_bf16_1K
-      {{16, MfmaTypeId::Bf16TyId, 2},
+      {{16, 16, MfmaTypeId::Bf16TyId, 2},
        {16, 16, 16, 4, ROCDL::mfma_f32_16x16x16bf16_1k::getOperationName()}},
-      {{16, MfmaTypeId::Bf16TyId, 3},
+      {{16, 16, MfmaTypeId::Bf16TyId, 3},
        {16, 16, 16, 4, ROCDL::mfma_f32_16x16x16bf16_1k::getOperationName()}},
       // mfma_f32_4x4x2_bf16
-      {{4, MfmaTypeId::Bf16TyId, 1},
+      {{4, 4, MfmaTypeId::Bf16TyId, 1},
        {4, 4, 32, 2, ROCDL::mfma_f32_4x4x2bf16::getOperationName()}},
+      {{4, 64, MfmaTypeId::Bf16TyId, 1},
+       {4, 64, 2, 2, ROCDL::mfma_f32_4x4x2bf16::getOperationName()}},
+      {{64, 4, MfmaTypeId::Bf16TyId, 1},
+       {64, 4, 2, 2, ROCDL::mfma_f32_4x4x2bf16::getOperationName()}},
       // mfma_f32_4x4x4_bf16_1K
-      {{4, MfmaTypeId::Bf16TyId, 2},
+      {{4, 4, MfmaTypeId::Bf16TyId, 2},
        {4, 4, 64, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
-      {{4, MfmaTypeId::Bf16TyId, 3},
+      {{4, 4, MfmaTypeId::Bf16TyId, 3},
        {4, 4, 64, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
+      {{4, 64, MfmaTypeId::Bf16TyId, 2},
+       {4, 64, 4, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
+      {{4, 64, MfmaTypeId::Bf16TyId, 3},
+       {4, 64, 4, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
+      {{64, 4, MfmaTypeId::Bf16TyId, 2},
+       {64, 4, 4, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
+      {{64, 4, MfmaTypeId::Bf16TyId, 3},
+       {64, 4, 4, 4, ROCDL::mfma_f32_4x4x4bf16_1k::getOperationName()}},
       // int8
-      // mfma_f32_32x32x8i8
-      {{32, MfmaTypeId::I8TyId, 1},
+      // mfma_i32_32x32x8i8
+      {{32, 32, MfmaTypeId::I8TyId, 1},
        {32, 32, 8, 4, ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
-      {{32, MfmaTypeId::I8TyId, 2},
+      {{32, 32, MfmaTypeId::I8TyId, 2},
        {32, 32, 8, 4, ROCDL::mfma_i32_32x32x8i8::getOperationName()}},
-      // mfma_f32_32x32x16i8
-      {{32, MfmaTypeId::I8TyId, 3},
+      // mfma_i32_32x32x16i8
+      {{32, 32, MfmaTypeId::I8TyId, 3},
        {32, 32, 16, 8, ROCDL::mfma_i32_32x32x16_i8::getOperationName()}},
-      // mfma_f32_16x16x16i8
-      {{16, MfmaTypeId::I8TyId, 1},
+      // mfma_i32_16x16x16i8
+      {{16, 16, MfmaTypeId::I8TyId, 1},
        {16, 16, 16, 4, ROCDL::mfma_i32_16x16x16i8::getOperationName()}},
-      {{16, MfmaTypeId::I8TyId, 2},
+      {{16, 16, MfmaTypeId::I8TyId, 2},
        {16, 16, 16, 4, ROCDL::mfma_i32_16x16x16i8::getOperationName()}},
-      // mfma_f32_16x16x32i8
-      {{16, MfmaTypeId::I8TyId, 3},
+      // mfma_i32_16x16x32i8
+      {{16, 16, MfmaTypeId::I8TyId, 3},
        {16, 16, 32, 8, ROCDL::mfma_i32_16x16x32_i8::getOperationName()}},
-      // mfma_f32_4x4x4i8
-      {{4, MfmaTypeId::I8TyId, 1},
+      // mfma_i32_4x4x4i8
+      {{4, 4, MfmaTypeId::I8TyId, 1},
        {4, 4, 64, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
-      {{4, MfmaTypeId::I8TyId, 2},
+      {{4, 4, MfmaTypeId::I8TyId, 2},
        {4, 4, 64, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
-      {{4, MfmaTypeId::I8TyId, 3},
+      {{4, 4, MfmaTypeId::I8TyId, 3},
        {4, 4, 64, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{4, 64, MfmaTypeId::I8TyId, 1},
+       {4, 64, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{4, 64, MfmaTypeId::I8TyId, 2},
+       {4, 64, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{4, 64, MfmaTypeId::I8TyId, 3},
+       {4, 64, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{64, 4, MfmaTypeId::I8TyId, 1},
+       {64, 4, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{64, 4, MfmaTypeId::I8TyId, 2},
+       {64, 4, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
+      {{64, 4, MfmaTypeId::I8TyId, 3},
+       {64, 4, 4, 4, ROCDL::mfma_i32_4x4x4i8::getOperationName()}},
       // fp8 * pf8
       // mfma_f32_32x32x16_FP8_FP8
-      {{32, MfmaTypeId::Fp8Fp8TyId, 3},
+      {{32, 32, MfmaTypeId::Fp8Fp8TyId, 3},
        {32, 32, 16, 8, ROCDL::mfma_f32_32x32x16_fp8_fp8::getOperationName()}},
       // mfma_f32_16x16x32_FP8_FP8
-      {{16, MfmaTypeId::Fp8Fp8TyId, 3},
+      {{16, 16, MfmaTypeId::Fp8Fp8TyId, 3},
        {16, 16, 32, 8, ROCDL::mfma_f32_16x16x32_fp8_fp8::getOperationName()}},
       // mfma_f32_32x32x16_FP8_BF8
-      {{32, MfmaTypeId::Fp8Bf8TyId, 3},
+      {{32, 32, MfmaTypeId::Fp8Bf8TyId, 3},
        {32, 32, 16, 8, ROCDL::mfma_f32_32x32x16_fp8_bf8::getOperationName()}},
       // mfma_f32_16x16x32_FP8_BF8
-      {{16, MfmaTypeId::Fp8Bf8TyId, 3},
+      {{16, 16, MfmaTypeId::Fp8Bf8TyId, 3},
        {16, 16, 32, 8, ROCDL::mfma_f32_16x16x32_fp8_bf8::getOperationName()}},
       // mfma_f32_32x32x16_BF8_FP8
-      {{32, MfmaTypeId::Bf8Fp8TyId, 3},
+      {{32, 32, MfmaTypeId::Bf8Fp8TyId, 3},
        {32, 32, 16, 8, ROCDL::mfma_f32_32x32x16_bf8_fp8::getOperationName()}},
       // mfma_f32_16x16x32_BF8_FP8
-      {{16, MfmaTypeId::Bf8Fp8TyId, 3},
+      {{16, 16, MfmaTypeId::Bf8Fp8TyId, 3},
        {16, 16, 32, 8, ROCDL::mfma_f32_16x16x32_bf8_fp8::getOperationName()}},
       // mfma_f32_32x32x16_BF8_BF8
-      {{32, MfmaTypeId::Bf8Bf8TyId, 3},
+      {{32, 32, MfmaTypeId::Bf8Bf8TyId, 3},
        {32, 32, 16, 8, ROCDL::mfma_f32_32x32x16_bf8_bf8::getOperationName()}},
       // mfma_f32_16x16x32_BF8_BF8
-      {{16, MfmaTypeId::Bf8Bf8TyId, 3},
+      {{16, 16, MfmaTypeId::Bf8Bf8TyId, 3},
        {16, 16, 32, 8, ROCDL::mfma_f32_16x16x32_bf8_bf8::getOperationName()}}};
   return MfmaInsnMap;
 };
 
-FailureOr<MfmaInsn> MfmaInsn::selectMfma(unsigned nonKDim, Type elementTypeA,
-                                         Type elementTypeB, int mfmaVersion) {
+FailureOr<MfmaInsn> MfmaInsn::selectMfma(unsigned mDim, unsigned nDim,
+                                         Type elementTypeA, Type elementTypeB,
+                                         int mfmaVersion) {
   auto mfmaInsnAttrMap = getMfmaInsnGroupAttrMap();
   MfmaInsnGroupSelectKey key = {
-      nonKDim, convertTypesToId(elementTypeA, elementTypeB), mfmaVersion};
+      mDim, nDim, convertTypesToId(elementTypeA, elementTypeB), mfmaVersion};
   auto it = mfmaInsnAttrMap.find(key);
   if (it == mfmaInsnAttrMap.end())
     return failure();

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1190,10 +1190,10 @@ def is_hip():
 
 def mfma_supported_granularity(m, n, k) -> bool:
     # todo make this gran_type matrix element type sensitive
-    for gran_type in [(32, 8), (16, 16), (4, 64)]:
-        granularity_mn, granularity_k = gran_type
+    for gran_type in [(32, 32, 8), (16, 16, 16), (4, 4, 64), (64, 4, 4), (4, 64, 4)]:
+        granularity_m, granularity_n, granularity_k = gran_type
 
-        if m % granularity_mn != 0 or n % granularity_mn != 0:
+        if m % granularity_m != 0 or n % granularity_n != 0:
             continue
         if k % granularity_k != 0:
             continue

--- a/test/TritonGPU/accelerate-matmul-cdna1.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna1.mlir
@@ -1,0 +1,800 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx908 --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 2}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 2}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 1.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+

--- a/test/TritonGPU/accelerate-matmul-cdna2.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna2.mlir
@@ -1,0 +1,800 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx90a --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 2.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+

--- a/test/TritonGPU/accelerate-matmul-cdna3.mlir
+++ b/test/TritonGPU/accelerate-matmul-cdna3.mlir
@@ -1,0 +1,816 @@
+// RUN: (! triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul=arch-generation-name=gfx940 --mlir-pass-pipeline-crash-reproducer=%t 2>/dev/null) | FileCheck --check-prefixes=CHECK %s
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f16_f16_f32
+    tt.func @convert_dot_32_32_32_f16_f16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_bf16_bf16_f32
+    tt.func @convert_dot_32_32_32_bf16_bf16_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f32_f32_f32
+    tt.func @convert_dot_32_32_32_f32_f32_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_i8_i8_i32
+    tt.func @convert_dot_32_32_32_i8_i8_i32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+// CHECK: convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_32_32_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<32x32x!a_ty, #dot_operand_a>, %b: tensor<32x32x!b_ty, #dot_operand_b>) -> tensor<32x32x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<32x32x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<32x32x!a_ty, #dot_operand_a> * tensor<32x32x!b_ty, #dot_operand_b> -> tensor<32x32x!c_ty, #blocked>
+        tt.return %D: tensor<32x32x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f16_f16_f32
+    tt.func @convert_dot_16_16_32_f16_f16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_bf16_bf16_f32
+    tt.func @convert_dot_16_16_32_bf16_bf16_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f32_f32_f32
+    tt.func @convert_dot_16_16_32_f32_f32_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_i8_i8_i32
+    tt.func @convert_dot_16_16_32_i8_i8_i32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = false}>
+// CHECK: convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_16_16_32_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<16x32x!a_ty, #dot_operand_a>, %b: tensor<32x16x!b_ty, #dot_operand_b>) -> tensor<16x16x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<16x16x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 8}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 8}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<16x32x!a_ty, #dot_operand_a> * tensor<32x16x!b_ty, #dot_operand_b> -> tensor<16x16x!c_ty, #blocked>
+        tt.return %D: tensor<16x16x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f16_f16_f32
+    tt.func @convert_dot_4_4_64_f16_f16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_bf16_bf16_f32
+    tt.func @convert_dot_4_4_64_bf16_bf16_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_f32_f32_f32
+    tt.func @convert_dot_4_4_64_f32_f32_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 4], isTransposed = false}>
+// CHECK: convert_dot_4_4_64_i8_i8_i32
+    tt.func @convert_dot_4_4_64_i8_i8_i32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_4_64_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x64x!a_ty, #dot_operand_a>, %b: tensor<64x4x!b_ty, #dot_operand_b>) -> tensor<4x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x64x!a_ty, #dot_operand_a> * tensor<64x4x!b_ty, #dot_operand_b> -> tensor<4x4x!c_ty, #blocked>
+        tt.return %D: tensor<4x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f16_f16_f32
+    tt.func @convert_dot_64_4_4_f16_f16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_bf16_bf16_f32
+    tt.func @convert_dot_64_4_4_bf16_bf16_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_f32_f32_f32
+    tt.func @convert_dot_64_4_4_f32_f32_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [64, 4], isTransposed = false}>
+// CHECK: convert_dot_64_4_4_i8_i8_i32
+    tt.func @convert_dot_64_4_4_i8_i8_i32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<64x4x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_64_4_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<64x4x!a_ty, #dot_operand_a>, %b: tensor<4x4x!b_ty, #dot_operand_b>) -> tensor<64x4x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<64x4x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<64x4x!a_ty, #dot_operand_a> * tensor<4x4x!b_ty, #dot_operand_b> -> tensor<64x4x!c_ty, #blocked>
+        tt.return %D: tensor<64x4x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f16
+!b_ty = f16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f16_f16_f32
+    tt.func @convert_dot_4_64_4_f16_f16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = bf16
+!b_ty = bf16
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_bf16_bf16_f32
+    tt.func @convert_dot_4_64_4_bf16_bf16_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f32
+!b_ty = f32
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_f32_f32_f32
+    tt.func @convert_dot_4_64_4_f32_f32_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 1}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 1}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = i8
+!b_ty = i8
+!c_ty = i32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+// CHECK: #mfma = #triton_gpu.mfma<{version = 3.0, warpsPerCTA = [1, 1], instrShape = [4, 64], isTransposed = false}>
+// CHECK: convert_dot_4_64_4_i8_i8_i32
+    tt.func @convert_dot_4_64_4_i8_i8_i32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0> : tensor<4x64x!c_ty, #blocked>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #blocked>) -> tensor<{{.*}}, #mfma>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 0, parent = #mfma, kWidth = 4}>>
+// CHECK: triton_gpu.convert_layout {{.*}} : (tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<{{.*}}, #triton_gpu.dot_op<{opIdx = 1, parent = #mfma, kWidth = 4}>>
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E4M3FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E4M3FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E4M3FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E4M3FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+
+// -----
+
+!a_ty = f8E5M2FNUZ
+!b_ty = f8E5M2FNUZ
+!c_ty = f32
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+
+// CHECK-NOT: convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32
+    tt.func @convert_dot_4_64_4_f8E5M2FNUZ_f8E5M2FNUZ_f32(%a: tensor<4x4x!a_ty, #dot_operand_a>, %b: tensor<4x64x!b_ty, #dot_operand_b>) -> tensor<4x64x!c_ty, #blocked> {
+        %cst_c = arith.constant dense<0.000000e+00> : tensor<4x64x!c_ty, #blocked>
+
+        %D = tt.dot %a, %b, %cst_c {allowTF32 = true, maxNumImpreciseAcc = 0 : i32, transA = false, transB = false} : tensor<4x4x!a_ty, #dot_operand_a> * tensor<4x64x!b_ty, #dot_operand_b> -> tensor<4x64x!c_ty, #blocked>
+        tt.return %D: tensor<4x64x!c_ty, #blocked>
+    }
+}
+


### PR DESCRIPTION
This PR enables two new MxN tile sizes: 64 x 4 and 4 x 64. Both of them uses mfma 4x4 instructions.