### PR TITLE
Attempt to unify perf kernel and AOTriton's kernel.

### DIFF
--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -505,7 +505,10 @@ def get_cdna_autotune_configs():
                       num_stages=1, num_warps=4),
         triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'waves_per_eu': 2, 'PRE_LOAD_V': False, 'GRID_CU_MULTIP': 2},
                       num_stages=1, num_warps=4),
-    ], ['CAUSAL_TYPE', 'dropout_p', 'Max_seqlen_q', 'Max_seqlen_k', 'Head_dim', 'Num_seqlens', 'Num_head_q', 'Num_head_k']
+    ], [
+        'CAUSAL_TYPE', 'dropout_p', 'Max_seqlen_q', 'Max_seqlen_k', 'Head_dim', 'Num_seqlens', 'Num_head_q',
+        'Num_head_k'
+    ]
 
 
 def get_rdna_autotune_configs():
@@ -525,7 +528,10 @@ def get_rdna_autotune_configs():
         # Fall-back config.
         triton.Config({'BLOCK_M': 16, 'BLOCK_N': 16, 'waves_per_eu': 1, 'PRE_LOAD_V': False, 'GRID_CU_MULTIP': 2},
                       num_stages=1, num_warps=2),
-    ], ['CAUSAL_TYPE', 'dropout_p', 'Max_seqlen_q', 'Max_seqlen_k', 'Head_dim', 'VARLEN', 'Num_head_q', 'Num_head_k']
+    ], [
+        'CAUSAL_TYPE', 'dropout_p', 'Max_seqlen_q', 'Max_seqlen_k', 'Head_dim', 'Num_seqlens', 'Num_head_q',
+        'Num_head_k'
+    ]
 
 
 def get_autotune_configs():

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -28,6 +28,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
 from utils.benchmark_utils import get_available_models, get_model_configs
 
 IS_JIT_COMPILING = True
@@ -559,10 +560,10 @@ def attn_fwd(
         ENABLE_DROPOUT: tl.constexpr,
         dropout_p,
         philox_seed_ptr,
-        philox_offset1 : '*u32',
-        philox_offset2 : 'i32',
-        philox_seed_output : '*u64',
-        philox_offset_output : '*u64',
+        philox_offset1,
+        philox_offset2 : tl.int32,  # TODO: move to tl.int64
+        philox_seed_output, # Should be '*u64', but code-formatter complains
+        philox_offset_output, # Should be '*u64', but code-formatter complains
         RETURN_ENCODED_SOFTMAX: tl.constexpr,
         encoded_softmax,
         # causal, (Planned Feature) windowed attention

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -1324,10 +1324,6 @@ class _attention(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, q, k, v, o, metadata: MetaData):
-        # NOTE: a large bias tensor leads to overflow during pointer arithmetic
-        if (metadata.bias is not None):
-            assert (metadata.bias.numel() < 2**31)
-
         if o is None:
             if not metadata.int8:
                 o = torch.empty_like(q, dtype=v.dtype)

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -579,11 +579,11 @@ def attn_fwd(
         # dropout and PRNG
         ENABLE_DROPOUT: tl.constexpr,
         dropout_p,
-        philox_seed_ptr : '*u64',
-        philox_offset1 : '*u64',
+        philox_seed_ptr,
+        philox_offset1,
         philox_offset2 : tl.int32,  # TODO: move to tl.int64
-        philox_seed_output : '*u64', # Should be '*u64', but code-formatter complains
-        philox_offset_output : '*u64', # Should be '*u64', but code-formatter complains
+        philox_seed_output, # Should be '*u64', but code-formatter complains
+        philox_offset_output, # Should be '*u64', but code-formatter complains
         RETURN_ENCODED_SOFTMAX: tl.constexpr,
         encoded_softmax,
         # causal, (Planned Feature) windowed attention

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -525,7 +525,7 @@ def get_rdna_autotune_configs():
         # Fall-back config.
         triton.Config({'BLOCK_M': 16, 'BLOCK_N': 16, 'waves_per_eu': 1, 'PRE_LOAD_V': False, 'GRID_CU_MULTIP': 2},
                       num_stages=1, num_warps=2),
-    ], ['IS_CAUSAL', 'dropout_p', 'MAX_SEQLENS_Q', 'MAX_SEQLENS_K', 'ACTUAL_BLOCK_DMODEL', 'VARLEN', 'HQ', 'HK']
+    ], ['CAUSAL_TYPE', 'dropout_p', 'Max_seqlen_q', 'Max_seqlen_k', 'Head_dim', 'VARLEN', 'Num_head_q', 'Num_head_k']
 
 
 def get_autotune_configs():

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -28,6 +28,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton.language import uint64 as u64  # type annotation of strides
 from triton.language.extra import libdevice
 from utils.benchmark_utils import get_available_models, get_model_configs
 
