### PR TITLE
Cap warp count to 16 for devices with warp size 64

### DIFF
--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -42,6 +42,7 @@ class GPUDriver(DriverBase):
             self.get_current_stream = lambda idx: torch.cuda.current_stream(idx).cuda_stream
         self.get_current_device = torch.cuda.current_device
         self.set_current_device = torch.cuda.set_device
+	self.warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
 
     # TODO: remove once TMA is cleaned up
     def assemble_tensormap_to_arg(self, tensormaps_info, args):

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -42,8 +42,8 @@ class GPUDriver(DriverBase):
             self.get_current_stream = lambda idx: torch.cuda.current_stream(idx).cuda_stream
         self.get_current_device = torch.cuda.current_device
         self.set_current_device = torch.cuda.set_device
-	    self.warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
-
+        self.warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
+        
     # TODO: remove once TMA is cleaned up
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -42,7 +42,7 @@ class GPUDriver(DriverBase):
             self.get_current_stream = lambda idx: torch.cuda.current_stream(idx).cuda_stream
         self.get_current_device = torch.cuda.current_device
         self.set_current_device = torch.cuda.set_device
-	self.warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
+	    self.warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
 
     # TODO: remove once TMA is cleaned up
     def assemble_tensormap_to_arg(self, tensormaps_info, args):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -620,6 +620,9 @@ class JITFunction(KernelInterface[T]):
                 return None
             # compile the kernel
             src = self.ASTSource(self, signature, constants, configs[0])
+            # some AMD devices have warp size 64 so num_warps must <=16 for <=1024 threads/block
+            if driver.active.warp_size == 64:
+                options.__dict__.update({'num_warps': 16})
             kernel = self.compile(
                 src,
                 target=target,


### PR DESCRIPTION
Add a check for device warp size and cap JIT runtime warp count for devices with warp size 64. Currently, exceeding 16 warps with a warp size of 64 (e.g. on Instinct devices) exceeds the 1024 thread/block limit and will error out. The warp size is detected and stored in driver.py, which is already being used in the offending function.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because (currently a draft to be discussed).

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
