### PR TITLE
refine tolerance in checking GEMM correctness

### DIFF
--- a/python/perf-kernels/03-matrix-multiplication-all-types.py
+++ b/python/perf-kernels/03-matrix-multiplication-all-types.py
@@ -245,13 +245,13 @@ def test_correctness(M, N, K, col_a, col_b, in_dtype, out_dtype):
         torch_output = torch.matmul(a_fp16, b_fp16)
     else:
         torch_output = torch.matmul(a, b)
-    #print(f"triton_output={c}")
-    #print(f"torch_output={torch_output}")
+    # print(f"triton_output={c}")
+    # print(f"torch_output={torch_output}")
     rtol = 0 if torch.version.hip is None else 1e-2
     if in_dtype == 'int8':
-        torch.testing.assert_close(c.to(torch.float16), torch_output, atol=5e-2, rtol=rtol)
+        torch.testing.assert_close(c.to(torch.float16), torch_output, atol=1e-3, rtol=rtol)
     else:
-        torch.testing.assert_close(c, torch_output.to(torch_out_dtype), atol=5e-2, rtol=rtol)
+        torch.testing.assert_close(c, torch_output.to(torch_out_dtype), atol=5e-3, rtol=rtol)
 
 
 # %%

--- a/python/perf-kernels/03-matrix-multiplication-all-types.py
+++ b/python/perf-kernels/03-matrix-multiplication-all-types.py
@@ -187,6 +187,11 @@ def gen_input(M, N, ty_name, needTrans, seed, device='cuda'):
         raw_data = torch.randn((N, M), dtype=torch.float32, device='cuda').T
     else:
         raw_data = torch.randn((M, N), dtype=torch.float32, device='cuda')
+    # avoid type conversion rounding errors of subnormal values
+    raw_data += 0.1
+    if d_type == tl.float8e4b8:
+        raw_data += torch.sign(raw_data)
+
     if (d_type == tl.float8e4b8 and TORCH_HAS_FP8E4B8) or \
         (d_type == tl.float8e5b16 and TORCH_HAS_FP8E5B16) or not d_type.is_fp8():
         input = raw_data.to(tl_to_torch_types[d_type])

--- a/python/perf-kernels/03-matrix-multiplication-all-types.py
+++ b/python/perf-kernels/03-matrix-multiplication-all-types.py
@@ -250,8 +250,8 @@ def test_correctness(M, N, K, col_a, col_b, in_dtype, out_dtype):
         torch_output = torch.matmul(a_fp16, b_fp16)
     else:
         torch_output = torch.matmul(a, b)
-    # print(f"triton_output={c}")
-    # print(f"torch_output={torch_output}")
+    #print(f"triton_output={c}")
+    #print(f"torch_output={torch_output}")
     rtol = 0 if torch.version.hip is None else 1e-2
     if in_dtype == 'int8':
         torch.testing.assert_close(c.to(torch.float16), torch_output, atol=1e-3, rtol=rtol)


### PR DESCRIPTION
Reduce the tolerance used to checking correctness. Previous big difference is mainly caused by the format `fp8e4m3b8`, which introduced big rounding error in converting subnormal values. The change is to avoid subnormal values when generating inputs. 
With that workaround, we can use much less tolerance in checking the correctness. 