### PR TITLE
Adding support for ttg.extract_slice with ttg.slice

### DIFF
--- a/test/TritonGPU/amd/amd-extractslice-op.mlir
+++ b/test/TritonGPU/amd/amd-extractslice-op.mlir
@@ -12,3 +12,40 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
     tt.return
   }
 }
+
+#blocked3 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @extract_slice_slice_1(%arg0: tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked3}>> {tt.divisibility = 16 : i32}) {
+    // CHECK: llvm.func @extract_slice_slice_1
+    // CHECK-COUNT-8: %{{[0-9]*}} = llvm.extractvalue  %arg0[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK: %8 = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
+    // CHECK-COUNT-4:  %{{[0-9]*}} = llvm.insertvalue %{{[0-9]*}}, %{{[0-9]*}}[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32)>
+    %1 = amdgpu.extract_slice %arg0 [128] : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked3}>> to tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked3}>>
+    tt.return
+  }
+}
+
+#blocked4 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @extract_slice_slice_0(%arg0: tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked4}>> {tt.divisibility = 16 : i32}) {
+    // CHECK: llvm.func @extract_slice_slice_0
+    // CHECK-COUNT-8: %{{[0-9]*}} = llvm.extractvalue  %arg0[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32)>
+    // CHECK: %8 = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
+    // CHECK-COUNT-4:  %{{[0-9]*}} = llvm.insertvalue %{{[0-9]*}}, %{{[0-9]*}}[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32)>
+    %0 = amdgpu.extract_slice %arg0 [0] : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked4}>> to tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked4}>>
+    tt.return
+  }
+}
+
+#blocked5 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @extract_slice_slice_2() {
+        %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked5}>>
+        %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked5}>>
+        // CHECK-COUNT-4:  %{{[0-9]*}} = llvm.insertvalue %{{[0-9]*}}, %{{[0-9]*}}[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32)>
+        %2 = amdgpu.extract_slice %0 [0] : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked5}>> to tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked5}>>
+        // CHECK-COUNT-4:  %{{[0-9]*}} = llvm.insertvalue %{{[0-9]*}}, %{{[0-9]*}}[{{[0-9]*}}] : !llvm.struct<(i32, i32, i32, i32)>
+        %3 = amdgpu.extract_slice %1 [0] : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked5}>> to tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked5}>>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -265,6 +265,26 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_membar_analysis(pm)
         amd.passes.ttgpuir.add_refine_amdgpu_ops(pm, options.arch)
         passes.common.add_canonicalizer(pm)
+
+        # Emit and read custom ttgir.
+        pm.run(mod)
+        if "TRITON_MLIR_DUMP_REFINE_OPS" in os.environ.keys():
+            print("TRITON_MLIR_DUMP_REFINE_OPS\n")
+            mod.dump()
+        if "TRITON_MLIR_INSERT_REFINE_OPS" in os.environ.keys():
+            insert_module_path = str(os.environ["TRITON_MLIR_INSERT_REFINE_OPS"])
+            print("TRITON_MLIR_INSERT_REFINE_OPS=%s\n" % insert_module_path)
+            if not os.path.exists(insert_module_path):
+                raise RuntimeError(f'cannot find mlir file to insert. Given: `{insert_module_path}`')
+            new_mod = ir.parse_mlir_module(insert_module_path, mod.context)
+            new_mod.context = mod.context
+            mod = new_mod
+
+        pm = ir.pass_manager(mod.context)
+        pm.enable_debug()
+
+        # Resume normal compilation
+        passes.common.add_canonicalizer(pm)
         amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
         ## __HIP_FTZ is used to control the denorm flushing behavior of exp2 op as follows:
         ## 1. If __HIP_FTZ = 1, exp2 flushes denorms in input and output regardless

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -265,26 +265,6 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_membar_analysis(pm)
         amd.passes.ttgpuir.add_refine_amdgpu_ops(pm, options.arch)
         passes.common.add_canonicalizer(pm)
