### PR TITLE
[AMD] adjusted refined `tt.dot` order for scheduling

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
@@ -101,8 +101,8 @@ def TritonAMDGPU_DotTile : TritonAMDGPU_Attr<"DotTile"> {
     while the element{M,N,K,Serial} refer to the element's id within the dot-tile.
 
   }];
-  let parameters = (ins "int32_t":$tileM, "int32_t":$tileN, "int32_t":$tileK, "uint32_t":$tileSerial, "int32_t":$elementM, "int32_t":$elementN, "int32_t":$elementK, "uint32_t":$elementSerial );
-  let assemblyFormat = "`<` $tileM `,` $tileN `,` $tileK `>` `[` $tileSerial `]` `,` `<` $elementM `,` $elementN `,` $elementK `>` `[` $elementSerial `]`";
+  let parameters = (ins "int32_t":$dotIndex, "int32_t":$tileM, "int32_t":$tileN, "int32_t":$tileK, "uint32_t":$tileSerial, "int32_t":$elementM, "int32_t":$elementN, "int32_t":$elementK, "uint32_t":$elementSerial );
+  let assemblyFormat = "`<` `[` $dotIndex `]` $tileM `,` $tileN `,` $tileK `>` `[` $tileSerial `]` `,` `<` $elementM `,` $elementN `,` $elementK `>` `[` $elementSerial `]`";
 }
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -185,13 +185,15 @@ LogicalResult rewriteLocalLoad(OpBuilder &rewriter,
 struct DotOpMFMAConverter {
   AMDMfmaEncodingAttr mfmaLayout;
   OpBuilder &rewriter;
+  int32_t dotIndex;
   Location loc;
   MLIRContext *ctx{};
 
   explicit DotOpMFMAConverter(AMDMfmaEncodingAttr mfmaLayout,
-                              OpBuilder &rewriter, Location loc)
-      : mfmaLayout(mfmaLayout), rewriter(rewriter), loc(loc),
-        ctx(mfmaLayout.getContext()) {}
+                              OpBuilder &rewriter, int32_t dotIndex,
+                              Location loc)
+      : mfmaLayout(mfmaLayout), rewriter(rewriter), dotIndex(dotIndex),
+        loc(loc), ctx(mfmaLayout.getContext()) {}
 
   LogicalResult convert(DotOp dotOp, DotOpAdaptor adaptor) const {
     InputPrecisionAttr precisionAttr = dotOp.getInputPrecisionAttr();
@@ -339,8 +341,8 @@ struct DotOpMFMAConverter {
         int32_t elementSerial =
             elementM * tileShapeN; // dots are n-major within tile
         auto dotTileAttr = triton::amdgpu::DotTileAttr::get(
-            ctx, tileM, tileN, tileK, tileSerial, elementM, elementN, elementK,
-            elementSerial);
+            ctx, dotIndex, tileM, tileN, tileK, tileSerial, elementM, elementN,
+            elementK, elementSerial);
         extract->setAttr(triton::amdgpu::DotTileAttr::getMnemonic(),
                          dotTileAttr);
         subtilesK.push_back(extract);
@@ -377,8 +379,8 @@ struct DotOpMFMAConverter {
         int32_t elementK = k % tileShapeK;
         int32_t elementSerial = elementN; // dots are n-major within tile
         auto dotTileAttr = triton::amdgpu::DotTileAttr::get(
-            ctx, tileM, tileN, tileK, tileSerial, elementM, elementN, elementK,
-            elementSerial);
+            ctx, dotIndex, tileM, tileN, tileK, tileSerial, elementM, elementN,
+            elementK, elementSerial);
         extract->setAttr(triton::amdgpu::DotTileAttr::getMnemonic(),
                          dotTileAttr);
         subtilesK.push_back(extract);
@@ -437,8 +439,8 @@ struct DotOpMFMAConverter {
                 int32_t elementN = n - tileStartN;
                 int32_t elementK = 0;
                 auto dotTileAttr = triton::amdgpu::DotTileAttr::get(
-                    ctx, tileM, tileN, tileK, tileSerial, elementM, elementN,
-                    elementK, elementSerial);
+                    ctx, dotIndex, tileM, tileN, tileK, tileSerial, elementM,
+                    elementN, elementK, elementSerial);
                 dotOp->setAttr(triton::amdgpu::DotTileAttr::getMnemonic(),
                                dotTileAttr);
                 refinedDotValues[int32_t(m * numRepN + n)] = dotOp;
@@ -468,7 +470,8 @@ inline RankedTensorType rankedTType(Value tensor) {
   return cast<RankedTensorType>(tensor.getType());
 };
 
-LogicalResult rewriteMFMA(OpBuilder &rewriter, triton::DotOp op) {
+LogicalResult rewriteMFMA(OpBuilder &rewriter, triton::DotOp op,
+                          int32_t dotIndex) {
   if (!(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
         isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()))) {
     LDBG("Both $a and %b should be DotOperand layout");
@@ -492,7 +495,7 @@ LogicalResult rewriteMFMA(OpBuilder &rewriter, triton::DotOp op) {
   auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
       cast<RankedTensorType>(op.getResult().getType()).getEncoding());
 
-  DotOpMFMAConverter converter(mfmaLayout, rewriter, loc);
+  DotOpMFMAConverter converter(mfmaLayout, rewriter, dotIndex, loc);
   return converter.convert(op, DotOpAdaptor(op));
 }
 
@@ -668,12 +671,14 @@ struct TritonAMDGPURefineOps
         }
       });
 