@@ -564,12 +565,14 @@ def attn_fwd(
         # Basic SDPA
         Q, K, V, B, A, Sm_scale : constexpr_or_f32, L, Out,
         Q_descale, K_descale, P_scale, P_descale, V_descale,
-        stride_qz, stride_qh, stride_qm, stride_qk,
-        stride_kz, stride_kh, stride_kn, stride_kk,
-        stride_vz, stride_vh, stride_vk, stride_vn,
-        stride_oz, stride_oh, stride_om, stride_on,
-        stride_bz, stride_bh, stride_bm, stride_bn,
-        stride_az, stride_ah,
+        # Note: do not apply u64 to last stride
+        #       which should be hard-coded to 1 otherwise the performance will be -50%
+        stride_qz:u64, stride_qh:u64, stride_qm:u64, stride_qk,
+        stride_kz:u64, stride_kh:u64, stride_kn:u64, stride_kk,
+        stride_vz:u64, stride_vh:u64, stride_vk:u64, stride_vn,
+        stride_oz:u64, stride_oh:u64, stride_om:u64, stride_on,
+        stride_bz:u64, stride_bh:u64, stride_bm:u64, stride_bn,
+        stride_az, stride_ah,  # Let Triton decide its type/constexpr for this small tensor
         # MQA/GQA
         Num_head_q : constexpr_or_i32,
         Num_head_k : constexpr_or_i32,

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -35,11 +35,11 @@ IS_JIT_COMPILING = True
 if IS_JIT_COMPILING:
     from triton.language import constexpr as constexpr_or_i32
     from triton.language import constexpr as constexpr_or_f32
-    from triton.language import constexpr as constexpr_or_bool
+    # from triton.language import constexpr as constexpr_or_bool  # Unused for now
 else:
     from triton.language import int32 as constexpr_or_i32
     from triton.language import float32 as constexpr_or_f32
-    from triton.language import int1 as constexpr_or_bool
+    # from triton.language import int1 as constexpr_or_bool
 
 # Note: we don't use Enum class because accessing the integer requires using
 #       `.value` property, which makes the code verbose.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,4 +12,4 @@ max_line_length = 88
 line-length = 120
 
 [tool.ruff.lint]
-ignore = ["E501", "E701", "E731", "E741", "F722"]
+ignore = ["E501", "E701", "E731", "E741"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,4 +12,4 @@ max_line_length = 88
 line-length = 120
 
 [tool.ruff.lint]
-ignore = ["E501", "E701", "E731", "E741"]
+ignore = ["E501", "E701", "E731", "E741", "F722"]


### PR DESCRIPTION
## Major changes

* Introduce a new naming convention: `Constant_in_jit_but_variable_in_aot`
    - Please use `constexpr_or_i32`/`constexpr_or_f32`/`constexpr_or_bool` annotation for such types
* Add `mstore2d` to handle OOB writes of encoded softmax
* Use `Max_seqlen_k` in calculating the Philox offsets, avoiding overlapped offsets for Varlen.
* Replace `PERSISTENT` and `PERSISTENT_DYNAMIC` with `PERSISTENT_TYPE = 0/1/2`  for No, Fixed and Dynamic options
* Add `Num_seqlens` to support padded varlen (Still Rank-4 Tensor, but only part of sequences are used)
    - `Num_seqlens == 0`: Classical SDPA
    - `Num_seqlens > 0`: Conventional Varlen
    - `Num_seqlens < 0`: Padded Varlen
* Replace `IS_CAUSAL` with `CAUSAL_TYPE`:
    - `CAUSAL_TYPE == 0`: No causal
    - `CAUSAL_TYPE == 1`: Top-left alignment (PyTorch ME backend's default)
    - `CAUSAL_TYPE == 2`: Bottom-right alignment (main_perf's previous settings)
* Fix Nan when sm_scale=0 on certain bias pattern (See: https://github.com/ROCm/aotriton/issues/47)
* Rearrange order of arguments. Please only add one argument for each line, with two exceptions:
    - strides of the same tensor should be put in a single line. 
    - Basic SPDA arguments and all tensors can be compactly packed together.
* Add hipGraph support to PRNG
* Add type annotation `tl.uint64` to all strides except for alibi, in order to support large tensor.

## Unit Test Changes

* Change the Dimension 0 of bias tensor from 1 to actual batch size through `torch.expand`.
* Add test for bias tensor with real batches, i.e., allocate actual memory and fill different values in different batches
    - This is required by LLAMA 3.2
* Remove the assertion of bias tensor size
    - `tl.uint64` type annotation on strides is used to overcome this limit