-
-        # Emit and read custom ttgir.
-        pm.run(mod)
-        if "TRITON_MLIR_DUMP_REFINE_OPS" in os.environ.keys():
-            print("TRITON_MLIR_DUMP_REFINE_OPS\n")
-            mod.dump()
-        if "TRITON_MLIR_INSERT_REFINE_OPS" in os.environ.keys():
-            insert_module_path = str(os.environ["TRITON_MLIR_INSERT_REFINE_OPS"])
-            print("TRITON_MLIR_INSERT_REFINE_OPS=%s\n" % insert_module_path)
-            if not os.path.exists(insert_module_path):
-                raise RuntimeError(f'cannot find mlir file to insert. Given: `{insert_module_path}`')
-            new_mod = ir.parse_mlir_module(insert_module_path, mod.context)
-            new_mod.context = mod.context
-            mod = new_mod
-
-        pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
-
-        # Resume normal compilation
-        passes.common.add_canonicalizer(pm)
         amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
         ## __HIP_FTZ is used to control the denorm flushing behavior of exp2 op as follows:
         ## 1. If __HIP_FTZ = 1, exp2 flushes denorms in input and output regardless

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -59,7 +59,6 @@ void mlir::triton::amdgpu::TritonAMDGPUDialect::initialize() {
 namespace mlir::triton::amdgpu {
 
 LogicalResult ExtractSliceOp::verify() {
-  //llvm::outs() << "ExtractSliceOp::verify()\n";
   auto srcTy = getSource().getType();
   auto srcLayout = srcTy.getEncoding();
   auto srcElementType = getElementTypeOrSelf(srcTy);
@@ -86,7 +85,6 @@ LogicalResult ExtractSliceOp::verify() {
   // the original tensor.
 
   auto offsets = getStaticOffsets();
-  //llvm::outs() << "offsets.size() " << offsets.size() << "\n";
   if (offsets.size() != rank) {
     return emitError("offsets rank must equal source rank ") << offsets;
   }
@@ -123,6 +121,7 @@ LogicalResult ExtractSliceOp::verify() {
                        << dimSizePerCTATile << "]";
     }
   }
+
   return success();
 }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -303,6 +303,7 @@ LogicalResult ConcatOp::verify() {
                          << scaledSrcDim << "` after concatenation";
     }
   }
+
   return success();
 }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -59,6 +59,7 @@ void mlir::triton::amdgpu::TritonAMDGPUDialect::initialize() {
 namespace mlir::triton::amdgpu {
 
 LogicalResult ExtractSliceOp::verify() {
+  //llvm::outs() << "ExtractSliceOp::verify()\n";
   auto srcTy = getSource().getType();
   auto srcLayout = srcTy.getEncoding();
   auto srcElementType = getElementTypeOrSelf(srcTy);
@@ -75,28 +76,21 @@ LogicalResult ExtractSliceOp::verify() {
   if (srcTy.getRank() != resultTy.getRank()) {
     return emitError("result rank must be equal to source rank");
   }
-  if (srcTy.getRank() != 2) {
-    return emitError("currently only 2D tensors are supported");
-  }
+  int64_t rank = srcTy.getRank();
 
   auto srcShape = srcTy.getShape();
   auto shapePerCTATile = mlir::triton::gpu::getShapePerCTATile(srcLayout);
-  shapePerCTATile[0] =
-      std::min(static_cast<unsigned>(srcShape[0]), shapePerCTATile[0]);
-  shapePerCTATile[1] =
-      std::min(static_cast<unsigned>(srcShape[1]), shapePerCTATile[1]);
 
   // ExtractSlice only supports slicing where offsets and sizes are multiples of
   // shapePerCTATile. This condition ensures that slice has the same layout as
   // the original tensor.
 
   auto offsets = getStaticOffsets();
-  if (offsets.size() != 2) {
-    return emitError("invalid offset shape ") << offsets;
+  //llvm::outs() << "offsets.size() " << offsets.size() << "\n";
+  if (offsets.size() != rank) {
+    return emitError("offsets rank must equal source rank ") << offsets;
   }
-
-  SmallVector<int64_t, 2> sizes;
-  for (auto i = 0; i < 2; ++i) {
+  for (auto i = 0; i < rank; ++i) {
     auto resultDimSize = resultTy.getDimSize(i);
     auto srcDimSize = srcTy.getDimSize(i);
     if (resultDimSize == 0) {
@@ -114,23 +108,21 @@ LogicalResult ExtractSliceOp::verify() {
       return emitError("invalid offset ")
              << offsets[i] << " at dimension " << i;
     }
-    sizes.push_back(resultDimSize);
-  }
+    int64_t size = resultDimSize;
 
-  if (sizes[0] % shapePerCTATile[0] != 0 ||
-      sizes[1] % shapePerCTATile[1] != 0) {
-    return emitError() << "sizes [" << sizes
+    int64_t dimSizePerCTATile = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
+    if (size % dimSizePerCTATile != 0) {
+      return emitError() << "size [" << size
                        << "] must be a multiple of shapePerCTATile ["
-                       << shapePerCTATile << "]";
-  }
+                       << dimSizePerCTATile << "]";
+    }
 
-  if (offsets[0] % shapePerCTATile[0] != 0 ||
-      offsets[1] % shapePerCTATile[1] != 0) {
-    return emitError() << "offset [" << offsets
+    if (offsets[i] % dimSizePerCTATile != 0) {
+      return emitError() << "offset [" << offsets
                        << "] must be a multiple of shapePerCTATile ["
-                       << shapePerCTATile << "]";
+                       << dimSizePerCTATile << "]";
+    }
   }
-
   return success();
 }
 
@@ -312,7 +304,6 @@ LogicalResult ConcatOp::verify() {
                          << scaledSrcDim << "` after concatenation";
     }
   }
-
   return success();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -125,7 +125,10 @@ struct ExtractSliceOpConversion
     return success();
   }
 
-
+  // This handles extract_slice when the layout is ttg.slice.
+  // For this case, the offsets, strides and sizes are only 1d,
+  // and the sizePerThread is takes from the parentLayout.
+  // ShapePerCTATile already examines the parentLayout for sliceLayout.
   LogicalResult processLayout1d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     Location loc = op->getLoc();
@@ -138,9 +141,8 @@ struct ExtractSliceOpConversion
     auto resultTy = cast<RankedTensorType>(op.getType());
     auto vals = unpackLLElements(loc, adaptor.getSource(), rewriter);
     auto elemsPerThread = triton::gpu::getElemsPerThread(srcTy);
-    auto sizePerThread = triton::gpu::getSizePerThread(srcLayout);
+    auto sizePerThread = triton::gpu::getSizePerThread(parent);
     auto totalSizePerThread = product<unsigned>(sizePerThread);
-    auto order = triton::gpu::getOrder(srcLayout);
     auto offsets = op.getStaticOffsets();
 
     LDBG("dim: " << dim);
@@ -148,7 +150,6 @@ struct ExtractSliceOpConversion
     LDBG("elemsPerThread: " << elemsPerThread[0] << "x" << "!");
     LDBG("sizePerThread: " << sizePerThread[0] << "x" << "!");
     LDBG("totalSizePerThread: " << totalSizePerThread);
-    LDBG("order: " << order[0] << "x" << "!");
     LDBG("offsets: " << offsets[0] << "x" << "!");
 
     // Calculate valid total number of workers in each dimension
@@ -175,22 +176,12 @@ struct ExtractSliceOpConversion
     LDBG("CTASizes: " << CTASizes[0] << "x" << "!");
     LDBG("CTAPerShape: " << CTAPerShape[0] << "x" << "!");
 
-    // TODO(dtanner) - how to incorporate dim into strides?
-    // ttg.slice dim=0 vs 1 would change strides.
-    // The below appears to be correct for the simplest dim=1 case from FA.
-    // Need much more debugging here.
-
-    // The diagram above illustrates the graphical representation of the
-    // skipElems, tensorStride, and lastIdx variables.
     auto skipElems =
-        // CTAOffsets[order[1]] * (elemsPerThread[order[0]] * sizePerThread[order[1]]) +
-        CTAOffsets[order[0]] * totalSizePerThread;
+        CTAOffsets[0] * totalSizePerThread;
     auto tensorStride =
-        (CTAPerShape[order[0]] - CTASizes[order[0]]) * totalSizePerThread;
+        (CTAPerShape[0] - CTASizes[0]) * totalSizePerThread;
     auto lastIdx =
-        //(CTAOffsets[order[1]] + CTASizes[order[1]] - 1) *
-        //elemsPerThread[order[0]] * sizePerThread[order[1]] +
-        (CTAOffsets[order[0]] + CTASizes[order[0]]) * totalSizePerThread;
+        (CTAOffsets[0] + CTASizes[0]) * totalSizePerThread;
     LDBG("skipElems: " << skipElems);
     LDBG("tensorStride: " << tensorStride);
     LDBG("lastIdx: " << lastIdx);
@@ -199,7 +190,7 @@ struct ExtractSliceOpConversion
 
     SmallVector<Value> resultVals;
     for (int i = skipElems; i < lastIdx; i += tensorStride) {
-      for (int j = 0; j < totalSizePerThread * CTASizes[order[0]]; ++j, ++i) {
+      for (int j = 0; j < totalSizePerThread * CTASizes[0]; ++j, ++i) {
         assert(i < lastIdx);
         LDBG("i: " << i);
         resultVals.push_back(vals[i]);
@@ -221,8 +212,8 @@ struct ExtractSliceOpConversion
             encoding)) {
       return processLayout2d(op, adaptor, rewriter);
     } else if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(encoding)) {
-      auto parentEncoding = sliceLayout.getParent();
-      if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(parentEncoding)) {
+      auto parent = sliceLayout.getParent();
+      if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(parent)) {
         return processLayout1d(op, adaptor, rewriter);
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -56,7 +56,7 @@ struct ExtractSliceOpConversion
       : ConvertOpToLLVMPattern<amdgpu::ExtractSliceOp>(typeConverter, benefit) {
   }
 
-  LogicalResult processLayout(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
+  LogicalResult processLayout2d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
     Location loc = op->getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSource().getType());
@@ -120,13 +120,114 @@ struct ExtractSliceOpConversion
     return success();
   }
 
+
+  
+  LogicalResult processLayout1d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const {
+    llvm::outs() << "\n\nprocessExtractSlice1d(): " << op << "\n";
+    Location loc = op->getLoc();
+    auto srcTy = cast<RankedTensorType>(op.getSource().getType());
+    auto srcLayout = srcTy.getEncoding();
+    auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout);
+    auto dim = sliceLayout.getDim();
+    auto parent = sliceLayout.getParent();
+    auto srcShape = srcTy.getShape();
+    auto resultTy = cast<RankedTensorType>(op.getType());
+    auto vals = unpackLLElements(loc, adaptor.getSource(), rewriter);
+    auto elemsPerThread = triton::gpu::getElemsPerThread(srcTy);
+    auto sizePerThread = triton::gpu::getSizePerThread(srcLayout);
+    auto totalSizePerThread = product<unsigned>(sizePerThread);
+    auto order = triton::gpu::getOrder(srcLayout);
+    auto offsets = op.getStaticOffsets();
+
+    llvm::outs() << "dim: " << dim << "\n";
+    llvm::outs() << "srcShape: " << srcShape[0] << "x" << "!" << "\n";
+    llvm::outs() << "elemsPerThread: " << elemsPerThread[0] << "x" << "!" << "\n";
+    llvm::outs() << "sizePerThread: " << sizePerThread[0] << "x" << "!" << "\n";
+    llvm::outs() << "totalSizePerThread: " << totalSizePerThread << "\n";
+    llvm::outs() << "order: " << order[0] << "x" << "!" << "\n";
+    llvm::outs() << "offsets: " << offsets[0] << "x" << "!" << "\n";
+
+    // Calculate valid total number of workers in each dimension
+    auto shapePerCTATile = triton::gpu::getShapePerCTATile(srcLayout);
+    for (auto i = 0; i < shapePerCTATile.size(); ++i) {
+      shapePerCTATile[i] = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
+    }
+    llvm::outs() << "shapePerCTATile: " << shapePerCTATile[0] << "x" << "!" << "\n";
+
+    SmallVector<int64_t> sizes;
+    SmallVector<int64_t> CTAOffsets;
+    SmallVector<int64_t> CTASizes;
+    SmallVector<int64_t> CTAPerShape;
+
+    // Calculate offsets and sizes in terms of CTA units.
+    for (auto i = 0; i < resultTy.getRank(); ++i) {
+      sizes.push_back(resultTy.getDimSize(i));
+      CTAOffsets.push_back(offsets[i] / shapePerCTATile[i]);
+      CTASizes.push_back(sizes[i] / shapePerCTATile[i]);
+      CTAPerShape.push_back(srcShape[i] / shapePerCTATile[i]);
+    }
+    llvm::outs() << "sizes: " << sizes[0] << "x" << "!" << "\n";
+
+
+
+
+/*
+    std::array<int64_t, 2> CTAOffsets{
+      offsets[0] / shapePerCTATile[0],
+      offsets[1] / shapePerCTATile[1]};
+    std::array<int64_t, 2> CTASizes{sizes[0] / shapePerCTATile[0],
+              sizes[1] / shapePerCTATile[1]};
+    std::array<int64_t, 2> CTAPerShape{srcShape[0] / shapePerCTATile[0],
+                srcShape[1] / shapePerCTATile[1]};
+*/
+    llvm::outs() << "CTAOffsets: " << CTAOffsets[0] << "x" << "!" << "\n";
+    llvm::outs() << "CTASizes: " << CTASizes[0] << "x" << "!" << "\n";
+    llvm::outs() << "CTAPerShape: " << CTAPerShape[0] << "x" << "!" << "\n";
+
+
+    // The diagram above illustrates the graphical representation of the
+    // skipElems, tensorStride, and lastIdx variables.
+    auto skipElems = 
+        // CTAOffsets[order[1]] * (elemsPerThread[order[0]] * sizePerThread[order[1]]) +
+        CTAOffsets[order[0]] * totalSizePerThread;
+    auto tensorStride =
+        (CTAPerShape[order[0]] - CTASizes[order[0]]) * totalSizePerThread;
+    auto lastIdx =
+        //(CTAOffsets[order[1]] + CTASizes[order[1]] - 1) *
+        //elemsPerThread[order[0]] * sizePerThread[order[1]] +
+        (CTAOffsets[order[0]] + CTASizes[order[0]]) * totalSizePerThread;
+    llvm::outs() << "skipElems: " << skipElems << "\n";
+    llvm::outs() << "tensorStride: " << tensorStride << "\n";
+    llvm::outs() << "lastIdx: " << lastIdx << "\n";
+
+    assert(lastIdx <= vals.size());
+
+    SmallVector<Value> resultVals;
+    for (int i = skipElems; i < lastIdx; i += tensorStride) {
+      for (int j = 0; j < totalSizePerThread * CTASizes[order[0]]; ++j, ++i) {
+        assert(i < lastIdx);
+        llvm::outs() << "i: " << i << "\n";
+        resultVals.push_back(vals[i]);
+      }
+    }
+    Value ret = packLLElements(loc, this->getTypeConverter(), resultVals,
+        rewriter, resultTy);
+
+    rewriter.replaceOp(op, ret);
+    return success();
+  }
+
   LogicalResult
   matchAndRewrite(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto srcTy = op.getSource().getType();
+    auto encoding = srcTy.getEncoding();
     if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(
             op.getSource().getType().getEncoding())) {
-      return processLayout(op, adaptor, rewriter);
+      return processLayout2d(op, adaptor, rewriter);
+    } else if (isa<SliceEncodingAttr>(encoding)) {
+      return processLayout1d(op, adaptor, rewriter);
     }
     return failure();
   }

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -7,11 +7,6 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
-#undef DEBUG_TYPE
-#define DEBUG_TYPE "tritonamdgpu-extract-slice-to-llvm"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
-
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -61,138 +56,64 @@ struct ExtractSliceOpConversion
       : ConvertOpToLLVMPattern<amdgpu::ExtractSliceOp>(typeConverter, benefit) {
   }
 
-  LogicalResult processLayout2d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
-                              ConversionPatternRewriter &rewriter) const {
-    Location loc = op->getLoc();
-    auto srcTy = cast<RankedTensorType>(op.getSource().getType());
-    auto srcLayout = srcTy.getEncoding();
-    auto srcShape = srcTy.getShape();
-    auto resultTy = cast<RankedTensorType>(op.getType());
-    auto vals = unpackLLElements(loc, adaptor.getSource(), rewriter);
-    auto elemsPerThread = triton::gpu::getElemsPerThread(srcTy);
-    auto sizePerThread = triton::gpu::getSizePerThread(srcLayout);
-    auto totalSizePerThread = product<unsigned>(sizePerThread);
-    auto order = triton::gpu::getOrder(srcLayout);
-
-    // Calculate valid total number of workers in each dimension
-    auto shapePerCTATile = triton::gpu::getShapePerCTATile(srcLayout);
-    shapePerCTATile[0] =
-        std::min(static_cast<unsigned>(srcShape[0]), shapePerCTATile[0]);
-    shapePerCTATile[1] =
-        std::min(static_cast<unsigned>(srcShape[1]), shapePerCTATile[1]);
-
-    // Rank == 2 checked in the verifier
-    SmallVector<int64_t, 2> sizes;
-    for (auto i = 0; i < 2; ++i) {
-      sizes.push_back(resultTy.getDimSize(i));
-    }
-
-    auto offsets = op.getStaticOffsets();
-
-    // Calculate offsets and sizes in terms of CTA units.
-    std::array<int64_t, 2> CTAOffsets{offsets[0] / shapePerCTATile[0],
-                                      offsets[1] / shapePerCTATile[1]};
-    std::array<int64_t, 2> CTASizes{sizes[0] / shapePerCTATile[0],
-                                    sizes[1] / shapePerCTATile[1]};
-    std::array<int64_t, 2> CTAPerShape{srcShape[0] / shapePerCTATile[0],
-                                       srcShape[1] / shapePerCTATile[1]};
-
-    // The diagram above illustrates the graphical representation of the
-    // skipElems, tensorStride, and lastIdx variables.
-    auto skipElems = CTAOffsets[order[1]] *
-                         (elemsPerThread[order[0]] * sizePerThread[order[1]]) +
-                     CTAOffsets[order[0]] * totalSizePerThread;
-    auto tensorStride =
-        (CTAPerShape[order[0]] - CTASizes[order[0]]) * totalSizePerThread;
-    auto lastIdx =
-        (CTAOffsets[order[1]] + CTASizes[order[1]] - 1) *
-            elemsPerThread[order[0]] * sizePerThread[order[1]] +
-        (CTAOffsets[order[0]] + CTASizes[order[0]]) * totalSizePerThread;
-
-    assert(lastIdx <= vals.size());
-
-    SmallVector<Value> resultVals;
-    for (int i = skipElems; i < lastIdx; i += tensorStride) {
-      for (int j = 0; j < totalSizePerThread * CTASizes[order[0]]; ++j, ++i) {
-        assert(i < lastIdx);
-        resultVals.push_back(vals[i]);
-      }
-    }
-    Value ret = packLLElements(loc, this->getTypeConverter(), resultVals,
-                               rewriter, resultTy);
-
-    rewriter.replaceOp(op, ret);
-    return success();
-  }
-
-  // This handles extract_slice when the layout is ttg.slice.
-  // For this case, the offsets, strides and sizes are only 1d,
-  // and the sizePerThread is takes from the parentLayout.
-  // ShapePerCTATile already examines the parentLayout for sliceLayout.
-  LogicalResult processLayout1d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
+  LogicalResult processLayout(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     Location loc = op->getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSource().getType());
     auto srcLayout = srcTy.getEncoding();
-    auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout);
-    auto dim = sliceLayout.getDim();
-    auto parent = sliceLayout.getParent();
     auto srcShape = srcTy.getShape();
     auto resultTy = cast<RankedTensorType>(op.getType());
     auto vals = unpackLLElements(loc, adaptor.getSource(), rewriter);
     auto elemsPerThread = triton::gpu::getElemsPerThread(srcTy);