+      int32_t dotIndex = 0;
       block->walk([&](triton::DotOp dotOp) {
         OpBuilder rewriter(dotOp->getContext());
         // TODO: extend to WMMA instructions
-        if (failed(rewriteMFMA(rewriter, dotOp))) {
+        if (failed(rewriteMFMA(rewriter, dotOp, dotIndex))) {
           LDBG("failed to refine tt.dotOp: " << *dotOp);
-        }
+        } else
+          ++dotIndex;
       });
 
       block->walk([&](triton::LoadOp loadOp) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -93,23 +93,83 @@ struct BasicDotWeightStrategy : public NodeWeightStrategy {
   void set(llvm::SmallVector<std::unique_ptr<Node>> &nodes) override {
     SmallVector<Node *> dots;
     SmallVector<Node *> loads;
+
+    struct DotInfo {
+      int32_t maxTileM{1};
+      int32_t maxTileN{1};
+      int32_t maxTileK{1};
+      uint32_t maxTileSerial{1};
+      int32_t maxElementM{1};
+      int32_t maxElementN{1};
+      int32_t maxElementK{1};
+      uint32_t maxElementSerial{1};
+      uint32_t baseWeight{0};
+      void update(triton::amdgpu::DotTileAttr attr) {
+        maxTileM = std::max(maxTileM, attr.getTileM() + 1);
+        maxTileN = std::max(maxTileN, attr.getTileN() + 1);
+        maxTileK = std::max(maxTileK, attr.getTileK() + 1);
+        maxTileSerial = std::max(maxTileSerial, attr.getTileSerial() + 1);
+        maxElementM = std::max(maxElementM, attr.getElementM()) + 1;
+        maxElementN = std::max(maxElementN, attr.getElementN() + 1);
+        maxElementK = std::max(maxElementK, attr.getElementK() + 1);
+        maxElementSerial =
+            std::max(maxElementSerial, attr.getElementSerial() + 1);
+      }
+      int32_t weight() { return maxTileSerial * maxElementSerial; }
+    };
+
+    int32_t maxDotIndex = 1;
+    DenseMap<int32_t, DotInfo> dotInfos;
     for (auto &node : nodes) {
-      if (dyn_cast<triton::DotOp>(node->getOp()))
+      if (dyn_cast<triton::DotOp>(node->getOp())) {
         dots.push_back(node.get());
+        if (auto attr =
+                node->getOp()->getAttrOfType<triton::amdgpu::DotTileAttr>(
+                    triton::amdgpu::DotTileAttr::getMnemonic())) {
+          auto currDotIndex = attr.getDotIndex();
+          if (!dotInfos.contains(currDotIndex)) {
+            dotInfos.insert({currDotIndex, DotInfo{}});
+          }
+          dotInfos[currDotIndex].update(attr);
+          maxDotIndex = std::max(maxDotIndex, currDotIndex + 1);
+        }
+      }
       if (dyn_cast<triton::LoadOp>(node->getOp()))
         loads.push_back(node.get());
     }
 
     // Make sure that prio is never equal to `0` for dotOps
     constexpr int32_t extraDefaultWeight = 10;
+    int64_t totalDotsWeight = extraDefaultWeight;
+    for (auto dotInfo : dotInfos) {
+      totalDotsWeight += dotInfo.second.weight();
+    }
+
     int32_t dotWeight = dots.size() + extraDefaultWeight;
-    const int32_t loadWeight = dotWeight + extraDefaultWeight;
+    const int32_t loadWeight = totalDotsWeight + extraDefaultWeight;
     for (auto loadNode : loads) {
       propagate(loadNode, loadWeight);
     }
 
+    for (int index = 1; index < maxDotIndex; ++index) {
+      auto &currInfo = dotInfos[index];
+      auto &prevInfo = dotInfos[index - 1];
+      currInfo.baseWeight = prevInfo.weight();
+    }
+
+    int64_t currDotWeight = extraDefaultWeight;
     for (auto dotNode : dots) {
-      propagate(dotNode, dotWeight--);
+      if (auto attr =
+              dotNode->getOp()->getAttrOfType<triton::amdgpu::DotTileAttr>(
+                  triton::amdgpu::DotTileAttr::getMnemonic())) {
+        auto &info = dotInfos[attr.getDotIndex()];
+        auto weight = attr.getElementSerial() +
+                      attr.getTileSerial() * info.maxElementSerial;
+        weight = info.baseWeight + info.weight() + extraDefaultWeight - weight;
+        propagate(dotNode, weight);
+      } else {
+        propagate(dotNode, totalDotsWeight--);
+      }
     }
   }
 


### PR DESCRIPTION
Hi @guacamoleo,

Here is just an example of `dot` ordering for our `reschedul-ops` pass. We need to take into account that there might be more than one `tt.DotOp` (sorry the calculations are a bit messy). I tried to assign higher weights to `tt.Dots` which comes from the first GEMM.

 I didn't observe any performance gain. It is just an example which may help you to impose some specific order of `mfmas`. Therefore, it is just a draft PR (please, don't merge it).