### PR TITLE
DotTiling to handle invalid configurations more robustly.

### DIFF
--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -207,7 +207,8 @@ calcDotTileShape(const SmallVector<unsigned, 3>
   bool localLoadIssueExposed = true;
 
   // Try a finite number of times to increase the TileShape meet performance criteria.
-  int maxTries = 12; // sufficient to create 64x64 tile.
+  // TODO - possibly need to refactor loop bounds before production ready.
+  constexpr int maxTries = 12; // sufficient to create 64x64 tile.
   for (int i = 0; i < maxTries; ++i) {
     // If TileShape meets performance criteria, return.
     if (!(localLoadDataLatencyExposed || localLoadRateExposed || localLoadIssueExposed)) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -278,8 +278,6 @@ struct DotOpMFMAConverter {
 
     auto mfmasPerRep =
         getMfmasPerRep(ctaTile, warpsPerCTA, numRepShape, mfmaShape);
-    LDBG("mfmasPerRep: " << mfmasPerRep[0] << "x" << mfmasPerRep[1] << "x"
-                         << mfmasPerRep[2]);
 
     // Calculate Dot-Tiling.
     unsigned cyclesPerMfma = getCyclesPerMfma(dotOp);


### PR DESCRIPTION
DotTiling to handle invalid combination of input parameters by returning a default tile shape.
DotTiling to use only a fixed number of iterations to calculate ideal DotTileShape; no infinite loops.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