-    auto sizePerThread = triton::gpu::getSizePerThread(parent);
+    auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout);
+    auto sizePerThread = triton::gpu::getSizePerThread(
+      sliceLayout ? sliceLayout.getParent() : srcLayout);
     auto totalSizePerThread = product<unsigned>(sizePerThread);
+    auto order = triton::gpu::getOrder(srcLayout);
     auto offsets = op.getStaticOffsets();
-
-    LDBG("dim: " << dim);
-    LDBG("srcShape: " << srcShape[0] << "x" << "!");
-    LDBG("elemsPerThread: " << elemsPerThread[0] << "x" << "!");
-    LDBG("sizePerThread: " << sizePerThread[0] << "x" << "!");
-    LDBG("totalSizePerThread: " << totalSizePerThread);
-    LDBG("offsets: " << offsets[0] << "x" << "!");
 
     // Calculate valid total number of workers in each dimension
     auto shapePerCTATile = triton::gpu::getShapePerCTATile(srcLayout);
     for (auto i = 0; i < shapePerCTATile.size(); ++i) {
       shapePerCTATile[i] = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
     }
-    LDBG("shapePerCTATile: " << shapePerCTATile[0] << "x" << "!");
 
+    // Calculate offsets and sizes in terms of CTA units.
     SmallVector<int64_t> sizes;
     SmallVector<int64_t> CTAOffsets;
     SmallVector<int64_t> CTASizes;
     SmallVector<int64_t> CTAPerShape;
