### PR TITLE
[release/internal/2.3.x] Conditionalize "libamd_comgr.so" based on rocm version

### DIFF
--- a/scripts/amd/setup_rocm_libs.sh
+++ b/scripts/amd/setup_rocm_libs.sh
@@ -59,11 +59,15 @@ fi
 ROCM_SO=(
     "${libamdhip}"
     "libhsa-runtime64.so.1"
-    "libamd_comgr.so.2"
     "libdrm.so.2"
     "libdrm_amdgpu.so.1"
 )
 
+if [[ $ROCM_INT -ge 60400 ]]; then
+    ROCM_SO+=("libamd_comgr.so.3")
+else
+    ROCM_SO+=("libamd_comgr.so.2")
+fi
 if [[ $ROCM_INT -ge 60100 ]]; then
     ROCM_SO+=("librocprofiler-register.so.0")
 fi	


### PR DESCRIPTION
Relates to: https://github.com/ROCm/pytorch/pull/1962
Newer ROCm builds than ROCm 6.3 need libamd_comgr.so.3 instead of libamd_comgr.so.2 
Breaking builds:
http://rocm-ci.amd.com/blue/organizations/jenkins/pytorch-pipeline-manylinux-wheel-builder_rel-6.4/detail/pytorch-pipeline-manylinux-wheel-builder_rel-6.4/95/pipeline/714/

Validation:
http://rocm-ci.amd.com/job/pytorch2.3-manylinux-wheels_rel-6.4/15/
