### PR TITLE
Fix pid remapping logic when GRID_MN cannot divide NUM_XCDS

### DIFF
--- a/python/perf-kernels/tools/occ.sh
+++ b/python/perf-kernels/tools/occ.sh
@@ -39,8 +39,8 @@ get_occ_per_CU() {
 
 $1 > output.mlir 2>&1
 
-LDS_line=$(sed -n '/triton_gpu\.shared\ /p' output.mlir | tail -n 1 | grep -o 'triton_gpu.shared = [0-9]*')
-numWarps_line=$(sed -n '/triton_gpu\.num-warps/p' output.mlir | tail -n 1 | grep -o 'triton_gpu.num-warps. = [0-9]*')
+LDS_line=$(sed -n '/ttg\.shared\ /p' output.mlir | tail -n 1 | grep -o 'ttg.shared = [0-9]*')
+numWarps_line=$(sed -n '/ttg\.num-warps/p' output.mlir | tail -n 1 | grep -o 'ttg.num-warps. = [0-9]*')
 
 LDS=${LDS_line##*=}
 num_warps=${numWarps_line##*=}


### PR DESCRIPTION
https://github.com/ROCm/triton/pull/713 does not fix all the issues. This PR fixed the correctness issue of the following config

```yaml
- {'M': 1280, 'N': 512, 'K': 4160, 'rowMajorA': 'T', 'rowMajorB': 'N', 'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 8, 'num_stages': 2, 'waves_per_eu': 0, 'matrix_instr_non\
kdim': 16, 'kpack': 2, 'instruction_sched_variant': "none"}
```

This PR also fixed the issue with occ.sh due to recent upstream change from triton_gpu to ttg.