-
-    // Calculate offsets and sizes in terms of CTA units.
     for (auto i = 0; i < resultTy.getRank(); ++i) {
       sizes.push_back(resultTy.getDimSize(i));
       CTAOffsets.push_back(offsets[i] / shapePerCTATile[i]);
       CTASizes.push_back(sizes[i] / shapePerCTATile[i]);
       CTAPerShape.push_back(srcShape[i] / shapePerCTATile[i]);
     }
-    LDBG("sizes: " << sizes[0] << "x" << "!");
-    LDBG("CTAOffsets: " << CTAOffsets[0] << "x" << "!");
-    LDBG("CTASizes: " << CTASizes[0] << "x" << "!");
-    LDBG("CTAPerShape: " << CTAPerShape[0] << "x" << "!");
 
-    auto skipElems =
-        CTAOffsets[0] * totalSizePerThread;
-    auto tensorStride =
-        (CTAPerShape[0] - CTASizes[0]) * totalSizePerThread;
-    auto lastIdx =
-        (CTAOffsets[0] + CTASizes[0]) * totalSizePerThread;
-    LDBG("skipElems: " << skipElems);
-    LDBG("tensorStride: " << tensorStride);
-    LDBG("lastIdx: " << lastIdx);
-
+    // SliceLayout uses 1d offsets.
+    auto skipElems = CTAOffsets[0] * totalSizePerThread;
+    auto tensorStride = (CTAPerShape[0] - CTASizes[0]) * totalSizePerThread;
+    auto lastIdx = (CTAOffsets[0] + CTASizes[0]) * totalSizePerThread;
+    auto numElemsPerVec = totalSizePerThread * CTASizes[0];
+    if(!sliceLayout) {
+      // Non-SliceLayouts use 2d offsets (based on order).
+      skipElems = CTAOffsets[order[1]] *
+          (elemsPerThread[order[0]] * sizePerThread[order[1]]) +
+          CTAOffsets[order[0]] * totalSizePerThread;
+      tensorStride =
+          (CTAPerShape[order[0]] - CTASizes[order[0]]) * totalSizePerThread;
+      lastIdx =
+          (CTAOffsets[order[1]] + CTASizes[order[1]] - 1) *
+          elemsPerThread[order[0]] * sizePerThread[order[1]] +
+          (CTAOffsets[order[0]] + CTASizes[order[0]]) * totalSizePerThread;
+      numElemsPerVec = totalSizePerThread * CTASizes[order[0]];
+    }
     assert(lastIdx <= vals.size());
 
     SmallVector<Value> resultVals;
     for (int i = skipElems; i < lastIdx; i += tensorStride) {
-      for (int j = 0; j < totalSizePerThread * CTASizes[0]; ++j, ++i) {
+      for (int j = 0; j < numElemsPerVec; ++j, ++i) {
         assert(i < lastIdx);
-        LDBG("i: " << i);
         resultVals.push_back(vals[i]);
       }
     }
@@ -210,11 +131,11 @@ struct ExtractSliceOpConversion
     auto encoding = srcTy.getEncoding();
     if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(
             encoding)) {
-      return processLayout2d(op, adaptor, rewriter);
+      return processLayout(op, adaptor, rewriter);
     } else if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(encoding)) {
       auto parent = sliceLayout.getParent();
       if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(parent)) {
-        return processLayout1d(op, adaptor, rewriter);
+        return processLayout(op, adaptor, rewriter);
       }
     }
     return failure();

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -7,6 +7,11 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-extract-slice-to-llvm"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -121,10 +126,8 @@ struct ExtractSliceOpConversion
   }
 
 
