### PR TITLE
Add workaround for pytorch device selection issue

### DIFF
--- a/python/perf-kernels/streamk/tune_streamk.py
+++ b/python/perf-kernels/streamk/tune_streamk.py
@@ -203,6 +203,10 @@ def profile_batch_kernels(M, N, K, gpuid, gpus, jobs, verbose):
     if gpuIdx + 1 > jobs:
         return
     os.environ['ROCR_VISIBLE_DEVICES'] = str(gpuid)
+    # ROCR_VISIBLE_DEVICES is not parsed correctly by all pytorch versions which produces an out of bounds access
+    # To workaround this issue force it to use the first HIP_VISIBLE_DEVICE which is the one we select with ROCR_VISIBLE_DEVICES
+    # https://github.com/pytorch/pytorch/issues/140318 we need to keep this even after the fix is merged because we might use older pytorch versions
+    os.environ['HIP_VISIBLE_DEVICES'] = '0'
     jobId = gpuIdx
     while jobId < jobs:
         kernelname = get_filename_profile_driver(M, N, K, jobId)

--- a/python/perf-kernels/tools/tune_gemm/tune_gemm.py
+++ b/python/perf-kernels/tools/tune_gemm/tune_gemm.py
@@ -193,6 +193,10 @@ def profile_batch_kernels(M, N, K, gpuid, gpus, jobs, verbose):
     if gpuIdx + 1 > jobs:
         return
     os.environ['ROCR_VISIBLE_DEVICES'] = str(gpuid)
+    # ROCR_VISIBLE_DEVICES is not parsed correctly by all pytorch versions which produces an out of bounds access
+    # To workaround this issue force it to use the first HIP_VISIBLE_DEVICE which is the one we select with ROCR_VISIBLE_DEVICES
+    # https://github.com/pytorch/pytorch/issues/140318 we need to keep this even after the fix is merged because we might use older pytorch versions
+    os.environ['HIP_VISIBLE_DEVICES'] = '0'
     jobId = gpuIdx
     while jobId < jobs:
         kernel_name = get_filename_profile_driver(M, N, K, jobId)


### PR DESCRIPTION
When switching to `rocm/pytorch:latest` we experience a perf CI crash. This PR fixes that by adding a workaround for the broken pytorch device selection.
Some pytorch versions only look at `HIP_VISIBLE_DEVICES` and therefore crash when we limit the devices with `ROCR_VISIBLE_DEVICES` because it computes the incorrect device count because it only checks HIP_VISIBLE_DEVICES.
https://github.com/pytorch/pytorch/issues/140318

Right now tune_gemm/streamk correctly limits the visible devices via `ROCR_VISIBLE_DEVICES` to just the GPU we want to run on. Note that when we use more GPUs we launch one process per GPU. So HIP only sees one device per process which means we can always select the first gpu -> `HIP_VISIBLE_DEVICES=0` does not have a behavior change but fixes the pytorch device count calculation.