### PR TITLE
Revert Integration CI change to run on all branches except llvm-*

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,8 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore: ['llvm-**']
+    # You can name your branch dev-foo to get CI runs.
+    branches: [main, 'dev-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -9,7 +9,8 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore: ['llvm-**']
+    # You can name your branch dev-foo to get CI runs.
+    branches: [main, 'dev-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]


### PR DESCRIPTION
Due to https://github.com/triton-lang/triton/pull/4917/files the upstream Integration pipeline now runs on all branches except llvm-* . Previously it ran only on PRs into main or dev-* branches.

Two options I see here:
- Disable the Integration Pipeline in this repository which was failing anyways: https://github.com/ROCm/triton/actions/workflows/integration-tests.yml
- Revert to old behaviour (merge this PR) which changes upstream code