-  
   LogicalResult processLayout1d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
-    llvm::outs() << "\n\nprocessExtractSlice1d(): " << op << "\n";
     Location loc = op->getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSource().getType());
     auto srcLayout = srcTy.getEncoding();
@@ -140,20 +143,20 @@ struct ExtractSliceOpConversion
     auto order = triton::gpu::getOrder(srcLayout);
     auto offsets = op.getStaticOffsets();
 
-    llvm::outs() << "dim: " << dim << "\n";
-    llvm::outs() << "srcShape: " << srcShape[0] << "x" << "!" << "\n";
-    llvm::outs() << "elemsPerThread: " << elemsPerThread[0] << "x" << "!" << "\n";
-    llvm::outs() << "sizePerThread: " << sizePerThread[0] << "x" << "!" << "\n";
-    llvm::outs() << "totalSizePerThread: " << totalSizePerThread << "\n";
-    llvm::outs() << "order: " << order[0] << "x" << "!" << "\n";
-    llvm::outs() << "offsets: " << offsets[0] << "x" << "!" << "\n";
+    LDBG("dim: " << dim);
+    LDBG("srcShape: " << srcShape[0] << "x" << "!");
+    LDBG("elemsPerThread: " << elemsPerThread[0] << "x" << "!");
+    LDBG("sizePerThread: " << sizePerThread[0] << "x" << "!");
+    LDBG("totalSizePerThread: " << totalSizePerThread);
+    LDBG("order: " << order[0] << "x" << "!");
+    LDBG("offsets: " << offsets[0] << "x" << "!");
 
     // Calculate valid total number of workers in each dimension
     auto shapePerCTATile = triton::gpu::getShapePerCTATile(srcLayout);
     for (auto i = 0; i < shapePerCTATile.size(); ++i) {
       shapePerCTATile[i] = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
     }
