### PR TITLE
Adding dot-tiling into decomposing dot.

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
@@ -99,7 +99,7 @@ def TritonAMDGPU_DotTile : TritonAMDGPU_Attr<"DotTile"> {
     operation (e.g., `tt.dot`) the result of a given operation belongs to.
     The parameters tile{M,N,K,Serial} refer to the dot-tile's id within the dot,
     while the element{M,N,K,Serial} refer to the element's id within the dot-tile.
-    
+
   }];
   let parameters = (ins "int32_t":$tileM, "int32_t":$tileN, "int32_t":$tileK, "uint32_t":$tileSerial, "int32_t":$elementM, "int32_t":$elementN, "int32_t":$elementK, "uint32_t":$elementSerial );
   let assemblyFormat = "`<` $tileM `,` $tileN `,` $tileK `>` `[` $tileSerial `]` `,` `<` $elementM `,` $elementN `,` $elementK `>` `[` $elementSerial `]`";

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
@@ -90,4 +90,19 @@ def TritonAMDGPU_SchedHintsEnum : TritonAMDGPU_I32Enum<
 def TritonAMDGPU_SchedHintVariantAttr :
   TritonAMDGPU_I32EnumAttr<"SchedHintVariant", TritonAMDGPU_SchedHintsEnum>;
 
+def TritonAMDGPU_DotTile : TritonAMDGPU_Attr<"DotTile"> {
+  let cppNamespace = "::mlir::triton::amdgpu";
+  let mnemonic = "DotTile";
+  let summary = "Information regarding the dot-tile this op belongs to.";
+  let description = [{
+    The attribute is a way to describe which input argument of the target
+    operation (e.g., `tt.dot`) the result of a given operation belongs to.
+    The parameters tile{M,N,K,Serial} refer to the dot-tile's id within the dot,
+    while the element{M,N,K,Serial} refer to the element's id within the dot-tile.
+    
+  }];
+  let parameters = (ins "int32_t":$tileM, "int32_t":$tileN, "int32_t":$tileK, "uint32_t":$tileSerial, "int32_t":$elementM, "int32_t":$elementN, "int32_t":$elementK, "uint32_t":$elementSerial );
+  let assemblyFormat = "`<` $tileM `,` $tileN `,` $tileK `>` `[` $tileSerial `]` `,` `<` $elementM `,` $elementN `,` $elementK `>` `[` $elementSerial `]`";
+}
+
 #endif

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -1,11 +1,10 @@
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
-#include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
-#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -37,12 +36,13 @@ unsigned calcCyclesPerMfma(AMDMfmaEncodingAttr mfmaLayout, DotOp dotOp) {
   bool allowXF32 =
       dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
   auto maybeMfmaInsn = MfmaInsn::selectMfma(mDim, nDim, elemTyA, elemTyB,
-                                              mfmaVersion, allowXF32);
+                                            mfmaVersion, allowXF32);
   if (failed(maybeMfmaInsn))
     llvm::report_fatal_error("No match found in MFMA database\n");
   // Estimate rate of mfma op type.
-  unsigned maxBitWidth = std::max(maybeMfmaInsn->getElementTypeA().getIntOrFloatBitWidth(),
-                                  maybeMfmaInsn->getElementTypeB().getIntOrFloatBitWidth());
+  unsigned maxBitWidth =
+      std::max(maybeMfmaInsn->getElementTypeA().getIntOrFloatBitWidth(),
+               maybeMfmaInsn->getElementTypeB().getIntOrFloatBitWidth());
   // Estimate throughput as fma's per cycle.
   unsigned opsPerCycle;
   if (maxBitWidth <= 8) { // fp8, bf8, i8
@@ -55,11 +55,11 @@ unsigned calcCyclesPerMfma(AMDMfmaEncodingAttr mfmaLayout, DotOp dotOp) {
     opsPerCycle = 64; // fp64
   }
   // total floating point mfmas
-  int64_t totalOps = maybeMfmaInsn->getMDim()
-      * maybeMfmaInsn->getNDim()
-      * maybeMfmaInsn->getKDim();
+  int64_t totalOps = maybeMfmaInsn->getMDim() * maybeMfmaInsn->getNDim() *
+                     maybeMfmaInsn->getKDim();
   unsigned cyclesPerMfma = static_cast<unsigned>(totalOps / opsPerCycle);
-  DBGS() << maybeMfmaInsn->getInsnName() << " = " << cyclesPerMfma << " cycles\n";
+  DBGS() << maybeMfmaInsn->getInsnName() << " = " << cyclesPerMfma
+         << " cycles\n";
   return cyclesPerMfma;
 }
 
