### PR TITLE
rmsnorm optimization for M = 1

### DIFF
--- a/python/perf-kernels/rmsnorm.py
+++ b/python/perf-kernels/rmsnorm.py
@@ -109,8 +109,10 @@ def test_rmsnorm(M, N):
     torch.manual_seed(0)
     x = torch.randn(M, N, device='cuda')
     y = torch.zeros_like(x, device='cuda')
+    n_rows, n_cols = x.shape
+    blk_size = triton.next_power_of_2(n_cols)
     g = torch.ones((1, N), device='cuda')
-    y_triton = triton_rmsnorm(x, y, g)
+    y_triton = triton_rmsnorm(x, y, g, n_rows, n_cols, blk_size)
 
     y_torch = torch_rmsnorm(x, g)
 

--- a/python/perf-kernels/rmsnorm.py
+++ b/python/perf-kernels/rmsnorm.py
@@ -203,8 +203,10 @@ def main():
     if args.no_benchmark:
         x = torch.randn(args.M_start, args.N_start, device='cuda')
         y = torch.zeros_like(x, device='cuda')
+        n_rows, n_cols = x.shape
+        blk_size = triton.next_power_of_2(n_cols)
         g = torch.ones((1, args.N_start), device='cuda')
-        triton_rmsnorm(x, y, g)
+        triton_rmsnorm(x, y, g, n_rows, n_cols, blk_size)
     else:
         run_benchmark(args)
 


### PR DESCRIPTION
### rmsnorm kernel optimization 

-  enable buffer load/store
-  change grid size as tl.constexpr
-  add autotuning configs with waves_per_eu = 0
-  move memory allocation outside of the wrapper to reduce autotuning overheads
-  fix issue for no_benchmark case.
-  it has average 88% performance improvement over the base version.