### PR TITLE
Fused moe gemm + silu activation

### DIFF
--- a/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8.json
+++ b/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8.json
@@ -1,35 +1,35 @@
 {
-    "small_M": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    },
-    "medium_M": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    },
-    "large_M": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    }
+  "small_M": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  },
+  "medium_M": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  },
+  "large_M": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  }
 }

--- a/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8.json
+++ b/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8.json
@@ -1,0 +1,35 @@
+{
+    "small_M": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    },
+    "medium_M": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    },
+    "large_M": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    }
+}

--- a/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=int8_w8a16.json
+++ b/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=int8_w8a16.json
@@ -1,0 +1,35 @@
+{
+    "small_M": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    },
+    "medium_M": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    },
+    "large_M": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 2
+    }
+}

--- a/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=int8_w8a16.json
+++ b/python/perf-kernels/fused_moe/configs/device_name=AMD_Instinct_MI300X,dtype=int8_w8a16.json
@@ -1,35 +1,35 @@
 {
-    "small_M": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    },
-    "medium_M": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    },
-    "large_M": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 0,
-        "matrix_instr_nonkdim": 16,
-        "kpack": 2
-    }
+  "small_M": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  },
+  "medium_M": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  },
+  "large_M": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 2
+  }
 }

--- a/python/perf-kernels/fused_moe/moe-gemm.py
+++ b/python/perf-kernels/fused_moe/moe-gemm.py
@@ -367,10 +367,13 @@ def moe_gemm(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, metadata: MetaDa
 
     EVEN_K = K % config["BLOCK_SIZE_K"] == 0
 
-    moe_gemm_kernel[grid](a, b, c, a_descale, b_descale, a.stride(0), a.stride(1), b.stride(0), b.stride(1), b.stride(2), c.stride(1),
-                          c.stride(2), stride_bse, stride_bsn, top_k, topk_weights, sorted_token_ids, expert_ids, EM, N, K, EVEN_K,
-                          MUL_ROUTED_WEIGHT=topk_weights is not None, use_fp8_w8a8=use_fp8_w8a8, use_int8_w8a16=use_int8_w8a16, **config)
+    moe_gemm_kernel[grid](a, b, c, a_descale,
+                          b_descale, a.stride(0), a.stride(1), b.stride(0), b.stride(1), b.stride(2), c.stride(1),
+                          c.stride(2), stride_bse, stride_bsn, top_k, topk_weights, sorted_token_ids, expert_ids, EM, N,
+                          K, EVEN_K, MUL_ROUTED_WEIGHT=topk_weights is not None, use_fp8_w8a8=use_fp8_w8a8,
+                          use_int8_w8a16=use_int8_w8a16, **config)
     return c
+
 
 quantization_max_repr_val = {
     torch.int8: 127, torch.float8_e4m3fnuz: 240.0, torch.float8_e4m3fn: 448.0, torch.float8_e5m2fnuz: 57344.0,

--- a/python/perf-kernels/fused_moe/moe-gemm.py
+++ b/python/perf-kernels/fused_moe/moe-gemm.py
@@ -117,9 +117,9 @@ def silu_and_mul_kernel(A, Out, stride_am, stride_an, stride_cm, stride_cn, EM: 
 
 @triton.jit
 def moe_inner(a_ptrs, b_ptrs, A_scale, B_scale, stride_ak, stride_bk, stride_bse, stride_bsn, topk_weights_ptr,
-              off_experts, offs_bn, token_mask, offs_k, offs_token, K: tl.constexpr,
-              MUL_ROUTED_WEIGHT: tl.constexpr, use_fp8_w8a8: tl.constexpr, use_int8_w8a16: tl.constexpr,
-              BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr):
+              off_experts, offs_bn, token_mask, offs_k, offs_token, K: tl.constexpr, MUL_ROUTED_WEIGHT: tl.constexpr,
+              use_fp8_w8a8: tl.constexpr, use_int8_w8a16: tl.constexpr, BLOCK_SIZE_M: tl.constexpr,
+              BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr):
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
     if use_int8_w8a16:

--- a/python/perf-kernels/fused_moe/moe-gemm.py
+++ b/python/perf-kernels/fused_moe/moe-gemm.py
@@ -20,11 +20,42 @@ M_THRESHOLD_SMALL = 256
 M_THRESHOLD_MEDIUM = 1024
 
 
+class MetaData():
+    use_fp8_w8a8 = False
+    use_int8_w8a16 = False
+
+    def __init__(self, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config):
+        self.topk_weights = topk_weights
+        self.topk_ids = topk_ids
+        self.sorted_token_ids = sorted_token_ids
+        self.expert_ids = expert_ids
+        self.num_tokens_post_padded = num_tokens_post_padded
+        self.config = config
+
+    def set_use_fp8_w8a8(self, a_descale, b_descale, fp8_type):
+        self.use_fp8_w8a8 = True
+        self.a_descale = a_descale
+        self.b_descale = b_descale
+        self.fp8_type = fp8_type
+
+    def set_use_int8_w8a16(self, b_descale):
+        self.use_int8_w8a16 = True
+        self.b_descale = b_descale
+        self.a_descale = None
+
+    def check_args(self, a, b, o):
+        assert a.shape[-1] == b.shape[-1] and b.shape[1] == o.shape[-1]
+
+        assert not (self.use_fp8_w8a8 and self.use_int8_w8a16)
+
+
 @triton.jit
 def moe_gemm_kernel(
     A,
     B,
     Out,
+    A_scale,
+    B_scale,
     stride_am,
     stride_ak,
     stride_be,
@@ -32,6 +63,8 @@ def moe_gemm_kernel(
     stride_bk,
     stride_cm,
     stride_cn,
+    stride_bse,
+    stride_bsn,
     top_k: tl.constexpr,
     topk_weights_ptr,
     sorted_token_ids_ptr,
@@ -41,6 +74,8 @@ def moe_gemm_kernel(
     K: tl.constexpr,
     EVEN_K: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
+    use_fp8_w8a8: tl.constexpr,
+    use_int8_w8a16: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -94,6 +129,14 @@ def moe_gemm_kernel(
     a_ptrs = A + (offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak)
     b_ptrs = B + off_experts * stride_be + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
+    if use_int8_w8a16:
+        b_scale_ptrs = B_scale + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
+        b_scale = tl.load(b_scale_ptrs)
+
+    if use_fp8_w8a8:
+        a_scale = tl.load(A_scale)
+        b_scale = tl.load(B_scale + off_experts)
+
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -105,13 +148,26 @@ def moe_gemm_kernel(
             a = tl.load(a_ptrs, mask=(token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K)), other=0.0)
             b = tl.load(b_ptrs, mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K), other=0.0)
 
-        accumulator = tl.dot(a, b, acc=accumulator)
+        if use_int8_w8a16:
+            accumulator = tl.dot(a, b.to(Out.dtype.element_ty), acc=accumulator)
+        elif use_fp8_w8a8:
+            accumulator += tl.dot(a, b)
+        else:
+            accumulator = tl.dot(a, b, acc=accumulator)
+
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
     if MUL_ROUTED_WEIGHT:
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
         accumulator = accumulator * moe_weight[:, None]
+
+    if use_int8_w8a16:
+        accumulator = (accumulator * b_scale).to(Out.dtype.element_ty)
+    elif use_fp8_w8a8:
+        accumulator = (accumulator * a_scale * b_scale).to(Out.dtype.element_ty)
+    else:
+        accumulator = accumulator.to(Out.dtype.element_ty)
 
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     out_ptrs = Out + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
@@ -287,10 +343,22 @@ def try_get_optimal_moe_config(
     return config
 
 
-def moe_gemm(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor,
-             sorted_token_ids: torch.Tensor, expert_ids: torch.Tensor, num_tokens_post_padded: torch.Tensor,
-             config) -> None:
+def moe_gemm(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, metadata: MetaData) -> None:
     # TODO shard M dim
+    metadata.check_args(a, b, c)
+
+    topk_ids, num_tokens_post_padded, topk_weights, sorted_token_ids, expert_ids, config = metadata.topk_ids, metadata.num_tokens_post_padded, metadata.topk_weights, metadata.sorted_token_ids, metadata.expert_ids, metadata.config
+
+    use_fp8_w8a8, use_int8_w8a16 = metadata.use_fp8_w8a8, metadata.use_int8_w8a16
+    a_descale, b_descale = None, None
+    stride_bse = None
+    stride_bsn = None
+    if use_fp8_w8a8 or use_int8_w8a16:
+        a_descale, b_descale = metadata.a_descale, metadata.b_descale
+        if use_int8_w8a16:
+            stride_bse = b_descale.stride(0)
+            stride_bsn = b_descale.stride(1)
+
     _, top_k = topk_ids.shape
 
     EM = num_tokens_post_padded.item()
@@ -299,13 +367,56 @@ def moe_gemm(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, topk_weights: to
 
     EVEN_K = K % config["BLOCK_SIZE_K"] == 0
 
-    moe_gemm_kernel[grid](a, b, c, a.stride(0), a.stride(1), b.stride(0), b.stride(1), b.stride(2), c.stride(1),
-                          c.stride(2), top_k, topk_weights, sorted_token_ids, expert_ids, EM, N, K, EVEN_K,
-                          MUL_ROUTED_WEIGHT=topk_weights is not None, **config)
+    moe_gemm_kernel[grid](a, b, c, a_descale, b_descale, a.stride(0), a.stride(1), b.stride(0), b.stride(1), b.stride(2), c.stride(1),
+                          c.stride(2), stride_bse, stride_bsn, top_k, topk_weights, sorted_token_ids, expert_ids, EM, N, K, EVEN_K,
+                          MUL_ROUTED_WEIGHT=topk_weights is not None, use_fp8_w8a8=use_fp8_w8a8, use_int8_w8a16=use_int8_w8a16, **config)
     return c
 
+quantization_max_repr_val = {
+    torch.int8: 127, torch.float8_e4m3fnuz: 240.0, torch.float8_e4m3fn: 448.0, torch.float8_e5m2fnuz: 57344.0,
+    torch.float8_e5m2: 57344.0
+}
 
-def input_helper(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool, dtype):
+
+def quantize_tensor(tensor: torch.Tensor, dtype, dim=()) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    quantize_dim = [i for i in range(tensor.dim()) if i not in dim]
+    max_vals = tensor.abs().amax(dim=quantize_dim, keepdim=True)
+    max_repr_val = quantization_max_repr_val[dtype]
+    # Avoid division by zero
+    max_vals[max_vals == 0] = 1e-8
+
+    # Compute scale factors for each channel
+    scale: torch.Tensor = max_repr_val / max_vals.to(torch.float32)
+
+    # Quantize the tensor
+    tensor = tensor * scale
+    tensor = tensor.round_()
+    tensor.clamp_(-max_repr_val, max_repr_val)
+    tensor_quantized = tensor.to(torch.int8)
+
+    scale = scale.squeeze(dim=quantize_dim)
+
+    return tensor_quantized, scale, 1 / scale
+
+
+def quantize_input(a, b, use_fp8_w8a8: tl.constexpr, use_int8_w8a16: tl.constexpr, metatdata: MetaData, fp8_type=None):
+    assert not (use_fp8_w8a8 and use_int8_w8a16)
+    assert not (use_fp8_w8a8 and fp8_type is None)
+
+    if use_fp8_w8a8:
+        a_quantized, _, a_descale = quantize_tensor(a, dtype=fp8_type)
+        b_quantized, _, b_descale = quantize_tensor(b, dim=(0, ), dtype=fp8_type)
+        metatdata.set_use_fp8_w8a8(a_descale, b_descale, fp8_type)
+        return a_quantized, b_quantized
+
+    if use_int8_w8a16:
+        b_quantized, _, b_descale = quantize_tensor(b, dim=(0, 1), dtype=torch.int8)
+        metatdata.set_use_int8_w8a16(b_descale)
+        return a, b_quantized
+
+
+def input_helper(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool, use_fp8_w8a8: bool,
+                 use_int8_w8a16: bool, fp8_type, dtype):
     a = torch.randn((M, K), dtype=dtype, device='cuda')
     b = torch.randn((E, N, K), dtype=dtype, device='cuda')
     c = torch.zeros((M, top_k, N), dtype=dtype, device='cuda')
@@ -315,7 +426,7 @@ def input_helper(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool
     softmax_vals = torch.softmax(values, dim=1)
     topk_weights, topk_ids = torch.topk(softmax_vals, k=top_k, dim=1)
 
-    config_dtype = None
+    config_dtype = get_config_dtype_str(use_fp8_w8a8=use_fp8_w8a8, use_int8_w8a16=use_int8_w8a16, dtype=dtype)
     get_config_func = functools.partial(
         try_get_optimal_moe_config,
         E,
@@ -324,10 +435,13 @@ def input_helper(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool
     config = get_config_func(M)
     sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(topk_ids, config['BLOCK_SIZE_M'], E)
 
-    if not routed_weight:
-        return a, b, c, None, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config
+    metadata = MetaData(topk_weights if routed_weight else None, topk_ids, sorted_token_ids, expert_ids,
+                        num_tokens_post_padded, config)
 
-    return a, b, c, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config
+    if use_fp8_w8a8 or use_int8_w8a16:
+        a, b = quantize_input(a, b, use_fp8_w8a8, use_int8_w8a16, metadata, fp8_type)
+
+    return a, b, c, metadata
 
 
 @pytest.mark.parametrize("M, N, K, top_k, E", [
@@ -345,11 +459,13 @@ def input_helper(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool
 @pytest.mark.parametrize('routed_weight', [True, False])
 def test_correctness(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool, dtype=torch.float16):
     torch.manual_seed(20)
-    a, b, c, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config = input_helper(
-        M, N, K, top_k, E, routed_weight=routed_weight, dtype=dtype)
+    a, b, c, metadata = input_helper(M, N, K, top_k, E, routed_weight=routed_weight, use_fp8_w8a8=False,
+                                     use_int8_w8a16=False, fp8_type=None, dtype=dtype)
 
-    tri_out = moe_gemm(a, b, c, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config)
+    tri_out = moe_gemm(a, b, c, metadata)
 
+    topk_ids = metadata.topk_ids
+    topk_weights = metadata.topk_weights
     ref_out = torch.empty_like(c)
     # Repeat a -> (M, top_k, K)
     a_expanded = a.unsqueeze(1).repeat(1, top_k, 1)
@@ -358,6 +474,88 @@ def test_correctness(M: int, N: int, K: int, top_k: int, E: int, routed_weight: 
     ref_out = torch.einsum("mek,menk->men", a_expanded, b_indexed)
     if routed_weight:
         ref_out *= topk_weights.unsqueeze(-1)
+
+    # Validate correctness
+    torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("M, N, K, top_k, E", [
+    (64, 14336, 4096, 2, 8),
+    (16, 14336, 1, 2, 4),
+    (1, 14336, 128, 2, 4),
+    (16, 14336, 128, 1, 4),
+    (16, 14336, 128, 1, 1),
+    (64, 7186, 128, 2, 8),
+    (64, 3584, 128, 2, 8),
+    (64, 1792, 128, 2, 8),
+    (64, 64, 128, 2, 8),
+])
+@pytest.mark.parametrize('routed_weight', [True, False])
+@pytest.mark.parametrize('use_fp8_w8a8', [True])
+# triton does not support torch.float8_e4m3fn
+@pytest.mark.parametrize('fp8_type', [torch.float8_e5m2, torch.float8_e5m2fnuz])
+def test_correctness_fp8(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool, use_fp8_w8a8, fp8_type,
+                         dtype=torch.float16):
+    torch.manual_seed(20)
+    a, b, c, metadata = input_helper(M, N, K, top_k, E, routed_weight=routed_weight, use_fp8_w8a8=use_fp8_w8a8,
+                                     use_int8_w8a16=False, fp8_type=fp8_type, dtype=dtype)
+
+    tri_out = moe_gemm(a, b, c, metadata)
+
+    topk_ids = metadata.topk_ids
+    topk_weights = metadata.topk_weights
+    ref_out = torch.empty_like(c)
+    # Repeat a -> (M, top_k, K)
+    a_expanded = a.unsqueeze(1).repeat(1, top_k, 1)
+    # (M, top_k, N, K)
+    b_indexed = b.half()[topk_ids]
+    ref_out = torch.einsum("mek,menk->men", a_expanded.float(), b_indexed.float())
+
+    if routed_weight:
+        ref_out *= topk_weights.unsqueeze(-1)
+
+    ref_out = ref_out * metadata.b_descale[topk_ids].unsqueeze(-1)
+    ref_out = ref_out * metadata.a_descale
+    ref_out = ref_out.to(dtype)
+
+    # Validate correctness
+    torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("M, N, K, top_k, E", [
+    (64, 14336, 4096, 2, 8),
+    (16, 14336, 1, 2, 4),
+    (1, 14336, 128, 2, 4),
+    (16, 14336, 128, 1, 4),
+    (16, 14336, 128, 1, 1),
+    (64, 7186, 128, 2, 8),
+    (64, 3584, 128, 2, 8),
+    (64, 1792, 128, 2, 8),
+    (64, 64, 128, 2, 8),
+])
+@pytest.mark.parametrize('routed_weight', [True, False])
+@pytest.mark.parametrize('use_int8_w8a16', [True])
+def test_correctness_int8(M: int, N: int, K: int, top_k: int, E: int, routed_weight: bool, use_int8_w8a16,
+                          dtype=torch.float16):
+    torch.manual_seed(20)
+    a, b, c, metadata = input_helper(M, N, K, top_k, E, routed_weight=routed_weight, use_fp8_w8a8=False,
+                                     use_int8_w8a16=use_int8_w8a16, fp8_type=None, dtype=dtype)
+
+    tri_out = moe_gemm(a, b, c, metadata)
+
+    topk_ids = metadata.topk_ids
+    topk_weights = metadata.topk_weights
+    ref_out = torch.empty_like(c)
+    # Repeat a -> (M, top_k, K)
+    a_expanded = a.unsqueeze(1).repeat(1, top_k, 1)
+    # (M, top_k, N, K)
+    b_indexed = b[topk_ids]
+    ref_out = torch.einsum("mek,menk->men", a_expanded.to(torch.float32), b_indexed.to(torch.float32))
+    if routed_weight:
+        ref_out *= topk_weights.unsqueeze(-1)
+
+    ref_out = ref_out * metadata.b_descale[topk_ids, :]
+    ref_out = ref_out.to(dtype)
 
     # Validate correctness
     torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=1e-2)
@@ -406,7 +604,11 @@ def model_benchmark_configs(args):
 
 def run_benchmark(custom, args):
     routed_weight = args.routed_weight
+    use_int8_w8a16 = args.int8_w8a16
+    use_fp8_w8a8 = args.fp8_w8a8
     dtype = arg_to_torch_dtype[args.dtype]
+    fp8_type = arg_to_torch_dtype[args.fp8_type]
+
     x_names = ['M', 'N', 'K', 'E', 'top_k']
     if custom:
         assert args.M and args.N and args.K and args.E and args.top_k, \
@@ -423,16 +625,19 @@ def run_benchmark(custom, args):
     line_names = ['Time (ms)', 'TFLOPS', 'Bandwidth (GB/s)']
     line_vals = ['time', 'tflops', 'bandwidth']
 
-    benchmark = triton.testing.Benchmark(x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals,
-                                         line_names=line_names, styles=[('red', '-'), ('blue', '-'), ('yellow', '-')],
-                                         ylabel='ms / TFLOPS / GB/s', plot_name='moe-gemm-benchmark',
-                                         args={'dtype': dtype, 'routed_weight': routed_weight})
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals, line_names=line_names,
+        styles=[('red', '-'), ('blue', '-'),
+                ('yellow', '-')], ylabel='ms / TFLOPS / GB/s', plot_name='moe-gemm-benchmark', args={
+                    'dtype': dtype, 'routed_weight': routed_weight, 'use_fp8_w8a8': use_fp8_w8a8, 'use_int8_w8a16':
+                    use_int8_w8a16, 'fp8_type': fp8_type
+                })
 
     @triton.testing.perf_report([benchmark])
-    def bench_moe_gemm(M, N, K, E, top_k, dtype, routed_weight, metric, model=None):
-        # metric will be either 'time'/'tflops' or 'bandwidth'
-        a, b, c, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config = input_helper(
-            M, N, K, top_k, E, routed_weight=routed_weight, dtype=dtype)
+    def bench_moe_gemm(M, N, K, E, top_k, dtype, routed_weight, metric, use_fp8_w8a8, use_int8_w8a16, fp8_type,
+                       model=None):
+        a, b, c, metadata = input_helper(M, N, K, top_k, E, routed_weight=routed_weight, use_fp8_w8a8=use_fp8_w8a8,
+                                         use_int8_w8a16=use_int8_w8a16, fp8_type=fp8_type, dtype=dtype)
 
         # (M, K) * (top_k, N, K) -> (M, top_k, N). 2 for multiplication and accumulation
         flops = 2.0 * M * top_k * K * N
@@ -440,14 +645,21 @@ def run_benchmark(custom, args):
         if routed_weight:
             flops += M * top_k * N
 
-        bytes_ = torch.tensor([], dtype=dtype).element_size()
+        if use_fp8_w8a8:
+            a_bytes = b_bytes = torch.tensor([], dtype=fp8_type).element_size()
+            c_bytes = torch.tensor([], dtype=dtype).element_size()
+        elif use_int8_w8a16:
+            b_bytes = torch.tensor([], dtype=torch.int8).element_size()
+            a_bytes = c_bytes = torch.tensor([], dtype=dtype).element_size()
+        else:
+            a_bytes = b_bytes = c_bytes = torch.tensor([], dtype=dtype).element_size()
+
         # (M, K) memory load for A (E,  N,  K) for B not (top_k,  N,  K) because we are in total bringing in all expert matrices into the chip from memory. It's just that not all multiply the same A.
-        mem_read = (M * K + E * N * K) * bytes_
+        mem_read = (M * K) * a_bytes + (E * N * K) * b_bytes
         # Memory write for the gemm product
-        mem_write = (M * top_k * N) * bytes_
+        mem_write = (M * top_k * N) * c_bytes
         mem = mem_read + mem_write
-        fn = lambda: moe_gemm(a, b, c, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded,
-                              config)
+        fn = lambda: moe_gemm(a, b, c, metadata)
         ms = triton.testing.do_bench(fn)
 
         bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
@@ -482,12 +694,18 @@ def parse_args():
     parser.add_argument("-E", type=int, default=0, help="Number of experts")
     parser.add_argument("-top_k", type=int, default=0, help="top_k experts per token")
     parser.add_argument("-routed_weight", action='store_true', default=False)
+    parser.add_argument("-int8_w8a16", action='store_true', default=False)
+    parser.add_argument("-fp8_w8a8", action='store_true', default=False)
     parser.add_argument("-dtype", default='fp16')
+    parser.add_argument("-fp8_type", default='e5m2')
     args = parser.parse_args()
     return args
 
 
-arg_to_torch_dtype = {'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32}
+arg_to_torch_dtype = {
+    'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32, "e5m2": torch.float8_e5m2, "e5m2fnuz":
+    torch.float8_e5m2fnuz, "e4m3fn": torch.float8_e4m3fn, "e4m3fnuz": torch.float8_e4m3fnuz
+}
 
 
 def main():


### PR DESCRIPTION
added 
- fused silu_and_multiply into the moe gemm kernel
- a separate silu_and_multiply kernel for benchmarking
- test for both fused silu_and_multiply + moe gemm and silu_and_multiply kernel alone
- benchmark support for the above features.

Not fused moe gemm + silu activation:
|     M    |      N    |     K    |  E  | top_k | Time (ms) |      TFLOPS     | Bandwidth (GB/s) |
|----------|-----------|----------|-----|-------|-----------|-----------------|------------------|
|    64.0  |    256.0  |   128.0  | 8.0 |   2.0 |   0.160872 |      0.053811   |        3.670763  |
|    64.0  |   1792.0  |  1024.0  | 8.0 |   2.0 |   0.157812 |      2.976516   |      187.696838  |
|    64.0  |   7168.0  |  4096.0  | 8.0 |   2.0 |   0.322130 |     23.582173   |     1476.434601  |
|   128.0  |   7168.0  |  4096.0  | 8.0 |   2.0 |   0.327998 |     45.848947   |     1440.615762  |
|  1024.0  |   7168.0  |  4096.0  | 8.0 |   2.0 |   0.704121 |    173.119110   |      730.894766  |
|  4096.0  |   7168.0  |  4096.0  | 8.0 |   2.0 |   1.385702 |    363.116161   |      408.827750  |
|    64.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   0.449420 |     33.529734   |     2089.982919  |
|   128.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   0.450716 |     66.941020   |     2097.098976  |
|   256.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   0.534825 |    113.052503   |     1777.954711  |
|   512.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   0.628094 |    192.196762   |     1521.764560  |
|  1024.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   1.064061 |    231.233717   |      949.332146  |
|  2048.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   1.411736 |    334.606204   |      695.738145  |
|  4096.0  |  14336.0  |  4096.0  | 8.0 |   2.0 |   2.616804 |    391.498488   |      448.567284  |

Fused moe gemm + activation:
moe-gemm-benchmark:
         M        N       K    E  top_k  Time (ms)      TFLOPS  Bandwidth (GB/s)
0     64.0    256.0   128.0  8.0    2.0   0.099920    0.088580          6.038851
1     64.0   1792.0  1024.0  8.0    2.0   0.110950    4.454053        288.554980
2     64.0   7168.0  4096.0  8.0    2.0   0.293957   25.555493       1599.714397
3    128.0   7168.0  4096.0  8.0    2.0   0.298787   50.297688       1571.505069
4   1024.0   7168.0  4096.0  8.0    2.0   0.686597  175.436396        698.660062
5   4096.0   7168.0  4096.0  8.0    2.0   1.397160  346.580868        390.036567
6     64.0  14336.0  4096.0  8.0    2.0   0.451650   33.283002       2085.665342
7    128.0  14336.0  4096.0  8.0    2.0   0.475684   62.297008       1969.283288
8    256.0  14336.0  4096.0  8.0    2.0   0.512927  127.292250       1875.314673
9    512.0  14336.0  4096.0  8.0    2.0   0.657738  203.264431       1435.827133
10  1024.0  14336.0  4096.0  8.0    2.0   1.006813  243.019437        930.457930
11  2048.0  14336.0  4096.0  8.0    2.0   1.486273  327.245959        659.572967
12  4096.0  14336.0  4096.0  8.0    2.0   2.568381  374.377968        413.970691

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