@@ -67,28 +67,26 @@ unsigned calcCyclesPerMfma(AMDMfmaEncodingAttr mfmaLayout, DotOp dotOp) {
 Calculate how many mfmas are in a rep, e.g. 1x1x2.
 // TODO(dtanner) Is there a more direct method for this?
 */
-SmallVector<unsigned, 3> calcMfmasPerRep(
-    SmallVector<int64_t> ctaTile,
-    SmallVector<unsigned> warpsPerCta,
-    SmallVector<int64_t> numReps,
-    SmallVector<unsigned> mfmaShape
-) {
+SmallVector<unsigned, 3> calcMfmasPerRep(SmallVector<int64_t> ctaTile,
+                                         SmallVector<unsigned> warpsPerCta,
+                                         SmallVector<int64_t> numReps,
+                                         SmallVector<unsigned> mfmaShape) {
   // Tile shape per warp.
   SmallVector<int64_t, 3> warpTile = {
-    ctaTile[0] / warpsPerCta[0],
-    ctaTile[1] / warpsPerCta[1],
-    ctaTile[2],
+      ctaTile[0] / warpsPerCta[0],
+      ctaTile[1] / warpsPerCta[1],
+      ctaTile[2],
   };
   // Tile shape per rep.
   SmallVector<int64_t, 3> repTile = {
-    warpTile[0] / numReps[0],
-    warpTile[1] / numReps[1],
-    warpTile[2] / numReps[2],
+      warpTile[0] / numReps[0],
+      warpTile[1] / numReps[1],
+      warpTile[2] / numReps[2],
   };
   SmallVector<unsigned, 3> mfmasPerRep = {
-    static_cast<unsigned>(repTile[0] / mfmaShape[0]),
-    static_cast<unsigned>(repTile[1] / mfmaShape[1]),
-    static_cast<unsigned>(repTile[2] / mfmaShape[2])};
+      static_cast<unsigned>(repTile[0] / mfmaShape[0]),
+      static_cast<unsigned>(repTile[1] / mfmaShape[1]),
+      static_cast<unsigned>(repTile[2] / mfmaShape[2])};
   return mfmasPerRep;
 }
 
@@ -96,12 +94,13 @@ SmallVector<unsigned, 3> calcMfmasPerRep(
   Returns the ideal dot-tile shape (in number of reps, not number of mfmas).
 
   The dot-tile shape is chosen such that:
-  (1) A dot-tile's worth of local_load_a and local_load_b can 
+  (1) A dot-tile's worth of local_load_a and local_load_b can
       can be issued during a dot-tile's worth of mfmas.
   (2) A dot-tile's worth of dot cycles hides the local_load data latency.
   (3) The dot-tile is as small and square as possible.
 
-    Typical shapes when mfmasPerRep = 1x1x2 for b128 and localLoadIssueRate=32 for b128
+    Typical shapes when mfmasPerRep = 1x1x2 for b128 and localLoadIssueRate=32
+  for b128
     - 2x2 for fp16 (128 mfma cycles per tile) and
     - 4x4 for fp8 (256 mfma cycles per tile).
 
@@ -109,80 +108,82 @@ SmallVector<unsigned, 3> calcMfmasPerRep(
     - mfmasPerRep - shape of number of mfmas in decomposed dot, e.g. 1x1x2.
     - preferLargerM - prefer M > N if not square.
     - cyclesPerMfma - how many cycles does mfma take in total.
-    - localLoadIssueRate - cycles between issuing consecutive ds_reads to not overrun hardware queues.
-        This is estimated to be b128 -> 32 cycles, b64 -> 16 cycles, b32 -> 8 cycles.
-        Default is 32 cycles, which assumes all ds_read_b128.
-    - localLoadDataLatency - cycles between issuing ds_read and waiting for data; rounded up to pow2.
-  
+    - localLoadIssueRate - cycles between issuing consecutive ds_reads to not
+  overrun hardware queues. This is estimated to be b128 -> 32 cycles, b64 -> 16
+  cycles, b32 -> 8 cycles. Default is 32 cycles, which assumes all ds_read_b128.
+    - localLoadDataLatency - cycles between issuing ds_read and waiting for
+  data; rounded up to pow2.
+
   Notes:
    - The intended scheduling of dot-tiles is
   --------------------------------
-  local_load_a[n] // a,b loads can be issued during dot-tile without any loss of performance.
-  local_load_b[n]
-  DotTile[n-2] 
+  local_load_a[n] // a,b loads can be issued during dot-tile without any loss of
+  performance. local_load_b[n] DotTile[n-2]
   --------------------------------
   DotTile[n-1] // a,b load data latency hiding.
   --------------------------------
   DotTile[n]   // all a,b data is ready by the first mfma of tile.
   --------------------------------
 
-    - Dot-tile shapes can be further refined if the data latency becomes much larger than
-  the issue rate; in this case we can remove the condition that one tile
-  hides all the data latency (which could make the tiles huge and waste registers),
-  and intead local load issue rate is the only criteria and we retroactively calculate
-  how many tiles are needed to hide the data latency.
-    - Dot-tile shapes can be further refined so that a dot-tile only needs to load a or b,
-  and not both a and b.
-    - At this time it is assumed that dot-tile-shape[K] = 1 since K's don't interact with eachother.
-    - It is assumed that mfmasPerRep = 1x1x2 means that 1 local_load_a + 1 local_load_b
-  supplies operands for 2 mfmas, i.e. a single mfmasPerRep requires 1 local_load_a and 1 b.
-  Therefore, if for some reason the local_loads per mfmaPerRep changes,
-  this algoirthm needs to be updated so it can correctly calculate how many local_loads
-  are required to supply the dot-tile of mfmas.
+    - Dot-tile shapes can be further refined if the data latency becomes much
+  larger than the issue rate; in this case we can remove the condition that one
+  tile hides all the data latency (which could make the tiles huge and waste
+  registers), and intead local load issue rate is the only criteria and we
+  retroactively calculate how many tiles are needed to hide the data latency.
+    - Dot-tile shapes can be further refined so that a dot-tile only needs to
+  load a or b, and not both a and b.
+    - At this time it is assumed that dot-tile-shape[K] = 1 since K's don't
+  interact with eachother.
+    - It is assumed that mfmasPerRep = 1x1x2 means that 1 local_load_a + 1
+  local_load_b supplies operands for 2 mfmas, i.e. a single mfmasPerRep requires
+  1 local_load_a and 1 b. Therefore, if for some reason the local_loads per
+  mfmaPerRep changes, this algoirthm needs to be updated so it can correctly
+  calculate how many local_loads are required to supply the dot-tile of mfmas.
 */
 typedef SmallVector<unsigned, 2> DotTileShape;
 DotTileShape calcDotTileShape(
-  SmallVector<unsigned, 3> mfmasPerRep, // = 16x16x64 / 16x16x32 = 1x1x2
-  bool preferLargerM,
-  unsigned cyclesPerMfma = 8,
-  unsigned localLoadIssueRate = 32,
-  unsigned localLoadDataLatency = 128
-) {
+    SmallVector<unsigned, 3> mfmasPerRep, // = 16x16x64 / 16x16x32 = 1x1x2
+    bool preferLargerM, unsigned cyclesPerMfma = 8,
+    unsigned localLoadIssueRate = 32, unsigned localLoadDataLatency = 128) {
   DotTileShape tileShape = {1, 1};
-  int64_t numMfmas = tileShape[0]*tileShape[1]*mfmasPerRep[0]*mfmasPerRep[1]*mfmasPerRep[2];
+  int64_t numMfmas = tileShape[0] * tileShape[1] * mfmasPerRep[0] *
+                     mfmasPerRep[1] * mfmasPerRep[2];
   int64_t mfmaCycles = numMfmas * cyclesPerMfma;
-  int64_t numLoads = tileShape[0]*mfmasPerRep[0] + tileShape[1]*mfmasPerRep[1];
+  int64_t numLoads =
+      tileShape[0] * mfmasPerRep[0] + tileShape[1] * mfmasPerRep[1];
   int64_t loadIssueCycles = numLoads * localLoadIssueRate;
   // Keep on increasing the dimension of the tile
   while (mfmaCycles < loadIssueCycles || mfmaCycles < localLoadDataLatency) {
-    if ((tileShape[0]*mfmasPerRep[0] < tileShape[1]*mfmasPerRep[1])
-        || ((tileShape[0]*mfmasPerRep[0] == tileShape[1]*mfmasPerRep[1]) && preferLargerM)) {
+    if ((tileShape[0] * mfmasPerRep[0] < tileShape[1] * mfmasPerRep[1]) ||
+        ((tileShape[0] * mfmasPerRep[0] == tileShape[1] * mfmasPerRep[1]) &&
+         preferLargerM)) {
       tileShape[0] *= 2;
     } else {
       tileShape[1] *= 2;
     }
-    numMfmas = tileShape[0]*tileShape[1]*mfmasPerRep[0]*mfmasPerRep[1]*mfmasPerRep[2];
+    numMfmas = tileShape[0] * tileShape[1] * mfmasPerRep[0] * mfmasPerRep[1] *
+               mfmasPerRep[2];
     mfmaCycles = numMfmas * cyclesPerMfma;
-    numLoads = tileShape[0]*mfmasPerRep[0]+tileShape[1]*mfmasPerRep[1];
+    numLoads = tileShape[0] * mfmasPerRep[0] + tileShape[1] * mfmasPerRep[1];
     loadIssueCycles = numLoads * localLoadIssueRate;
   };
   return tileShape;
 }
 
 /*
-  DotTiling creates tiles of mfmas while they are decomposed from a dot operation.
-  A tile of mfmas is a set of mfmas that will be co-scheduled
-  because they use the same A,B operands; co-scheduling mfmas with same operands
-  allows finer control over prefetching from LDS and register usage for these operands.
+  DotTiling creates tiles of mfmas while they are decomposed from a dot
+  operation. A tile of mfmas is a set of mfmas that will be co-scheduled because
+  they use the same A,B operands; co-scheduling mfmas with same operands allows
+  finer control over prefetching from LDS and register usage for these operands.
   Args:
    - inputNumRepM - total number of [decomposed] dot ops along m.
    - inputNumRepN - total number of [decomposed] dot ops along n.
    - inputTileShapeM - number of [decomposed] dot ops along m per tile.
    - inputTileShapeN - number of [decomposed] dot ops along n per tile.
-   - inputOuterLoopM - should be set to (warpTileM >= warpTileN). True means m should be
-       outer loop of mfma ops so that inner loop is smaller dimension which leads to smallest
-       number of registers carrying A,B operands.
-  E.g. numRep = 8x4, tileShape=2x2.
+   - inputOuterLoopM - should be set to (warpTileM >= warpTileN). True means m
+  should be outer loop of mfma ops so that inner loop is smaller dimension which
+  leads to smallest number of registers carrying A,B operands. E.g. numRep =
+  8x4, tileShape=2x2.
 */
 struct DotTileOrder {
   const int numRepM;
@@ -196,15 +197,11 @@ struct DotTileOrder {
   int tileShapeInner;
   int numTilesOuter;
   int numTilesInner;
-  explicit DotTileOrder(int inputNumRepM, int inputNumRepN,
-                     int inputTileShapeM, int inputTileShapeN,
-                     bool inputOuterLoopM)
-      : numRepM(inputNumRepM),
-        numRepN(inputNumRepN),
-        tileShapeM(inputTileShapeM),
-        tileShapeN(inputTileShapeN),
-        numTilesM(numRepM / tileShapeM),
-        numTilesN(numRepN / tileShapeN),
+  explicit DotTileOrder(int inputNumRepM, int inputNumRepN, int inputTileShapeM,
+                        int inputTileShapeN, bool inputOuterLoopM)
+      : numRepM(inputNumRepM), numRepN(inputNumRepN),
+        tileShapeM(inputTileShapeM), tileShapeN(inputTileShapeN),
+        numTilesM(numRepM / tileShapeM), numTilesN(numRepN / tileShapeN),
         outerTileM(inputOuterLoopM) {
     // Num mfmas must evenly divide into tiles.
     assert(numTilesM * tileShapeM == numRepM);
@@ -242,15 +239,9 @@ struct DotTileOrder {
       return tileOuterIdx * tileShapeOuter; // N is outer tile loop.
     }
   }
-  int getNumTilesM() const {
-    return numTilesM;
-  }
-  int getNumTilesN() const {
-    return numTilesN;
-  }
-  int getOuterTileM() const {
-    return outerTileM;
-  }
+  int getNumTilesM() const { return numTilesM; }
+  int getNumTilesN() const { return numTilesN; }
+  int getOuterTileM() const { return outerTileM; }
 };
 
 } // namespace

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -1,0 +1,236 @@
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
+#include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-refine-ops"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+namespace {
+/*
+ TODO - this needs to be MUCH more official.
+*/
+unsigned calcCyclesPerMfma(AMDMfmaEncodingAttr mfmaLayout, DotOp dotOp) {
+  // Get mfma op type.
+  Value a = dotOp.getA();
+  Value b = dotOp.getB();
+  auto aTensorTy = cast<RankedTensorType>(a.getType());
+  auto bTensorTy = cast<RankedTensorType>(b.getType());
+  auto elemTyA = aTensorTy.getElementType();
+  auto elemTyB = bTensorTy.getElementType();
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  auto mfmaVersion = mfmaLayout.getVersionMajor();
+  bool allowXF32 =
+      dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
+  auto maybeMfmaInsn = MfmaInsn::selectMfma(mDim, nDim, elemTyA, elemTyB,
+                                              mfmaVersion, allowXF32);
+  if (failed(maybeMfmaInsn))
+    llvm::report_fatal_error("No match found in MFMA database\n");
+  // Estimate rate of mfma op type.
+  unsigned maxBitWidth = std::max(maybeMfmaInsn->getElementTypeA().getIntOrFloatBitWidth(),
+                                  maybeMfmaInsn->getElementTypeB().getIntOrFloatBitWidth());
+  // Estimate throughput as fma's per cycle.
+  unsigned opsPerCycle;
+  if (maxBitWidth <= 8) { // fp8, bf8, i8
+    opsPerCycle = 512;
+  } else if (maxBitWidth <= 16) { // fp16, bf16
+    opsPerCycle = 256;
+  } else if (maxBitWidth <= 32) { // fp32
+    opsPerCycle = 128;
+  } else {
+    opsPerCycle = 64; // fp64
+  }
+  // total floating point mfmas
+  int64_t totalOps = maybeMfmaInsn->getMDim()
+      * maybeMfmaInsn->getNDim()
+      * maybeMfmaInsn->getKDim();
+  unsigned cyclesPerMfma = static_cast<unsigned>(totalOps / opsPerCycle);
+  llvm::outs() << maybeMfmaInsn->getInsnName() << " = " << cyclesPerMfma << " cycles\n";
+  return cyclesPerMfma;
+}
+
+/*
+Calculate how many mfmas are in a rep, e.g. 1x1x2.
+// TODO - is there a more direct method for this?
+*/
+SmallVector<unsigned, 3> calcMfmasPerRep(
+    SmallVector<int64_t> ctaTile,
+    SmallVector<unsigned> warpsPerCta,
+    SmallVector<int64_t> numReps,
+    SmallVector<unsigned> mfmaShape
+) {
+  // Tile size per warp.
+  SmallVector<int64_t, 3> warpTile = {
+    ctaTile[0] / warpsPerCta[0],
+    ctaTile[1] / warpsPerCta[1],
+    ctaTile[2],
+  };
+  // Tile size per rep.
+  SmallVector<int64_t, 3> repTile = {
+    warpTile[0] / numReps[0],
+    warpTile[1] / numReps[1],
+    warpTile[2] / numReps[2],
+  };
+  SmallVector<unsigned, 3> mfmasPerRep = {
+    static_cast<unsigned>(repTile[0] / mfmaShape[0]),
+    static_cast<unsigned>(repTile[1] / mfmaShape[1]),
+    static_cast<unsigned>(repTile[2] / mfmaShape[2])};
+  return mfmasPerRep;
+}
+
+// TODO(guacamoleo) - we also need to detect whether the a or b operands of a tile are already loaded
+// into registers, e.g. for FA, and we want to choose the tile shape (small improvement)
+// and tile order (rows vs colums which will be a large improvement).
+
+/*
+ Returns the dot tile size (in number of reps, not number of mfmas);
+ typical sizes when mfmasPerRep = 1x1x2 for b128 and localLoadIssueRate=32 for b128
+ 2x2 for fp16 (128 mfma cycles per tile) and
+ 4x4 for fp8 (256 mfma cycles per tile).
+ 
+ Tile size is chosen so that
+ (1) A tile's worth of local_load_a or local_load_b can 
+     can be issued during a tile's worth of mfmas, and
+ (2) A tile's worth of mfmas hides the ds_read data latency.
+ Args:
+  - mfmasPerRep - 3D shape of number of mfmas in decomposed dot, e.g. 1x1x2.
+  - preferLargerM - prefer M > N if not square.
+  - cyclesPerMfma - how many cycles does mfma take in total.
+  - localLoadIssueRate - cycles between issuing consecutive ds_reads to not overrun hardware queues.
+      This is estimated to be b128 -> 32 cycles, b64 -> 16 cycles, b32 -> 8 cycles.
+  - localLoadDataLatency - cycles between issuing ds_read and waiting for data; rounded up to pow2.
+  Notes:
+  The intended scheduling of tiles-of-reps-of-mfmas is 
+  --------------------------------
+  local_load_a[n]
+  MFMA_Tile[n-3] // a can be loaded during tile
+  --------------------------------
+  local_load_b[n]
+  MFMA_Tile[n-2] // b can be loaded during tile
+  --------------------------------
+  MFMA_Tile[n-1] // load data latency hiding
+  --------------------------------
+  MFMA_Tile[n] // all a,b data is ready by the first mfma of tile.
+  --------------------------------
+  This can be further refined if the data latency becomes much larger than
+  the issue rate; in this case we can remove the condition that one tile
+  hides all the data latency (which could make the tiles huge and waste registers),
+  and intead local load issue rate is the only criteria and we retroactively calculate
+  how many tiles are needed to hide the data latency.
+*/
+SmallVector<unsigned, 2> calcDotTileSize(
+  SmallVector<unsigned, 3> mfmasPerRep, // = 16x16x64 / 16x16x32 = 1x1x2; served by 1 a,b load
+  bool preferLargerM,
+  unsigned cyclesPerMfma = 8,
+  unsigned localLoadIssueRate = 32,
+  unsigned localLoadDataLatency = 128
+) {
+  SmallVector<unsigned, 2> tileSize = {1, 1};
+  int64_t numMfmas = tileSize[0]*tileSize[1]*mfmasPerRep[0]*mfmasPerRep[1]*mfmasPerRep[2];
+  int64_t mfmaCycles = numMfmas * cyclesPerMfma;
+  int64_t numLoads = std::max(tileSize[0]*mfmasPerRep[0], tileSize[1]*mfmasPerRep[1]);
+  int64_t loadIssueCycles = numLoads * localLoadIssueRate;
+  while (mfmaCycles < loadIssueCycles || mfmaCycles < localLoadDataLatency) {
+    if (tileSize[0]*mfmasPerRep[0] < tileSize[1]*mfmasPerRep[1] || preferLargerM) {
+      tileSize[0] *= 2;
+    } else {
+      tileSize[1] *= 2;
+    }
+    numMfmas = tileSize[0]*tileSize[1]*mfmasPerRep[0]*mfmasPerRep[1]*mfmasPerRep[2];
+    mfmaCycles = numMfmas * cyclesPerMfma;
+    numLoads = tileSize[0]*mfmasPerRep[0]+tileSize[1]*mfmasPerRep[1];
+    loadIssueCycles = numLoads * localLoadIssueRate;
+  };
+  return tileSize;
+}
+
+/*
+  DotTiling creates tiles of mfmas while they are decomposed from a dot operation.
+  A tile of mfmas is a set of mfmas that will be co-scheduled
+  because they use the same A,B operands; co-scheduling mfmas with same operands
+  allows finer control over prefetching from LDS and register usage for these operands.
+  Args:
+   - inputNumRepM - total number of [decomposed] dot ops along m.
+   - inputNumRepN - total number of [decomposed] dot ops along n.
+   - inputTileSizeM - number of [decomposed] dot ops along m per tile.
+   - inputTileSizeN - number of [decomposed] dot ops along n per tile.
+   - inputOuterLoopM - should be set to (warpTileM >= warpTileN). True means m should be
+       outer loop of mfma ops so that inner loop is smaller dimension which leads to smallest
+       number of registers carrying A,B operands.
+  E.g. numRep = 8x4, tileSize=2x2.
+*/
+struct DotTileOrder {
+  const int numRepM;
+  const int numRepN;
+  const int tileSizeM;
+  const int tileSizeN;
+  const int numTilesM;
+  const int numTilesN;
+  bool outerTileM;
+  int tileSizeOuter;
+  int tileSizeInner;
+  int numTilesOuter;
+  int numTilesInner;
+  explicit DotTileOrder(int inputNumRepM, int inputNumRepN,
+                     int inputTileSizeM, int inputTileSizeN,
+                     bool inputOuterLoopM)
+      : numRepM(inputNumRepM),
+        numRepN(inputNumRepN),
+        tileSizeM(inputTileSizeM),
+        tileSizeN(inputTileSizeN),
+        numTilesM(numRepM / tileSizeM),
+        numTilesN(numRepN / tileSizeN),
+        outerTileM(inputOuterLoopM) {
+    // Num mfmas must evenly divide into tiles.
+    assert(numTilesM * tileSizeM == numRepM);
+    assert(numTilesN * tileSizeN == numRepN);
+    // Assign M and N to be outer vs inner tile loop.
+    if (outerTileM) {
+      // M is tile of outer loop.
+      tileSizeOuter = tileSizeM;
+      tileSizeInner = tileSizeN;
+      numTilesOuter = numTilesM;
+      numTilesInner = numTilesN;
+    } else {
+      // N is tile of outer loop.
+      tileSizeOuter = tileSizeN;
+      tileSizeInner = tileSizeM;
+      numTilesOuter = numTilesN;
+      numTilesInner = numTilesM;
+    }
+  }
+  int getTileSizeM() const { return tileSizeM; }
+  int getTileSizeN() const { return tileSizeN; }
+  int getNumTilesOuter() const { return numTilesOuter; }
+  int getNumTilesInner() const { return numTilesInner; }
+  int getTileStartM(int tileOuterIdx, int tileInnerIdx) const {
+    if (outerTileM) {
+      return tileOuterIdx * tileSizeOuter; // M is outer tile loop.
+    } else {
+      return tileInnerIdx * tileSizeInner; // M is inner tile loop.
+    }
+  }
+  int getTileStartN(int tileOuterIdx, int tileInnerIdx) const {
+    if (outerTileM) {
+      return tileInnerIdx * tileSizeInner; // N is inner tile loop.
+    } else {
+      return tileOuterIdx * tileSizeOuter; // N is outer tile loop.
+    }
+  }
+};
+
+} // namespace

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -20,6 +20,7 @@
 // #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -176,7 +177,6 @@ struct DotOpMFMAConverter {
         ctx(mfmaLayout.getContext()) {}
 
   LogicalResult convert(DotOp dotOp, DotOpAdaptor adaptor) const {
-
     InputPrecisionAttr precisionAttr = dotOp.getInputPrecisionAttr();
     auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
     auto mDim = mfmaLayout.getMDim();
@@ -210,7 +210,6 @@ struct DotOpMFMAConverter {
     int kWidth = encodeA.getKWidth();
     auto repA = mfmaLayout.getRepForOperand(aTensorTy.getShape(), kWidth, 0);
     auto repB = mfmaLayout.getRepForOperand(bTensorTy.getShape(), kWidth, 1);
-
     assert(repA[2] == repB[1]);
 
     Value loadedA = adaptor.getA();
@@ -219,80 +218,154 @@ struct DotOpMFMAConverter {
 
     const auto numRepM = repA[1];
     const auto numRepN = repB[2];
+    const auto numRepK = repA[2];
     const auto numRepB = repA[0];
+    SmallVector<int64_t> numRepShape = {numRepM , numRepN , numRepK };
 
-    LDBG("numRepM: " << numRepM << "; numRepN: " << numRepN
-                     << "; numRepB: " << numRepB);
+    SmallVector<int64_t> refinedShapeA = {shapeA[0] / numRepM, shapeA[1] / numRepK};
+    SmallVector<int64_t> refinedShapeB = {shapeB[0] / numRepK, shapeB[1] / numRepN};
+    SmallVector<int64_t> refinedShapeCD = {shapeC[0] / numRepM, shapeC[1] / numRepN};
 
-    constexpr int M = 0;
-    constexpr int N = 1;
+    // Calculate mfmas per rep.
+    SmallVector<int64_t> ctaTile = {shapeC[0], shapeC[1], shapeA[1]};
+    SmallVector<int64_t> warpTile = {
+      shapeC[0] / warpsPerCTA[0],
+      shapeC[1] / warpsPerCTA[1],
+      shapeA[1],
+      };
+    auto mfmaVersion = mfmaLayout.getVersionMajor();
+    bool allowXF32 =
+        dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
+    auto maybeMfmaInsn = MfmaInsn::selectMfma(mDim, nDim, elemTyA, elemTyB,
+                                              mfmaVersion, allowXF32);
+    if (failed(maybeMfmaInsn))
+      llvm::report_fatal_error("No match found in MFMA database\n");
+    SmallVector<unsigned> mfmaShape = {
+      maybeMfmaInsn->getMDim(),
+      maybeMfmaInsn->getNDim(),
+      maybeMfmaInsn->getKDim()};
 
-    SmallVector<int64_t> refinedShapeA = {shapeA[M] / numRepM, shapeA[N]};
-    SmallVector<int64_t> refinedShapeB = {shapeB[M], shapeB[N] / numRepN};
-    SmallVector<int64_t> refinedShapeCD = {shapeC[M] / numRepM,
-                                           shapeC[N] / numRepN};
+    auto mfmasPerRep = calcMfmasPerRep(
+        ctaTile,
+        warpsPerCTA,
+        numRepShape,
+        mfmaShape);
+    llvm::outs() << "mfmasPerRep: "
+      << mfmasPerRep[0] << "x"
+      << mfmasPerRep[1] << "x"
+      << mfmasPerRep[2] << "\n";
 
-    SmallVector<int64_t> elementsPerSlice = {refinedShapeCD[0],
-                                             refinedShapeCD[1]};
+    // Calculate Dot-Tiling.
+    unsigned cyclesPerMfma = calcCyclesPerMfma(mfmaLayout, dotOp);
+    // Prefer tile to be skinny along inner loop dimension to minimize registers.
+    const bool preferOuterLoopM (warpTile[0] >= warpTile[1]);
+    const bool preferTileLargerM = !preferOuterLoopM;
+    // Calculate dot-tile size (in reps per tile).
+    auto tileSize = calcDotTileSize(mfmasPerRep, preferTileLargerM, cyclesPerMfma);
 
-    auto refinedTensorTypeA =
+    llvm::outs() << "mfmasPerTile: "
+        << tileSize[0] * mfmasPerRep[0] << "x"
+        << tileSize[1] * mfmasPerRep[1] << "x"
+        <<           1 * mfmasPerRep[2] << "\n";
+    const int tileSizeM = tileSize[0];
+    const int tileSizeN = tileSize[1];
+    const DotTileOrder dotTileOrder(numRepM, numRepN, tileSizeM, tileSizeM, preferOuterLoopM);
+
+    // Extract slices for A operands.
+    int64_t elementsPerSliceM = refinedShapeCD[0];
+    int64_t elementsPerSliceN = refinedShapeCD[1];
+    int64_t elementsPerSliceK = refinedShapeA[1];
+    auto extractSliceTypeA =
         RankedTensorType::get(refinedShapeA, elemTyA, encodeA);
-    auto refinedTensorTypeB =
+    rewriter.setInsertionPointAfter(dotOp);
+    SmallVector<SmallVector<amdgpu::ExtractSliceOp>> subtilesA;
+    unsigned tileIdx = 0;
+    for (int32_t k = 0; k < numRepK; ++k) {
+      SmallVector<amdgpu::ExtractSliceOp> subtilesK;
+      for (int32_t i = 0; i < numRepM; ++i) {
+        int32_t shiftM = i * elementsPerSliceM;
+        int32_t shiftK = k * elementsPerSliceK;
+        auto extract = rewriter.create<amdgpu::ExtractSliceOp>(
+          loc, Type{extractSliceTypeA}, Value{a},
+          DenseI64ArrayAttr::get(ctx, {shiftM, shiftK})
+          );
+        subtilesK.push_back(extract);
+      }
+      subtilesA.push_back(subtilesK);
+    }
+
+    // Extract slices for B operands.
+    auto extractSliceTypeB =
         RankedTensorType::get(refinedShapeB, elemTyB, encodeB);
+    SmallVector<SmallVector<amdgpu::ExtractSliceOp>> subtilesB;
+    tileIdx = 0;
+    for (int32_t k = 0; k < numRepK; ++k) {
+      SmallVector<amdgpu::ExtractSliceOp> subtilesK;
+      for (int32_t j = 0; j < numRepN; ++j) {
+        int32_t shiftN = j * elementsPerSliceN;
+        int32_t shiftK = k * elementsPerSliceK;
+        auto extract = rewriter.create<amdgpu::ExtractSliceOp>(
+          loc, Type{extractSliceTypeB}, Value{b},
+          DenseI64ArrayAttr::get(ctx, {shiftK, shiftN}));
+        subtilesK.push_back(extract);
+      }
+      subtilesB.push_back(subtilesK);
+    }
+
+    // Create refined dot ops in dot-tiles.
     auto refinedTensorTypeC =
         RankedTensorType::get(refinedShapeCD, elemTyC, encodeC);
     auto refinedTensorTypeD =
         RankedTensorType::get(refinedShapeCD, elemTyD, encodeD);
-
-    constexpr bool mutableMemory = true;
-    auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
-
-    auto extractSliceTypeA =
-        RankedTensorType::get(refinedShapeA, elemTyA, encodeA);
-
-    auto extractSliceTypeB =
-        RankedTensorType::get(refinedShapeB, elemTyB, encodeB);
-
-    rewriter.setInsertionPoint(dotOp);
-    SmallVector<ttg::LocalLoadOp> subtilesA;
-    SmallVector<amdgpu::ExtractSliceOp> extractedTilesA;
-    for (int32_t i = 0; i < numRepM; ++i) {
-      int64_t shift = i * elementsPerSlice[M];
-      auto extract = rewriter.create<amdgpu::ExtractSliceOp>(
-          loc, Type{extractSliceTypeA}, Value{a},
-          DenseI64ArrayAttr::get(ctx, {shift, 0}));
-      extractedTilesA.push_back(extract);
-    }
-
-    // rewriter.setInsertionPointAfter(localLoadB);
-    SmallVector<ttg::LocalLoadOp> subtilesB;
-    SmallVector<amdgpu::ExtractSliceOp> extractedTilesB;
-    for (int32_t i = 0; i < numRepN; ++i) {
-      int32_t shift = i * elementsPerSlice[N];
-      auto extract = rewriter.create<amdgpu::ExtractSliceOp>(
-          loc, Type{extractSliceTypeB}, Value{b},
-          DenseI64ArrayAttr::get(ctx, {0, shift}));
-      extractedTilesB.push_back(extract);
-    }
-
-    rewriter.setInsertionPointAfter(dotOp);
-    auto dotAttrs = dotOp->getAttrs();
     SmallVector<Value> refinedDotValues;
-    for (int32_t m = 0; m < numRepM; ++m) {
-      for (int32_t n = 0; n < numRepN; ++n) {
-        SmallVector<int64_t> offset = {m * elementsPerSlice[M],
-                                       n * elementsPerSlice[N]};
-        auto refinedTensorC = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-            loc, Type{refinedTensorTypeC}, Value{c}, offset);
-
-        auto refinedTensorA = extractedTilesA[m];
-        auto refinedTensorB = extractedTilesB[n];
-
-        auto result = rewriter.create<tt::DotOp>(
-            loc, refinedTensorTypeD,
-            ValueRange{refinedTensorA, refinedTensorB, refinedTensorC},
-            dotAttrs);
-        refinedDotValues.push_back(result);
+    // Extract slices for first "C" opds.
+    for (int tileOuterIdx = 0; tileOuterIdx < dotTileOrder.getNumTilesOuter(); ++tileOuterIdx) {
+      for (int tileInnerIdx = 0; tileInnerIdx < dotTileOrder.getNumTilesInner(); ++tileInnerIdx) {
+        const int tileStartM = dotTileOrder.getTileStartM(tileOuterIdx, tileInnerIdx);
+        const int tileStartN = dotTileOrder.getTileStartN(tileOuterIdx, tileInnerIdx);
+        for (int m = tileStartM; m < tileStartM + tileSizeM; ++m) {
+          for (int n = tileStartN; n < tileStartN + tileSizeN; ++n) {
+            SmallVector<int64_t> offset = {m * elementsPerSliceM,
+                                           n * elementsPerSliceN};
+            auto refinedTensorC = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+                loc, Type{refinedTensorTypeC}, Value{c}, offset);
+            refinedDotValues.push_back(refinedTensorC);
+          }
+        }
+      }
+    }
+    auto dotAttrs = dotOp->getAttrs();
+    int32_t tileSerial = 0;
+    // Iterate over dot-tiles.
+    for (int32_t k = 0; k < numRepK; ++k) {
+      for (int tileOuterIdx = 0; tileOuterIdx < dotTileOrder.getNumTilesOuter(); ++tileOuterIdx) {
+        for (int tileInnerIdx = 0; tileInnerIdx < dotTileOrder.getNumTilesInner(); ++tileInnerIdx) {
+          const int tileStartM = dotTileOrder.getTileStartM(tileOuterIdx, tileInnerIdx);
+          const int tileStartN = dotTileOrder.getTileStartN(tileOuterIdx, tileInnerIdx);
+          int32_t elementSerial = 0;
+          // Iterate over dots within dot-tile.
+          for (int m = tileStartM; m < tileStartM + tileSizeM; ++m) {
+            for (int n = tileStartN; n < tileStartN + tileSizeN; ++n) {
+              int32_t tileM = tileStartM / tileSizeM;
+              int32_t tileN = tileStartN / tileSizeN;
+              int32_t tileK = k;
+              int32_t elementM = m - tileStartM;
+              int32_t elementN = n - tileStartN;
+              int32_t elementK = 0;
+              auto dotTileAttr = triton::amdgpu::DotTileAttr::get(ctx, tileM, tileN, tileK, tileSerial, elementM, elementN, elementK, elementSerial);
+              auto refinedTensorA = subtilesA[k][m];
+              auto refinedTensorB = subtilesB[k][n];
+              auto dotOp = rewriter.create<tt::DotOp>(
+                  loc, refinedTensorTypeD,
+                  ValueRange{refinedTensorA, refinedTensorB,
+                  refinedDotValues[int32_t(m*numRepN+n)]}, dotAttrs);
+              dotOp->setAttr(triton::amdgpu::DotTileAttr::getMnemonic(), dotTileAttr);
+              refinedDotValues[int32_t(m*numRepN+n)] = dotOp;
+              elementSerial++;
+            }
+          }
+          tileSerial++;
+        }
       }
     }
 
@@ -490,9 +563,9 @@ struct TritonAMDGPURefineOps
   }
 
   void runOnOperation() override {
+    llvm::outs() << "TritonAMDGPURefineOps::runOnOperation()\n";
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
-
     mlir::triton::AMD::TargetInfo targetInfo(this->arch.getValue());
     if (targetInfo.getISAFamily() == mlir::triton::AMD::ISAFamily::Unknown) {
       mod.emitError("unsupported target: '") << this->arch.getValue() << "'";
@@ -515,29 +588,29 @@ struct TritonAMDGPURefineOps
       });
 
       block->walk([&](triton::DotOp dotOp) {
-        OpBuilder rewriter(dotOp->getContext());
-        // TODO: extend to WMMA instructions
-        if (failed(rewriteMFMA(rewriter, dotOp))) {
-          LDBG("failed to refine tt.dotOp: " << *dotOp);
-        }
-      });
+          OpBuilder rewriter(dotOp->getContext());
+          // TODO: extend to WMMA instructions
+          if (failed(rewriteMFMA(rewriter, dotOp))) {
+            LDBG("failed to refine tt.dotOp: " << *dotOp);
+          }
+        });
 
       block->walk([&](triton::LoadOp loadOp) {
-        OpBuilder rewriter(loadOp->getContext());
+          OpBuilder rewriter(loadOp->getContext());
         if (loadOp->getNumOperands() == 1) {
-          if (failed(rewriteLoadOp(rewriter, loadOp))) {
-            LDBG("failed to refine tt.loadOp: " << *loadOp);
+            if (failed(rewriteLoadOp(rewriter, loadOp))) {
+              LDBG("failed to refine tt.loadOp: " << *loadOp);
           }
-        }
-      });
+            }
+        });
 
       block->walk([&](triton::gpu::LocalStoreOp storeOp) {
-        OpBuilder rewriter(storeOp->getContext());
+          OpBuilder rewriter(storeOp->getContext());
         if (storeOp->getNumOperands() == 2) {
-          if (failed(rewriteLocalStoreOp(rewriter, storeOp))) {
-            LDBG("failed to refine ttg.localLoadOp: " << *storeOp);
-          }
-        }
+            if (failed(rewriteLocalStoreOp(rewriter, storeOp))) {
+              LDBG("failed to refine ttg.localLoadOp: " << *storeOp);
+            }
+      }
       });
       return WalkResult::advance();
     });

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -361,7 +361,8 @@ struct TritonAMDGPURescheduleOps
      - Determine memory ops' supported issue rate.
      - Place performance and anti-dependencies between memory ops and dots.
      - Run scheduler with new dependencies in place.
-    Note that rescheduling can be run after any new dependencies are created to visualize graph.
+    Note that rescheduling can be run after any new dependencies are created to
+    visualize graph.
   */
   void reschedule(Block *mlirBlock) {
 


### PR DESCRIPTION
Adding dot-tiling to decomposeMFMA(), including calculating the shape and order of dot-tiling, creating the dots in tiled order and adding DotTileAttr to convey the dot's structural information through the IR to the scheduling passes.

The decomposed dots and extract_slices of the A,B operands are given DotTile attributes. It will be later required by canonicalization to pass the DotTile attribute from the extract_slice across the concat to the local_load. This will enable the schedulers' analysis and dependency passes to directly see the relationship between dots and local_loads.

---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