-    llvm::outs() << "shapePerCTATile: " << shapePerCTATile[0] << "x" << "!" << "\n";
+    LDBG("shapePerCTATile: " << shapePerCTATile[0] << "x" << "!");
 
     SmallVector<int64_t> sizes;
     SmallVector<int64_t> CTAOffsets;
@@ -167,28 +170,19 @@ struct ExtractSliceOpConversion
       CTASizes.push_back(sizes[i] / shapePerCTATile[i]);
       CTAPerShape.push_back(srcShape[i] / shapePerCTATile[i]);
     }
-    llvm::outs() << "sizes: " << sizes[0] << "x" << "!" << "\n";
+    LDBG("sizes: " << sizes[0] << "x" << "!");
+    LDBG("CTAOffsets: " << CTAOffsets[0] << "x" << "!");
+    LDBG("CTASizes: " << CTASizes[0] << "x" << "!");
+    LDBG("CTAPerShape: " << CTAPerShape[0] << "x" << "!");
 
-
-
-
-/*
-    std::array<int64_t, 2> CTAOffsets{
-      offsets[0] / shapePerCTATile[0],
-      offsets[1] / shapePerCTATile[1]};
-    std::array<int64_t, 2> CTASizes{sizes[0] / shapePerCTATile[0],
-              sizes[1] / shapePerCTATile[1]};
-    std::array<int64_t, 2> CTAPerShape{srcShape[0] / shapePerCTATile[0],
-                srcShape[1] / shapePerCTATile[1]};
-*/
-    llvm::outs() << "CTAOffsets: " << CTAOffsets[0] << "x" << "!" << "\n";
-    llvm::outs() << "CTASizes: " << CTASizes[0] << "x" << "!" << "\n";
-    llvm::outs() << "CTAPerShape: " << CTAPerShape[0] << "x" << "!" << "\n";
-
+    // TODO(dtanner) - how to incorporate dim into strides?
+    // ttg.slice dim=0 vs 1 would change strides.
+    // The below appears to be correct for the simplest dim=1 case from FA.
+    // Need much more debugging here.
 
     // The diagram above illustrates the graphical representation of the
     // skipElems, tensorStride, and lastIdx variables.
