### PR TITLE
Adding support for refining tt.reduce

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -265,7 +265,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_membar_analysis(pm)
         amd.passes.ttgpuir.add_refine_amdgpu_ops(pm, options.arch)
         passes.common.add_canonicalizer(pm)
-        #amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
+        amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
         ## __HIP_FTZ is used to control the denorm flushing behavior of exp2 op as follows:
         ## 1. If __HIP_FTZ = 1, exp2 flushes denorms in input and output regardless
         ##    of the value of kernel arg `allow_flush_denorm`.

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -265,7 +265,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_membar_analysis(pm)
         amd.passes.ttgpuir.add_refine_amdgpu_ops(pm, options.arch)
         passes.common.add_canonicalizer(pm)
-        amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
+        #amd.passes.ttgpuir.add_reschedule_amdgpu_ops(pm, options.arch)
         ## __HIP_FTZ is used to control the denorm flushing behavior of exp2 op as follows:
         ## 1. If __HIP_FTZ = 1, exp2 flushes denorms in input and output regardless
         ##    of the value of kernel arg `allow_flush_denorm`.

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -79,7 +79,8 @@ getMfmasPerRep(const SmallVector<int64_t> &ctaTile,
   LDBG("ctaTile: " << ctaTile[0] << "x" << ctaTile[1] << "x" << ctaTile[2]);
   LDBG("warpsPerCtaTile: " << warpsPerCta[0] << "x" << warpsPerCta[1]);
   LDBG("numReps: " << numReps[0] << "x" << numReps[1] << "x" << numReps[2]);
-  LDBG("mfmaShape: " << mfmaShape[0] << "x" << mfmaShape[1] << "x" << mfmaShape[2]);
+  LDBG("mfmaShape: " << mfmaShape[0] << "x" << mfmaShape[1] << "x"
+                     << mfmaShape[2]);
   // Tile shape per warp.
   SmallVector<int64_t, 3> warpTile = {
       ctaTile[0] / warpsPerCta[0],
@@ -98,9 +99,11 @@ getMfmasPerRep(const SmallVector<int64_t> &ctaTile,
       static_cast<unsigned>(repTile[0] / mfmaShape[0]),
       static_cast<unsigned>(repTile[1] / mfmaShape[1]),
       static_cast<unsigned>(repTile[2] / mfmaShape[2])};
-  LDBG("mfmasPerRep: " << mfmasPerRep[0] << "x" << mfmasPerRep[1] << "x" << mfmasPerRep[2]);
+  LDBG("mfmasPerRep: " << mfmasPerRep[0] << "x" << mfmasPerRep[1] << "x"
+                       << mfmasPerRep[2]);
   if (mfmasPerRep[0] < 1 || mfmasPerRep[1] < 1 || mfmasPerRep[2] < 1) {
-    llvm::errs() << "DotTiling::getMfmasPerRep() - Invalid combination of ctaTile, warpsPerCta and mfmaShape.\n";
+    llvm::errs() << "DotTiling::getMfmasPerRep() - Invalid combination of "
+                    "ctaTile, warpsPerCta and mfmaShape.\n";
     return SmallVector<unsigned, 3>({1, 1, 1});
   }
   return mfmasPerRep;
@@ -206,13 +209,15 @@ calcDotTileShape(const SmallVector<unsigned, 3>
   bool localLoadRateExposed = true;
   bool localLoadIssueExposed = true;
 
-  // Try a finite number of times to increase the TileShape meet performance criteria.
+  // Try a finite number of times to increase the TileShape meet performance
+  // criteria.
   // TODO - possibly need to refactor loop bounds before production ready.
   constexpr int maxTries = 12; // sufficient to create 64x64 tile.
   for (int i = 0; i < maxTries; ++i) {
     // If TileShape meets performance criteria, return.
-    if (!(localLoadDataLatencyExposed || localLoadRateExposed || localLoadIssueExposed)) {
-        return tileShape;
+    if (!(localLoadDataLatencyExposed || localLoadRateExposed ||
+          localLoadIssueExposed)) {
+      return tileShape;
     }
     // TileShape doesn't meet performance criteria, increase it's size.
     // Enforce criteria #4 - small square.

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -108,17 +108,18 @@ LogicalResult ExtractSliceOp::verify() {
     }
     int64_t size = resultDimSize;
 
-    int64_t dimSizePerCTATile = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
+    int64_t dimSizePerCTATile =
+        std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
     if (size % dimSizePerCTATile != 0) {
       return emitError() << "size [" << size
-                       << "] must be a multiple of shapePerCTATile ["
-                       << dimSizePerCTATile << "]";
+                         << "] must be a multiple of shapePerCTATile ["
+                         << dimSizePerCTATile << "]";
     }
 
     if (offsets[i] % dimSizePerCTATile != 0) {
       return emitError() << "offset [" << offsets
-                       << "] must be a multiple of shapePerCTATile ["
-                       << dimSizePerCTATile << "]";
+                         << "] must be a multiple of shapePerCTATile ["
+                         << dimSizePerCTATile << "]";
     }
   }
 

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -62,7 +62,7 @@ struct ExtractSliceOpConversion
   }
 
   LogicalResult processLayout2d(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
-                              ConversionPatternRewriter &rewriter) const {
+                                ConversionPatternRewriter &rewriter) const {
     Location loc = op->getLoc();
     auto srcTy = cast<RankedTensorType>(op.getSource().getType());
     auto srcLayout = srcTy.getEncoding();
@@ -155,7 +155,8 @@ struct ExtractSliceOpConversion
     // Calculate valid total number of workers in each dimension
     auto shapePerCTATile = triton::gpu::getShapePerCTATile(srcLayout);
     for (auto i = 0; i < shapePerCTATile.size(); ++i) {
-      shapePerCTATile[i] = std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
+      shapePerCTATile[i] =
+          std::min(static_cast<unsigned>(srcShape[i]), shapePerCTATile[i]);
     }
     LDBG("shapePerCTATile: " << shapePerCTATile[0] << "x" << "!");
 
@@ -176,12 +177,9 @@ struct ExtractSliceOpConversion
     LDBG("CTASizes: " << CTASizes[0] << "x" << "!");
     LDBG("CTAPerShape: " << CTAPerShape[0] << "x" << "!");
 
-    auto skipElems =
-        CTAOffsets[0] * totalSizePerThread;
-    auto tensorStride =
-        (CTAPerShape[0] - CTASizes[0]) * totalSizePerThread;
-    auto lastIdx =
-        (CTAOffsets[0] + CTASizes[0]) * totalSizePerThread;
+    auto skipElems = CTAOffsets[0] * totalSizePerThread;
+    auto tensorStride = (CTAPerShape[0] - CTASizes[0]) * totalSizePerThread;
+    auto lastIdx = (CTAOffsets[0] + CTASizes[0]) * totalSizePerThread;
     LDBG("skipElems: " << skipElems);
     LDBG("tensorStride: " << tensorStride);
     LDBG("lastIdx: " << lastIdx);
@@ -197,7 +195,7 @@ struct ExtractSliceOpConversion
       }
     }
     Value ret = packLLElements(loc, this->getTypeConverter(), resultVals,
-        rewriter, resultTy);
+                               rewriter, resultTy);
 
     rewriter.replaceOp(op, ret);
     return success();
@@ -213,7 +211,8 @@ struct ExtractSliceOpConversion
       return processLayout2d(op, adaptor, rewriter);
     } else if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(encoding)) {
       auto parent = sliceLayout.getParent();
-      if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(parent)) {
+      if (isa<BlockedEncodingAttr, AMDMfmaEncodingAttr, DotOperandEncodingAttr>(
+              parent)) {
         return processLayout1d(op, adaptor, rewriter);
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -24,12 +24,6 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "triton/Tools/LinearLayout.h"
-#include "triton/Dialect/TritonGPU/IR/Attributes.h"
-#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
-
-//#include "triton/Dialect/TritonGPU/IR/Dialect.cpp.inc"
-//#include "triton/Dialect/Triton/IR/Dialect.h.inc"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 #define GEN_PASS_CLASSES
@@ -642,128 +636,57 @@ LogicalResult rewriteLocalStoreOp(OpBuilder &rewriter,
   return success();
 }
 
-/*
-triton.language.reduce(input, axis, combine_fn, keep_dims=False)¶
-Applies the combine_fn to all elements in input tensors along the provided axis
-Parameters:
-input (Tensor) – the input tensor, or tuple of tensors
-axis (int | None) – the dimension along which the reduction should be done. If None, reduce all dimensions
-combine_fn (Callable) – a function to combine two groups of scalar tensors (must be marked with @triton.jit)
-keep_dims (bool) – if true, keep the reduced dimensions with length 1
-
-*/
+// Reduce ops have different intput and output shapes and produce
+// sliced layouts.
+// This currently only supports 2d inputs.
 LogicalResult rewriteReduceOp(OpBuilder &rewriter, triton::ReduceOp op) {
-  llvm::outs() << "\n\nRefineOps::rewriteReduceOp()\n";
   auto ctx = op->getContext();
   auto loc = op.getLoc();
   uint32_t axisReduce = op.getAxis();
   uint32_t axisNonReduce = (axisReduce+1)%2;
-  llvm::outs() << "op:\n" << op << "\n\n"; // long func
-  llvm::outs() << "reduce axis: " << op.getAxis() << "\n"; // 1
-  //auto combineOps = op.getCombineOp().getOps();
-  //llvm::outs() << combineOp. << "\n";
-  llvm::outs() << "parent: " << op->getParentOp() << "\n"; // hex
-  llvm::outs() << "num operands: " << op.getNumOperands() << "\n"; // 1
-  auto types = op.getInputTypes(); // ranked tensor type - tensor<128x32xf32...
-  auto input = types[0];
-  llvm::outs() << "type: " << types[0] << "\n";
-  llvm::outs() << "elemPerThread: " << ttg::getTotalElemsPerThread(types[0]) << "\n"; // 8
-  llvm::outs() << "numElem: " << input.getNumElements() << "\n";
 
-  // region, blocks, combine op
-  //auto region = op->getRegion(0);
-  //llvm::outs() << "region: " <<  << "\n";
-  //llvm::outs() << "combine: " << op.getCombineOp() << "\n";
-
-  // Slice input tensor along non-dimension.
-  // for numReps
+  // Calculate refined shape.
   auto src = op->getOperand(0);
   auto srcType = rankedTType(src);
-  assert(srcType.getRank()==2);
+  if (srcType.getRank()!=2)
+    return failure();
   auto srcShape = srcType.getShape();
   auto srcEncoding = srcType.getEncoding();
   auto srcShapePerCtaTile = triton::gpu::getShapePerCTATile(srcEncoding);
-  llvm::outs() << "srcShapePerCtaTile: " << srcShapePerCtaTile[0] << "x" << srcShapePerCtaTile[1] << "\n";
-
   SmallVector<int64_t> repShape = {srcShape[0] / srcShapePerCtaTile[0], srcShape[1] / srcShapePerCtaTile[1]};
-  llvm::outs() << "repShape: " << repShape[0] << "x" << repShape[1] << "\n";
   int numReps = repShape[axisNonReduce];
-
-  //llvm::outs() << "region: " << op->getRegion(0) << "\n";
-  //llvm::outs() << "combine: " << op.getCombineOp().cloneInto() << "\n";
-
   SmallVector<int64_t> refinedSrcShape = {srcShape[0], srcShape[1]};
   refinedSrcShape[axisNonReduce] /= numReps;
   int64_t elementsPerRep = refinedSrcShape[axisNonReduce];
-
   auto elemTy = srcType.getElementType();
   auto refinedTensorType = RankedTensorType::get(refinedSrcShape, elemTy, srcEncoding);
+
+  // Create refined ops.
   rewriter.setInsertionPointAfter(op);
   SmallVector<Value> refinedReduces;
   for (int i = 0; i < numReps; ++i) {
     SmallVector<int64_t> offset(refinedSrcShape.size(), 0);
     offset[axisReduce] = 0;
     offset[axisNonReduce] = i * elementsPerRep;
-    // Slice input.
     auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
       loc, Type{refinedTensorType}, Value{src}, offset);
-    llvm::outs() << "sliceOp: " << sliceOp << "\n\n";
-    // Reduce slice.
     auto reduceOp = rewriter.create<triton::ReduceOp>(
         op.getLoc(), ValueRange{sliceOp}, axisReduce);
-
     IRMapping mapping;
-    //for (auto operand : reduce.getOperands()) {
-    //  auto viewOp = builder.create<triton::ReshapeOp>(
-    //      reduce.getLoc(), viewOpTensorType, operand,
-    //      /*allowReorder=*/true, /*efficientLayout=*/true);
-    //  mapping.map(operand, viewOp);
-    //}
     mapping.map(reduceOp.getOperand(0), sliceOp);
-
     op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);
-    //llvm::outs() << "region: " << reduceOp->getRegion(0) << "\n";
-    //llvm::outs() << "combine: " << reduceOp.getCombineOp() << "\n";
-
-    //auto reduceOp3 = rewriter.create<triton::ReduceOp>(
-    //      op.getLoc(), ValueRange{sliceOp}, axisReduce);
-
-    //auto reduceOp = op.clone();
-    //reduceOp->getOperand(0).setType(refinedTensorType);
-
-
-    //addNamedAttrs(reduceOp, adaptor.getAttributes());
-
-    //auto &newCombineOp = newReduce.getCombineOp();
-    //rewriter.cloneRegionBefore(op.getCombineOp(), newCombineOp, newCombineOp.end());
-
-    // TODO need lambda function inside
-    llvm::outs() << "reduceOp: " << reduceOp << "\n\n";
-    //auto reduceResult = reduceOp.getResult();
-    //reduceResult.getType();
-    //Value reduceValue = mlir::dyn_cast<Value>(reduceOp);
-    //if (reduceValue == nullptr) {
-    //  llvm::outs() << "ERROR converting reduceOp to Value\n";
-    //}
-    llvm::outs() << "reduceOp.results: " << reduceOp.getNumResults() << "\n";
-
     refinedReduces.push_back(reduceOp->getResult(0));
   }
 
   // Concat reduce slices.
   auto reduceResultType = op.getResultTypes()[0];
   SmallVector<int64_t> concatDimShape = {numReps};
-  //concatDimShape[axisReduce] = 1;
   auto concatDims = DenseI64ArrayAttr::get(ctx, concatDimShape);
-  //llvm::outs() << "concatDimShape: " << concatDimShape[0] << "x" << concatDimShape[1] << "\n";
   auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
       loc, reduceResultType, refinedReduces, concatDims);