-    auto skipElems = 
+    auto skipElems =
         // CTAOffsets[order[1]] * (elemsPerThread[order[0]] * sizePerThread[order[1]]) +
         CTAOffsets[order[0]] * totalSizePerThread;
     auto tensorStride =
@@ -197,9 +191,9 @@ struct ExtractSliceOpConversion
         //(CTAOffsets[order[1]] + CTASizes[order[1]] - 1) *
         //elemsPerThread[order[0]] * sizePerThread[order[1]] +
         (CTAOffsets[order[0]] + CTASizes[order[0]]) * totalSizePerThread;
-    llvm::outs() << "skipElems: " << skipElems << "\n";
-    llvm::outs() << "tensorStride: " << tensorStride << "\n";
-    llvm::outs() << "lastIdx: " << lastIdx << "\n";
+    LDBG("skipElems: " << skipElems);
+    LDBG("tensorStride: " << tensorStride);
+    LDBG("lastIdx: " << lastIdx);
 
     assert(lastIdx <= vals.size());
 
@@ -207,7 +201,7 @@ struct ExtractSliceOpConversion
     for (int i = skipElems; i < lastIdx; i += tensorStride) {
       for (int j = 0; j < totalSizePerThread * CTASizes[order[0]]; ++j, ++i) {
         assert(i < lastIdx);
-        llvm::outs() << "i: " << i << "\n";
+        LDBG("i: " << i);
         resultVals.push_back(vals[i]);
       }
     }
@@ -224,10 +218,13 @@ struct ExtractSliceOpConversion
     auto srcTy = op.getSource().getType();
     auto encoding = srcTy.getEncoding();
     if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(
-            op.getSource().getType().getEncoding())) {
+            encoding)) {
       return processLayout2d(op, adaptor, rewriter);
-    } else if (isa<SliceEncodingAttr>(encoding)) {
-      return processLayout1d(op, adaptor, rewriter);
+    } else if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(encoding)) {
+      auto parentEncoding = sliceLayout.getParent();
+      if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(parentEncoding)) {
+        return processLayout1d(op, adaptor, rewriter);
+      }
     }
     return failure();
   }


### PR DESCRIPTION
Refining ops for FA needs ttg.extract_slice to be able to handle layout=ttg.slice; these come from reductions for example.
This PR adds support for validating and converting ttg.extract_slice of ttg.slice to llvm.
 

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