-
   auto origOpResult = op.getResult();
   origOpResult.replaceAllUsesWith(concatOp);
-  llvm::outs() << "replaced uses\n";
   op.erase();
-  llvm::outs() << "erase\n";
   return success();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -644,6 +644,8 @@ LogicalResult rewriteReduceOp(OpBuilder &rewriter, triton::ReduceOp op) {
   auto loc = op.getLoc();
   uint32_t axisReduce = op.getAxis();
   uint32_t axisNonReduce = (axisReduce+1)%2;
+  if (op.getNumOperands() != 1)
+   return failure();
 
   // Calculate refined shape.
   auto src = op->getOperand(0);
@@ -671,7 +673,7 @@ LogicalResult rewriteReduceOp(OpBuilder &rewriter, triton::ReduceOp op) {
     auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
       loc, Type{refinedTensorType}, Value{src}, offset);
     auto reduceOp = rewriter.create<triton::ReduceOp>(
-        op.getLoc(), ValueRange{sliceOp}, axisReduce);
+        loc, ValueRange{sliceOp}, axisReduce);
     IRMapping mapping;
     mapping.map(reduceOp.getOperand(0), sliceOp);
     op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);


### PR DESCRIPTION
Adds support for refining 2d tt.reduce ops prior to micro scheduling. Uses ttg::getShapePerCTATile() to determine how many independent reduce ops can be formed.



The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
