### PR TITLE
Refine pattern matching rework

### DIFF
--- a/test/TritonGPU/amd/ops-refinement/elementwise.mlir
+++ b/test/TritonGPU/amd/ops-refinement/elementwise.mlir
@@ -14,6 +14,7 @@
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @exp_kernel(%arg0: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
     %0 = math.exp2 %arg0 : tensor<128x32xf32, #blocked>
     tt.return %0 : tensor<128x32xf32, #blocked>
   }
@@ -39,6 +40,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mul_kernel(%arg0: tensor<128x32xf32, #blocked>, %arg1: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
     %0 = arith.mulf %arg0, %arg1 : tensor<128x32xf32, #blocked>
     tt.return %0 : tensor<128x32xf32, #blocked>
   }
@@ -58,6 +60,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #mma = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @multiple_operations_kernel(%arg0: tensor<128x32xf32, #mma>, %arg1: tensor<128x32xf32, #mma>) -> tensor<128x32xf32, #mma> attributes {noinline = false} {
+    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
     %0 = math.exp2 %arg0 : tensor<128x32xf32, #mma>
     %1 = math.exp2 %0 : tensor<128x32xf32, #mma>
     %2 = math.exp2 %1 : tensor<128x32xf32, #mma>
@@ -79,6 +82,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @nested_operations_kernel(%arg0: tensor<128x32xf32, #blocked>, %arg1: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
     %0 = arith.mulf %arg0, %arg1 : tensor<128x32xf32, #blocked>
     %c0 = arith.constant 0 : i32
     %c1 = arith.constant 1 : i32
@@ -88,5 +92,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield %2 : tensor<128x32xf32, #blocked>
     }
     tt.return %1 : tensor<128x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @peer_operations_kernel
+// CHECK: scf.for
+// CHECK-COUNT-4: amdgpu.extract_slice
+// CHECK: math.exp2
+// CHECK: amdgpu.concat
+// CHECK: scf.for
+// CHECK-NOT: amdgpu.extract_slice
+// CHECK: math.exp2
+// CHECK-NOT: amdgpu.concat
+// CHECK: }
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @peer_operations_kernel(%arg0: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %1 = scf.for %arg1 = %c0 to %c4 step %c1 iter_args(%arg2 = %arg0) -> (tensor<128x32xf32, #blocked>) : i32 {
+      amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
+      %2 = math.exp2 %arg2 : tensor<128x32xf32, #blocked>
+      scf.yield %2 : tensor<128x32xf32, #blocked>
+    }
+    %3 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %1) -> (tensor<128x32xf32, #blocked>) : i32 {
+      %4 = math.exp2 %arg4 : tensor<128x32xf32, #blocked>
+      scf.yield %4 : tensor<128x32xf32, #blocked>
+    }
+    tt.return %3 : tensor<128x32xf32, #blocked>
   }
 }

--- a/test/TritonGPU/amd/ops-refinement/elementwise.mlir
+++ b/test/TritonGPU/amd/ops-refinement/elementwise.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s -split-input-file -triton-amdgpu-refine-ops='arch=gfx942' | FileCheck %s
 
-// CHECK-LABEL: exp_kernel
+// CHECK-LABEL: @exp_kernel
 // CHECK-DAG: [[VALUE_1:%.*]] = amdgpu.extract_slice {{.*}} [0, 0]
 // CHECK-DAG: [[VALUE_2:%.*]] = math.exp2 [[VALUE_1]]
 // CHECK-DAG: [[VALUE_3:%.*]] = amdgpu.extract_slice {{.*}} [0, 16]
@@ -16,5 +16,77 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func public @exp_kernel(%arg0: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
     %0 = math.exp2 %arg0 : tensor<128x32xf32, #blocked>
     tt.return %0 : tensor<128x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: mul_kernel
+// CHECK-DAG: [[VALUE_1:%.*]] = amdgpu.extract_slice {{.*}} [0, 0]
+// CHECK-DAG: [[VALUE_2:%.*]] = amdgpu.extract_slice {{.*}} [0, 0]
+// CHECK-DAG: [[VALUE_3:%.*]] = arith.mulf [[VALUE_1]], [[VALUE_2]]
+// CHECK-DAG: [[VALUE_4:%.*]] = amdgpu.extract_slice {{.*}} [0, 16]
+// CHECK-DAG: [[VALUE_5:%.*]] = amdgpu.extract_slice {{.*}} [0, 16]
+// CHECK-DAG: [[VALUE_6:%.*]] = arith.mulf [[VALUE_4]], [[VALUE_5]]
+// CHECK-DAG: [[VALUE_7:%.*]] = amdgpu.extract_slice {{.*}} [64, 0]
+// CHECK-DAG: [[VALUE_8:%.*]] = amdgpu.extract_slice {{.*}} [64, 0]
+// CHECK-DAG: [[VALUE_9:%.*]] = arith.mulf [[VALUE_7]], [[VALUE_8]]
+// CHECK-DAG: [[VALUE_10:%.*]] = amdgpu.extract_slice {{.*}} [64, 16]
+// CHECK-DAG: [[VALUE_11:%.*]] = amdgpu.extract_slice {{.*}} [64, 16]
+// CHECK-DAG: [[VALUE_12:%.*]] = arith.mulf [[VALUE_10]], [[VALUE_11]]
+// CHECK-DAG: [[VALUE_13:%.*]] = amdgpu.concat [[VALUE_3]], [[VALUE_6]], [[VALUE_9]], [[VALUE_12]]
+// CHECK-DAG: tt.return [[VALUE_13]]
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mul_kernel(%arg0: tensor<128x32xf32, #blocked>, %arg1: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    %0 = arith.mulf %arg0, %arg1 : tensor<128x32xf32, #blocked>
+    tt.return %0 : tensor<128x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @multiple_operations_kernel
+
+// CHECK-COUNT-4: amdgpu.extract_slice {{.*}}
+// CHECK: [[OP1:%.*]] = amdgpu.concat
+// CHECK-COUNT-4: amdgpu.extract_slice [[OP1]]
+// CHECK: [[OP2:%.*]] = amdgpu.concat
+// CHECK-COUNT-4: amdgpu.extract_slice [[OP2]]
+// CHECK: [[OP3:%.*]] = amdgpu.concat
+// CHECK: tt.return [[OP3]]
+#mma = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_operations_kernel(%arg0: tensor<128x32xf32, #mma>, %arg1: tensor<128x32xf32, #mma>) -> tensor<128x32xf32, #mma> attributes {noinline = false} {
+    %0 = math.exp2 %arg0 : tensor<128x32xf32, #mma>
+    %1 = math.exp2 %0 : tensor<128x32xf32, #mma>
+    %2 = math.exp2 %1 : tensor<128x32xf32, #mma>
+    tt.return %2 : tensor<128x32xf32, #mma>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @nested_operations_kernel
+// CHECK-COUNT-8: amdgpu.extract_slice
+// CHECK: mulf
+// CHECK: amdgpu.concat
+// CHECK: scf.for
+// CHECK-COUNT-4: amdgpu.extract_slice
+// CHECK: math.exp2
+// CHECK: amdgpu.concat
+// CHECK: }
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @nested_operations_kernel(%arg0: tensor<128x32xf32, #blocked>, %arg1: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    %0 = arith.mulf %arg0, %arg1 : tensor<128x32xf32, #blocked>
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    %1 = scf.for %arg2 = %c0 to %c4 step %c1 iter_args(%arg3 = %0) -> (tensor<128x32xf32, #blocked>) : i32 {
+      %2 = math.exp2 %0 : tensor<128x32xf32, #blocked>
+      scf.yield %2 : tensor<128x32xf32, #blocked>
+    }
+    tt.return %1 : tensor<128x32xf32, #blocked>
   }
 }

--- a/test/TritonGPU/amd/ops-refinement/elementwise.mlir
+++ b/test/TritonGPU/amd/ops-refinement/elementwise.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt %s -split-input-file -triton-amdgpu-refine-ops='arch=gfx942' | FileCheck %s
+
+// CHECK-LABEL: tt.func public @exp_kernel([[VALUE_0:%.*]]
+// CHECK-DAG: [[VALUE_1:%.*]] = amdgpu.extract_slice [[VALUE_0]] [0, 0]
+// CHECK-DAG: [[VALUE_2:%.*]] = math.exp2 [[VALUE_1]]
+// CHECK-DAG: [[VALUE_3:%.*]] = amdgpu.extract_slice [[VALUE_0]] [0, 16]
+// CHECK-DAG: [[VALUE_4:%.*]] = math.exp2 [[VALUE_3]]
+// CHECK-DAG: [[VALUE_5:%.*]] = amdgpu.extract_slice [[VALUE_0]] [64, 0]
+// CHECK-DAG: [[VALUE_6:%.*]] = math.exp2 [[VALUE_5]]
+// CHECK-DAG: [[VALUE_7:%.*]] = amdgpu.extract_slice [[VALUE_0]] [64, 16]
+// CHECK-DAG: [[VALUE_8:%.*]] = math.exp2 [[VALUE_7]]
+// CHECK-DAG: [[VALUE_9:%.*]] = amdgpu.concat [[VALUE_2]], [[VALUE_4]], [[VALUE_6]], [[VALUE_8]]
+// CHECK-DAG: tt.return [[VALUE_9]]
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @exp_kernel(%arg0: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
+    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
+    %0 = math.exp2 %arg0 : tensor<128x32xf32, #blocked>
+    tt.return %0 : tensor<128x32xf32, #blocked>
+  }
+}

--- a/test/TritonGPU/amd/ops-refinement/elementwise.mlir
+++ b/test/TritonGPU/amd/ops-refinement/elementwise.mlir
@@ -1,13 +1,13 @@
 // RUN: triton-opt %s -split-input-file -triton-amdgpu-refine-ops='arch=gfx942' | FileCheck %s
 
-// CHECK-LABEL: tt.func public @exp_kernel([[VALUE_0:%.*]]
-// CHECK-DAG: [[VALUE_1:%.*]] = amdgpu.extract_slice [[VALUE_0]] [0, 0]
+// CHECK-LABEL: exp_kernel
+// CHECK-DAG: [[VALUE_1:%.*]] = amdgpu.extract_slice {{.*}} [0, 0]
 // CHECK-DAG: [[VALUE_2:%.*]] = math.exp2 [[VALUE_1]]
-// CHECK-DAG: [[VALUE_3:%.*]] = amdgpu.extract_slice [[VALUE_0]] [0, 16]
+// CHECK-DAG: [[VALUE_3:%.*]] = amdgpu.extract_slice {{.*}} [0, 16]
 // CHECK-DAG: [[VALUE_4:%.*]] = math.exp2 [[VALUE_3]]
-// CHECK-DAG: [[VALUE_5:%.*]] = amdgpu.extract_slice [[VALUE_0]] [64, 0]
+// CHECK-DAG: [[VALUE_5:%.*]] = amdgpu.extract_slice {{.*}} [64, 0]
 // CHECK-DAG: [[VALUE_6:%.*]] = math.exp2 [[VALUE_5]]
-// CHECK-DAG: [[VALUE_7:%.*]] = amdgpu.extract_slice [[VALUE_0]] [64, 16]
+// CHECK-DAG: [[VALUE_7:%.*]] = amdgpu.extract_slice {{.*}} [64, 16]
 // CHECK-DAG: [[VALUE_8:%.*]] = math.exp2 [[VALUE_7]]
 // CHECK-DAG: [[VALUE_9:%.*]] = amdgpu.concat [[VALUE_2]], [[VALUE_4]], [[VALUE_6]], [[VALUE_8]]
 // CHECK-DAG: tt.return [[VALUE_9]]

--- a/test/TritonGPU/amd/ops-refinement/elementwise.mlir
+++ b/test/TritonGPU/amd/ops-refinement/elementwise.mlir
@@ -14,7 +14,6 @@
 #blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @exp_kernel(%arg0: tensor<128x32xf32, #blocked>) -> tensor<128x32xf32, #blocked> attributes {noinline = false} {
-    amdgpu.instruction_sched_hint {isBufferLoadsAEnabled = false, isBufferLoadsBEnabled = false, numDsReadsA = #amdgpu.InstCounter<0, none>, numDsReadsB = #amdgpu.InstCounter<0, none>, numDsWritesA = #amdgpu.InstCounter<0, none>, numDsWritesB = #amdgpu.InstCounter<0, none>, numGlobalLoadsA = #amdgpu.InstCounter<0, none>, numGlobalLoadsB = #amdgpu.InstCounter<0, none>, numMMAs = #amdgpu.InstCounter<0, none>, variant = #amdgpu.SchedHintVariant<refine_ops>}
     %0 = math.exp2 %arg0 : tensor<128x32xf32, #blocked>
     tt.return %0 : tensor<128x32xf32, #blocked>
   }

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -48,7 +48,7 @@ std::unique_ptr<Pass> createTritonAMDGPUFoldTrueCmpIPass();
 
 std::unique_ptr<Pass> createTritonAMDGPUMembarAnalysisPass();
 
-std::unique_ptr<OperationPass<ModuleOp>>
+std::unique_ptr<OperationPass<mlir::triton::FuncOp>>
 createTritonAMDGPURefineOpsPass(StringRef targetArch);
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -289,7 +289,7 @@ def TritonAMDGPUMembarAnalysis : Pass<"triton-amdgpu-membar-analysis", "mlir::Mo
 }
 
 
-def TritonAMDGPURefineOps : Pass<"triton-amdgpu-refine-ops", "mlir::ModuleOp"> {
+def TritonAMDGPURefineOps : Pass<"triton-amdgpu-refine-ops", "mlir::triton::FuncOp"> {
     let summary = "Convert Triton Ops to fine-grain ones";
     let constructor = "mlir::createTritonAMDGPURefineOpsPass(\"\")";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -1045,12 +1045,39 @@ LogicalResult rewriteBroadcastOp(PatternRewriter &rewriter,
   return success();
 }
 
-struct LocalLoadOpPattern : public OpRewritePattern<triton::gpu::LocalLoadOp> {
-  LocalLoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+template <typename OpTy>
+struct RefineRewritePattern : public OpRewritePattern<OpTy> {
+  RefineRewritePattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern<OpTy>(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::gpu::LocalLoadOp op,
-                                PatternRewriter &rewriter) const override {
+  virtual LogicalResult apply(OpTy op, PatternRewriter &rewriter) const = 0;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const final {
+    if (!isRefinable(op))
+      return failure();
+    return apply(op, rewriter);
+  }
+
+private:
+  bool isRefinable(Operation *op) const {
+    auto result =
+        op->getBlock()->walk([](triton::amdgpu::InstructionSchedHint hint) {
+          if (hint.getVariant() == triton::amdgpu::SchedHint::refine_ops)
+            return WalkResult::interrupt();
+          return WalkResult::advance();
+        });
+    return result.wasInterrupted();
+  }
+};
+
+struct LocalLoadOpPattern
+    : public RefineRewritePattern<triton::gpu::LocalLoadOp> {
+  LocalLoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : RefineRewritePattern(context, benefit) {}
+
+  LogicalResult apply(triton::gpu::LocalLoadOp op,
+                      PatternRewriter &rewriter) const override {
     if (op->getNumOperands() != 1) {
       return failure();
     }
@@ -1062,12 +1089,12 @@ struct LocalLoadOpPattern : public OpRewritePattern<triton::gpu::LocalLoadOp> {
   }
 };
 
-struct DotOpPattern : public OpRewritePattern<triton::DotOp> {
+struct DotOpPattern : public RefineRewritePattern<triton::DotOp> {
   DotOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::DotOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::DotOp op,
+                      PatternRewriter &rewriter) const override {
     auto result = rewriteMFMA(rewriter, op);
     if (failed(result)) {
       LDBG("failed to refine tt.Dot: " << *op);
@@ -1076,12 +1103,12 @@ struct DotOpPattern : public OpRewritePattern<triton::DotOp> {
   }
 };
 
-struct LoadOpPattern : public OpRewritePattern<triton::LoadOp> {
+struct LoadOpPattern : public RefineRewritePattern<triton::LoadOp> {
   LoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::LoadOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::LoadOp op,
+                      PatternRewriter &rewriter) const override {
     if (op->getNumOperands() != 1) {
       return failure();
     }
@@ -1094,12 +1121,12 @@ struct LoadOpPattern : public OpRewritePattern<triton::LoadOp> {
 };
 
 struct LocalStoreOpPattern
-    : public OpRewritePattern<triton::gpu::LocalStoreOp> {
+    : public RefineRewritePattern<triton::gpu::LocalStoreOp> {
   LocalStoreOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::gpu::LocalStoreOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::gpu::LocalStoreOp op,
+                      PatternRewriter &rewriter) const override {
     if (op->getNumOperands() != 2) {
       return failure();
     }
@@ -1111,12 +1138,12 @@ struct LocalStoreOpPattern
   }
 };
 
-struct ReduceOpPattern : public OpRewritePattern<triton::ReduceOp> {
+struct ReduceOpPattern : public RefineRewritePattern<triton::ReduceOp> {
   ReduceOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::ReduceOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::ReduceOp op,
+                      PatternRewriter &rewriter) const override {
     auto result = rewriteReduceOp(rewriter, op);
     if (failed(result)) {
       LDBG("failed to refine tt.reduce: " << *op);
@@ -1126,12 +1153,11 @@ struct ReduceOpPattern : public OpRewritePattern<triton::ReduceOp> {
 };
 
 template <typename OpTy>
-struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
+struct ElementWiseOpPattern : public RefineRewritePattern<OpTy> {
   ElementWiseOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern<OpTy>(context, benefit) {}
+      : RefineRewritePattern<OpTy>(context, benefit) {}
 
-  LogicalResult matchAndRewrite(OpTy op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(OpTy op, PatternRewriter &rewriter) const override {
     auto result = rewriteElementWiseOp<OpTy>(rewriter, op);
     if (failed(result)) {
       LDBG("failed to refine elementwise op: " << *op);
@@ -1140,12 +1166,12 @@ struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
   }
 };
 
-struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
+struct ExpandDimsOpPattern : public RefineRewritePattern<triton::ExpandDimsOp> {
   ExpandDimsOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::ExpandDimsOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::ExpandDimsOp op,
+                      PatternRewriter &rewriter) const override {
     auto result = rewriteExpandDimsOp(rewriter, op);
     if (failed(result)) {
       LDBG("failed to refine tt.expand_dims: " << *op);
@@ -1154,12 +1180,12 @@ struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
   }
 };
 
-struct BroadcastOpPattern : public OpRewritePattern<BroadcastOp> {
+struct BroadcastOpPattern : public RefineRewritePattern<BroadcastOp> {
   BroadcastOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+      : RefineRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(triton::BroadcastOp op,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult apply(triton::BroadcastOp op,
+                      PatternRewriter &rewriter) const override {
     auto result = rewriteBroadcastOp(rewriter, op);
     if (failed(result)) {
       LDBG("failed to refine tt.broadcast: " << *op);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -1061,13 +1061,18 @@ struct RefineRewritePattern : public OpRewritePattern<OpTy> {
 
 private:
   bool isRefinable(Operation *op) const {
-    auto result =
-        op->getBlock()->walk([](triton::amdgpu::InstructionSchedHint hint) {
-          if (hint.getVariant() == triton::amdgpu::SchedHint::refine_ops)
-            return WalkResult::interrupt();
-          return WalkResult::advance();
-        });
-    return result.wasInterrupted();
+    mlir::Block *block = op->getBlock();
+    while (block) {
+      for (auto &op : block->getOperations()) {
+        if (auto hint = dyn_cast<triton::amdgpu::InstructionSchedHint>(op)) {
+          if (hint.getVariant() == triton::amdgpu::SchedHint::refine_ops) {
+            return true;
+          }
+        }
+      }
+      block = block->getParentOp()->getBlock();
+    }
+    return false;
   }
 };
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -1064,14 +1064,14 @@ struct TritonAMDGPURefineOps
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    ModuleOp mod = getOperation();
+    mlir::triton::FuncOp func = getOperation();
     mlir::triton::AMD::TargetInfo targetInfo(this->arch.getValue());
     if (targetInfo.getISAFamily() == mlir::triton::AMD::ISAFamily::Unknown) {
-      mod.emitError("unsupported target: '") << this->arch.getValue() << "'";
+      func.emitError("unsupported target: '") << this->arch.getValue() << "'";
       return signalPassFailure();
     }
 
-    mod->walk([&](amdgpu::InstructionSchedHint hint) {
+    func->walk([&](amdgpu::InstructionSchedHint hint) {
       if (hint.getVariant() != amdgpu::SchedHint::refine_ops) {
         return WalkResult::advance();
       }
@@ -1187,7 +1187,7 @@ private:
 
 namespace mlir {
 
-std::unique_ptr<OperationPass<ModuleOp>>
+std::unique_ptr<OperationPass<mlir::triton::FuncOp>>
 createTritonAMDGPURefineOpsPass(StringRef targetArch) {
   return std::make_unique<TritonAMDGPURefineOps>(targetArch);
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -952,7 +952,8 @@ LogicalResult rewriteExpandDimsOp(PatternRewriter &rewriter,
 //        \             <64x32>   /
 //         -> <64x1> -> <64x32>  /
 //                      <64x32> /
-LogicalResult rewriteBroadcastOp(PatternRewriter &rewriter, BroadcastOp op) {
+LogicalResult rewriteBroadcastOp(PatternRewriter &rewriter,
+                                 triton::BroadcastOp op) {
   // src tensor e.g. <128x1>.
   int numOperands = op->getNumOperands();
   if (op->getNumOperands() != 1)
@@ -1157,7 +1158,7 @@ struct BroadcastOpPattern : public OpRewritePattern<BroadcastOp> {
   BroadcastOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
       : OpRewritePattern(context, benefit) {}
 
-  LogicalResult matchAndRewrite(BroadcastOp op,
+  LogicalResult matchAndRewrite(triton::BroadcastOp op,
                                 PatternRewriter &rewriter) const override {
     auto result = rewriteBroadcastOp(rewriter, op);
     if (failed(result)) {
@@ -1175,7 +1176,7 @@ struct TritonAMDGPURefineOps
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    mlir::triton::FuncOp func = getOperation();
+    triton::FuncOp func = getOperation();
     mlir::triton::AMD::TargetInfo targetInfo(this->arch.getValue());
     if (targetInfo.getISAFamily() == mlir::triton::AMD::ISAFamily::Unknown) {
       func.emitError("unsupported target: '") << this->arch.getValue() << "'";
@@ -1242,7 +1243,7 @@ struct TritonAMDGPURefineOps
 
 namespace mlir {
 
-std::unique_ptr<OperationPass<mlir::triton::FuncOp>>
+std::unique_ptr<OperationPass<triton::FuncOp>>
 createTritonAMDGPURefineOpsPass(StringRef targetArch) {
   return std::make_unique<TritonAMDGPURefineOps>(targetArch);
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -12,6 +12,7 @@
 // #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 // #include "triton/Analysis/Allocation.h"
 // #include "triton/Analysis/AxisInfo.h"
@@ -91,108 +92,113 @@ inline bool isRowMajor(::llvm::ArrayRef<unsigned> order) {
   return order[rank - 1] == 0;
 }
 
-LogicalResult rewriteLocalLoad(OpBuilder &rewriter,
-                               triton::gpu::LocalLoadOp op) {
-  auto *ctx = op->getContext();
-  auto loc = op->getLoc();
+struct LocalLoadOpPattern : public OpRewritePattern<triton::gpu::LocalLoadOp> {
+  LocalLoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  auto resultType = cast<RankedTensorType>(op.getType());
-  auto resultElementType = resultType.getElementType();
-  auto resultEncode = cast<DotOperandEncodingAttr>(resultType.getEncoding());
-  auto resultShape = resultType.getShape();
+  LogicalResult matchAndRewrite(triton::gpu::LocalLoadOp op,
+                                PatternRewriter &rewriter) const override {
+    auto *ctx = op->getContext();
+    auto loc = op->getLoc();
 
-  const auto rank = resultShape.size();
-  assert(rank == 2);
+    auto resultType = cast<RankedTensorType>(op.getType());
+    auto resultElementType = resultType.getElementType();
+    auto resultEncode = cast<DotOperandEncodingAttr>(resultType.getEncoding());
+    auto resultShape = resultType.getShape();
 
-  auto opIdx = resultEncode.getOpIdx();
-  const int kDimIdx = opIdx == 0 ? rank - 1 : rank - 2;
-  const int nonKDimIdx = opIdx == 0 ? rank - 2 : rank - 1;
+    const auto rank = resultShape.size();
+    assert(rank == 2);
 
-  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(resultEncode.getParent());
-  int kWidth = resultEncode.getKWidth();
-  auto numReps = mfmaLayout.getRepForOperand(resultShape, kWidth, opIdx);
+    auto opIdx = resultEncode.getOpIdx();
+    const int kDimIdx = opIdx == 0 ? rank - 1 : rank - 2;
+    const int nonKDimIdx = opIdx == 0 ? rank - 2 : rank - 1;
 
-  // indices into 3D numReps
-  int kRepsIdx = opIdx == 0 ? 2 : 1;
-  int nonKRepsIdx = opIdx == 0 ? 1 : 2;
-  int bRepsIdx = 0;
+    auto mfmaLayout = cast<AMDMfmaEncodingAttr>(resultEncode.getParent());
+    int kWidth = resultEncode.getKWidth();
+    auto numReps = mfmaLayout.getRepForOperand(resultShape, kWidth, opIdx);
 
-  // 2D shape which drops batch dimension.
-  SmallVector<int64_t> numReps2D = {numReps[1], numReps[2]};
+    // indices into 3D numReps
+    int kRepsIdx = opIdx == 0 ? 2 : 1;
+    int nonKRepsIdx = opIdx == 0 ? 1 : 2;
+    int bRepsIdx = 0;
 
-  auto numRepsNonK = numReps[nonKRepsIdx];
-  auto numRepsK = numReps[kRepsIdx];
-  auto numRepsB = numReps[bRepsIdx];
+    // 2D shape which drops batch dimension.
+    SmallVector<int64_t> numReps2D = {numReps[1], numReps[2]};
 
-  auto memDesc = op->getOperand(0);
-  auto memDescType = cast<ttg::MemDescType>(memDesc.getType());
-  auto memDescEncoding = memDescType.getEncoding();
-  SmallVector<unsigned int> order;
-  if (auto enc =
-          dyn_cast<triton::gpu::SwizzledSharedEncodingAttr>(memDescEncoding)) {
-    order = decltype(order)(enc.getOrder());
-  }
-  if (auto enc = dyn_cast<triton::gpu::AMDRotatingSharedEncodingAttr>(
-          memDescEncoding)) {
-    order = decltype(order)(enc.getOrder());
-  }
-  assert(!order.empty());
+    auto numRepsNonK = numReps[nonKRepsIdx];
+    auto numRepsK = numReps[kRepsIdx];
+    auto numRepsB = numReps[bRepsIdx];
 
-  SmallVector<int64_t> refinedShape = {resultShape[0] / numReps2D[0],
-                                       resultShape[1] / numReps2D[1]};
-  LDBG("refinedShape: " << refinedShape[0] << "x" << refinedShape[1]);
-
-  auto refinedTensorType =
-      RankedTensorType::get(refinedShape, resultElementType, resultEncode);
-
-  constexpr bool mutableMemory = true;
-  auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
-  auto subviewType = ttg::MemDescType::get(
-      refinedShape, memDescType.getElementType(), memDescType.getEncoding(),
-      sharedMemorySpace, mutableMemory, memDescType.getAllocShape());
-
-  rewriter.setInsertionPointAfter(op);
-  SmallVector<Value> subtiles;
-  for (int32_t i = 0; i < numReps2D[0]; ++i) {
-    for (int32_t j = 0; j < numReps2D[1]; ++j) {
-      int32_t offset0 = i * refinedShape[0];
-      int32_t offset1 = j * refinedShape[1];
-      auto offset = createOffset({}, {offset0, offset1}, rewriter, loc);
-      auto refinedView = rewriter.create<ttg::MemDescSubviewOp>(
-          loc, subviewType, memDesc, offset);
-      LDBG("RefinedLocalLoadSubvew: " << *refinedView);
-
-      auto refinedLoad = rewriter.create<ttg::LocalLoadOp>(
-          loc, refinedTensorType, refinedView);
-      subtiles.push_back(refinedLoad);
+    auto memDesc = op->getOperand(0);
+    auto memDescType = cast<ttg::MemDescType>(memDesc.getType());
+    auto memDescEncoding = memDescType.getEncoding();
+    SmallVector<unsigned int> order;
+    if (auto enc = dyn_cast<triton::gpu::SwizzledSharedEncodingAttr>(
+            memDescEncoding)) {
+      order = decltype(order)(enc.getOrder());
     }
+    if (auto enc = dyn_cast<triton::gpu::AMDRotatingSharedEncodingAttr>(
+            memDescEncoding)) {
+      order = decltype(order)(enc.getOrder());
+    }
+    assert(!order.empty());
+
+    SmallVector<int64_t> refinedShape = {resultShape[0] / numReps2D[0],
+                                         resultShape[1] / numReps2D[1]};
+    LDBG("refinedShape: " << refinedShape[0] << "x" << refinedShape[1]);
+
+    auto refinedTensorType =
+        RankedTensorType::get(refinedShape, resultElementType, resultEncode);
+
+    constexpr bool mutableMemory = true;
+    auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto subviewType = ttg::MemDescType::get(
+        refinedShape, memDescType.getElementType(), memDescType.getEncoding(),
+        sharedMemorySpace, mutableMemory, memDescType.getAllocShape());
+
+    rewriter.setInsertionPointAfter(op);
+    SmallVector<Value> subtiles;
+    for (int32_t i = 0; i < numReps2D[0]; ++i) {
+      for (int32_t j = 0; j < numReps2D[1]; ++j) {
+        int32_t offset0 = i * refinedShape[0];
+        int32_t offset1 = j * refinedShape[1];
+        auto offset = createOffset({}, {offset0, offset1}, rewriter, loc);
+        auto refinedView = rewriter.create<ttg::MemDescSubviewOp>(
+            loc, subviewType, memDesc, offset);
+        LDBG("RefinedLocalLoadSubvew: " << *refinedView);
+
+        auto refinedLoad = rewriter.create<ttg::LocalLoadOp>(
+            loc, refinedTensorType, refinedView);
+        subtiles.push_back(refinedLoad);
+      }
+    }
+
+    // concat dims is correct shape 8x1 vs 1x8, else gives wrong output shape.
+    std::vector<int64_t> loweringOrder(numReps2D.size());
+    int64_t counter = 0;
+    auto increment = [&counter](int64_t &val) { val = counter++; };
+    if (opIdx == 0)
+      std::for_each(loweringOrder.rbegin(), loweringOrder.rend(), increment);
+    else
+      std::for_each(loweringOrder.begin(), loweringOrder.end(), increment);
+
+    auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
+        loc, resultType, subtiles, numReps2D, loweringOrder);
+    LDBG("ConcatOp: " << *joinedResult);
+
+    rewriter.replaceOp(op, joinedResult);
+    return success();
   }
-
-  // concat dims is correct shape 8x1 vs 1x8, else gives wrong output shape.
-  std::vector<int64_t> loweringOrder(numReps2D.size());
-  int64_t counter = 0;
-  auto increment = [&counter](int64_t &val) { val = counter++; };
-  if (opIdx == 0)
-    std::for_each(loweringOrder.rbegin(), loweringOrder.rend(), increment);
-  else
-    std::for_each(loweringOrder.begin(), loweringOrder.end(), increment);
-
-  auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
-      loc, resultType, subtiles, numReps2D, loweringOrder);
-  LDBG("ConcatOp: " << *joinedResult);
-
-  op.replaceAllUsesWith(joinedResult.getResult());
-  return success();
-}
+};
 
 struct DotOpMFMAConverter {
   AMDMfmaEncodingAttr mfmaLayout;
-  OpBuilder &rewriter;
+  PatternRewriter &rewriter;
   Location loc;
   MLIRContext *ctx{};
 
   explicit DotOpMFMAConverter(AMDMfmaEncodingAttr mfmaLayout,
-                              OpBuilder &rewriter, Location loc)
+                              PatternRewriter &rewriter, Location loc)
       : mfmaLayout(mfmaLayout), rewriter(rewriter), loc(loc),
         ctx(mfmaLayout.getContext()) {}
 
@@ -463,7 +469,7 @@ struct DotOpMFMAConverter {
 
     // Note: dangling localLoadA or/and localLoadB (if exist)
     // should be removed by the dead code elimination pass
-    dotOp.erase();
+    rewriter.eraseOp(dotOp);
     return success();
   }
 };
@@ -472,33 +478,39 @@ inline RankedTensorType rankedTType(Value tensor) {
   return cast<RankedTensorType>(tensor.getType());
 };
 
-LogicalResult rewriteMFMA(OpBuilder &rewriter, triton::DotOp op) {
-  if (!(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
-        isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()))) {
-    LDBG("Both $a and %b should be DotOperand layout");
-    return failure();
+struct DotOpPattern : public OpRewritePattern<triton::DotOp> {
+  DotOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::DotOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
+          isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()))) {
+      LDBG("Both $a and %b should be DotOperand layout");
+      return failure();
+    }
+
+    auto cTensorTy = rankedTType(op.getC());
+    auto dTensorTy = rankedTType(op.getD());
+    if (!isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding())) {
+      LDBG("Currently, we only support $c with a mfma layout");
+      return failure();
+    }
+
+    if (!(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
+          cTensorTy.getShape()[1] == dTensorTy.getShape()[1])) {
+      LDBG("DotOp's $c operand should pass the same number of values as $d");
+      return failure();
+    }
+
+    auto loc = op.getLoc();
+    auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+        cast<RankedTensorType>(op.getResult().getType()).getEncoding());
+
+    DotOpMFMAConverter converter(mfmaLayout, rewriter, loc);
+    return converter.convert(op, DotOpAdaptor(op));
   }
-
-  auto cTensorTy = rankedTType(op.getC());
-  auto dTensorTy = rankedTType(op.getD());
-  if (!isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding())) {
-    LDBG("Currently, we only support $c with a mfma layout");
-    return failure();
-  }
-
-  if (!(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
-        cTensorTy.getShape()[1] == dTensorTy.getShape()[1])) {
-    LDBG("DotOp's $c operand should pass the same number of values as $d");
-    return failure();
-  }
-
-  auto loc = op.getLoc();
-  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
-      cast<RankedTensorType>(op.getResult().getType()).getEncoding());
-
-  DotOpMFMAConverter converter(mfmaLayout, rewriter, loc);
-  return converter.convert(op, DotOpAdaptor(op));
-}
+};
 
 struct RefinedBlock {
   RefinedBlock(ArrayRef<int64_t> shape, Type elemType,
@@ -536,171 +548,190 @@ struct RefinedBlock {
   RankedTensorType tensorType;
 };
 
-LogicalResult rewriteLoadOp(OpBuilder &rewriter, triton::LoadOp loadOp) {
-  auto ctx = loadOp->getContext();
-  auto loc = loadOp.getLoc();
+struct LoadOpPattern : public OpRewritePattern<triton::LoadOp> {
+  LoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  Value origSrc = loadOp->getOperand(0);
-  Value origResult = loadOp.getResult();
-  Type origResultType = loadOp.getResult().getType();
-  auto origPtrs = rankedTType(origSrc);
-  auto origShape = origPtrs.getShape();
-  auto elemType = origPtrs.getElementType();
-  auto encoding = dyn_cast<BlockedEncodingAttr>(origPtrs.getEncoding());
-  if (encoding == nullptr)
-    return failure();
+  LogicalResult matchAndRewrite(triton::LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = loadOp->getContext();
+    auto loc = loadOp.getLoc();
 
-  RefinedBlock refinedBlock(origShape, elemType, encoding);
+    Value origSrc = loadOp->getOperand(0);
+    Value origResult = loadOp.getResult();
+    Type origResultType = loadOp.getResult().getType();
+    auto origPtrs = rankedTType(origSrc);
+    auto origShape = origPtrs.getShape();
+    auto elemType = origPtrs.getElementType();
+    auto encoding = dyn_cast<BlockedEncodingAttr>(origPtrs.getEncoding());
+    if (encoding == nullptr)
+      return failure();
 
-  rewriter.setInsertionPointAfter(loadOp);
-  SmallVector<Value> refinedTensors;
+    RefinedBlock refinedBlock(origShape, elemType, encoding);
 
-  Value mask = loadOp.getMask();
-  Value other = loadOp.getOther();
-  auto boundaryCheck = loadOp.getBoundaryCheck();
-  auto padding = loadOp.getPadding();
-  auto cache = loadOp.getCache();
-  auto evict = loadOp.getEvict();
-  auto isVolatile = loadOp.getIsVolatile();
+    rewriter.setInsertionPointAfter(loadOp);
+    SmallVector<Value> refinedTensors;
 
-  AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
-  for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
-       ++linearIdx) {
-    auto coords = coordsMapper.map(linearIdx);
-    SmallVector<int64_t> offset(refinedBlock.numDims, 0);
-    for (auto [dim, coord] : llvm::enumerate(coords)) {
-      offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
+    Value mask = loadOp.getMask();
+    Value other = loadOp.getOther();
+    auto boundaryCheck = loadOp.getBoundaryCheck();
+    auto padding = loadOp.getPadding();
+    auto cache = loadOp.getCache();
+    auto evict = loadOp.getEvict();
+    auto isVolatile = loadOp.getIsVolatile();
+
+    AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
+    for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
+         ++linearIdx) {
+      auto coords = coordsMapper.map(linearIdx);
+      SmallVector<int64_t> offset(refinedBlock.numDims, 0);
+      for (auto [dim, coord] : llvm::enumerate(coords)) {
+        offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
+      }
+
+      auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
+
+      auto refinedTensor = rewriter.create<triton::LoadOp>(
+          loc, slice, mask, other, boundaryCheck, padding, cache, evict,
+          isVolatile);
+      refinedTensors.push_back(refinedTensor);
     }
 
-    auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-        loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
+    auto concatDims = DenseI64ArrayAttr::get(ctx, refinedBlock.numPerDims);
+    auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
+        loc, origResultType, refinedTensors, concatDims);
 
-    auto refinedTensor =
-        rewriter.create<triton::LoadOp>(loc, slice, mask, other, boundaryCheck,
-                                        padding, cache, evict, isVolatile);
-    refinedTensors.push_back(refinedTensor);
+    origResult.replaceAllUsesWith(joinedResult);
+    return success();
   }
+};
 
-  auto concatDims = DenseI64ArrayAttr::get(ctx, refinedBlock.numPerDims);
-  auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
-      loc, origResultType, refinedTensors, concatDims);
+struct LocalStoreOpPattern
+    : public OpRewritePattern<triton::gpu::LocalStoreOp> {
+  LocalStoreOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  origResult.replaceAllUsesWith(joinedResult);
-  return success();
-}
+  LogicalResult matchAndRewrite(triton::gpu::LocalStoreOp loadStoreOp,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = loadStoreOp->getContext();
+    auto loc = loadStoreOp.getLoc();
 
-LogicalResult rewriteLocalStoreOp(OpBuilder &rewriter,
-                                  triton::gpu::LocalStoreOp loadStoreOp) {
-  auto ctx = loadStoreOp->getContext();
-  auto loc = loadStoreOp.getLoc();
+    Value origSrc = loadStoreOp->getOperand(0);
+    auto origMemViewOp =
+        cast<ttg::MemDescSubviewOp>(loadStoreOp->getOperand(1).getDefiningOp());
+    Value origMemView = origMemViewOp->getOperand(0);
+    Value selectValue = origMemViewOp.getOffsets().front();
 
-  Value origSrc = loadStoreOp->getOperand(0);
-  auto origMemViewOp =
-      cast<ttg::MemDescSubviewOp>(loadStoreOp->getOperand(1).getDefiningOp());
-  Value origMemView = origMemViewOp->getOperand(0);
-  Value selectValue = origMemViewOp.getOffsets().front();
+    auto origSrcType = rankedTType(origSrc);
+    auto blockEncoding =
+        dyn_cast<BlockedEncodingAttr>(origSrcType.getEncoding());
+    if (blockEncoding == nullptr)
+      return failure();
 
-  auto origSrcType = rankedTType(origSrc);
-  auto blockEncoding = dyn_cast<BlockedEncodingAttr>(origSrcType.getEncoding());
-  if (blockEncoding == nullptr)
-    return failure();
+    auto origMemViewType = cast<ttg::MemDescType>(origMemView.getType());
+    auto sharedEncoding = cast<triton::gpu::SwizzledSharedEncodingAttr>(
+        origMemViewType.getEncoding());
+    if (sharedEncoding == nullptr)
+      return failure();
 
-  auto origMemViewType = cast<ttg::MemDescType>(origMemView.getType());
-  auto sharedEncoding = cast<triton::gpu::SwizzledSharedEncodingAttr>(
-      origMemViewType.getEncoding());
-  if (sharedEncoding == nullptr)
-    return failure();
+    RefinedBlock refinedBlock(origSrcType.getShape(),
+                              origSrcType.getElementType(), blockEncoding);
 
-  RefinedBlock refinedBlock(origSrcType.getShape(),
-                            origSrcType.getElementType(), blockEncoding);
+    constexpr bool mutableMemory = true;
+    auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
 
-  constexpr bool mutableMemory = true;
-  auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto subviewType = ttg::MemDescType::get(
+        refinedBlock.refinedShape, refinedBlock.elemType, sharedEncoding,
+        sharedMemorySpace, mutableMemory, origMemViewType.getAllocShape());
 
-  auto subviewType = ttg::MemDescType::get(
-      refinedBlock.refinedShape, refinedBlock.elemType, sharedEncoding,
-      sharedMemorySpace, mutableMemory, origMemViewType.getAllocShape());
+    rewriter.setInsertionPointAfter(loadStoreOp);
+    AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
+    for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
+         ++linearIdx) {
+      auto coords = coordsMapper.map(linearIdx);
+      SmallVector<int64_t> offset(refinedBlock.numDims, 0);
+      for (auto [dim, coord] : llvm::enumerate(coords)) {
+        offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
+      }
+      auto offsetValues = createOffset({selectValue}, offset, rewriter, loc);
+      auto slicedSharedMemView = rewriter.create<ttg::MemDescSubviewOp>(
+          loc, subviewType, origMemView, offsetValues);
 
-  rewriter.setInsertionPointAfter(loadStoreOp);
-  AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
-  for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
-       ++linearIdx) {
-    auto coords = coordsMapper.map(linearIdx);
-    SmallVector<int64_t> offset(refinedBlock.numDims, 0);
-    for (auto [dim, coord] : llvm::enumerate(coords)) {
-      offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
+      auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
+
+      rewriter.create<ttg::LocalStoreOp>(loc, slice, slicedSharedMemView);
     }
-    auto offsetValues = createOffset({selectValue}, offset, rewriter, loc);
-    auto slicedSharedMemView = rewriter.create<ttg::MemDescSubviewOp>(
-        loc, subviewType, origMemView, offsetValues);
 
-    auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-        loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
-
-    rewriter.create<ttg::LocalStoreOp>(loc, slice, slicedSharedMemView);
+    rewriter.eraseOp(loadStoreOp);
+    return success();
   }
-
-  loadStoreOp.erase();
-  return success();
-}
+};
 
 // Reduce ops have different intput and output shapes and produce
 // sliced layouts.
 // This currently only supports 2d inputs.
-LogicalResult rewriteReduceOp(OpBuilder &rewriter, triton::ReduceOp op) {
-  auto ctx = op->getContext();
-  auto loc = op.getLoc();
-  uint32_t axisReduce = op.getAxis();
-  uint32_t axisNonReduce = (axisReduce + 1) % 2;
-  if (op.getNumOperands() != 1)
-    return failure();
+struct ReduceOpPattern : public OpRewritePattern<triton::ReduceOp> {
+  ReduceOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  // Calculate refined shape.
-  auto src = op->getOperand(0);
-  auto srcType = rankedTType(src);
-  if (srcType.getRank() != 2)
-    return failure();
-  auto srcShape = srcType.getShape();
-  auto srcEncoding = srcType.getEncoding();
-  auto srcShapePerCtaTile = triton::gpu::getShapePerCTATile(srcType);
-  SmallVector<int64_t> repShape = {srcShape[0] / srcShapePerCtaTile[0],
-                                   srcShape[1] / srcShapePerCtaTile[1]};
-  int numReps = repShape[axisNonReduce];
-  SmallVector<int64_t> refinedSrcShape = {srcShape[0], srcShape[1]};
-  refinedSrcShape[axisNonReduce] /= numReps;
-  int64_t elementsPerRep = refinedSrcShape[axisNonReduce];
-  auto elemTy = srcType.getElementType();
-  auto refinedTensorType =
-      RankedTensorType::get(refinedSrcShape, elemTy, srcEncoding);
+  LogicalResult matchAndRewrite(triton::ReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = op->getContext();
+    auto loc = op.getLoc();
+    uint32_t axisReduce = op.getAxis();
+    uint32_t axisNonReduce = (axisReduce + 1) % 2;
+    if (op.getNumOperands() != 1)
+      return failure();
 
-  // Create refined ops.
-  rewriter.setInsertionPointAfter(op);
-  SmallVector<Value> refinedReduces;
-  for (int i = 0; i < numReps; ++i) {
-    SmallVector<int64_t> offset(refinedSrcShape.size(), 0);
-    offset[axisReduce] = 0;
-    offset[axisNonReduce] = i * elementsPerRep;
-    auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-        loc, Type{refinedTensorType}, Value{src}, offset);
-    auto reduceOp =
-        rewriter.create<triton::ReduceOp>(loc, ValueRange{sliceOp}, axisReduce);
-    IRMapping mapping;
-    mapping.map(reduceOp.getOperand(0), sliceOp);
-    op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);
-    refinedReduces.push_back(reduceOp->getResult(0));
+    // Calculate refined shape.
+    auto src = op->getOperand(0);
+    auto srcType = rankedTType(src);
+    if (srcType.getRank() != 2)
+      return failure();
+    auto srcShape = srcType.getShape();
+    auto srcEncoding = srcType.getEncoding();
+    auto srcShapePerCtaTile = triton::gpu::getShapePerCTATile(srcType);
+    SmallVector<int64_t> repShape = {srcShape[0] / srcShapePerCtaTile[0],
+                                     srcShape[1] / srcShapePerCtaTile[1]};
+    int numReps = repShape[axisNonReduce];
+    SmallVector<int64_t> refinedSrcShape = {srcShape[0], srcShape[1]};
+    refinedSrcShape[axisNonReduce] /= numReps;
+    int64_t elementsPerRep = refinedSrcShape[axisNonReduce];
+    auto elemTy = srcType.getElementType();
+    auto refinedTensorType =
+        RankedTensorType::get(refinedSrcShape, elemTy, srcEncoding);
+
+    // Create refined ops.
+    rewriter.setInsertionPointAfter(op);
+    SmallVector<Value> refinedReduces;
+    for (int i = 0; i < numReps; ++i) {
+      SmallVector<int64_t> offset(refinedSrcShape.size(), 0);
+      offset[axisReduce] = 0;
+      offset[axisNonReduce] = i * elementsPerRep;
+      auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          loc, Type{refinedTensorType}, Value{src}, offset);
+      auto reduceOp = rewriter.create<triton::ReduceOp>(
+          loc, ValueRange{sliceOp}, axisReduce);
+      IRMapping mapping;
+      mapping.map(reduceOp.getOperand(0), sliceOp);
+      op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);
+      refinedReduces.push_back(reduceOp->getResult(0));
+    }
+
+    // Concat reduce slices.
+    auto reduceResultType = op.getResultTypes()[0];
+    SmallVector<int64_t> concatDimShape = {numReps};
+    auto concatDims = DenseI64ArrayAttr::get(ctx, concatDimShape);
+    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+        loc, reduceResultType, refinedReduces, concatDims);
+    auto origOpResult = op.getResult();
+    origOpResult.replaceAllUsesWith(concatOp);
+    rewriter.eraseOp(op);
+    return success();
   }
-
-  // Concat reduce slices.
-  auto reduceResultType = op.getResultTypes()[0];
-  SmallVector<int64_t> concatDimShape = {numReps};
-  auto concatDims = DenseI64ArrayAttr::get(ctx, concatDimShape);
-  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-      loc, reduceResultType, refinedReduces, concatDims);
-  auto origOpResult = op.getResult();
-  origOpResult.replaceAllUsesWith(concatOp);
-  op.erase();
-  return success();
-}
+};
 
 SmallVector<unsigned> getRefinedShapePerCTATile(Type type) {
   auto tensorType = cast<mlir::RankedTensorType>(type);
@@ -710,123 +741,125 @@ SmallVector<unsigned> getRefinedShapePerCTATile(Type type) {
 // Refine ops with distributed layouts.
 // Assumes same layout for operands.
 template <typename OpTy>
-LogicalResult rewriteElementWiseOp(OpBuilder &rewriter, OpTy op) {
-  // Verify opd[0] is valid.
-  int numOperands = op->getNumOperands();
-  if (op->getNumOperands() < 1)
-    return failure();
-  auto src = op->getOperand(0);
-  if (!isa<mlir::RankedTensorType>(src.getType()))
-    return failure();
-  auto srcType = rankedTType(src);
-  auto rank = srcType.getRank();
-  if (rank != 2) { // TODO(dtanner) remove me
-    return failure();
-  }
+struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
+  ElementWiseOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern<OpTy>(context, benefit) {}
 
-  auto srcShape = srcType.getShape();
-  auto srcEncoding = srcType.getEncoding();
-  auto srcLL = ttg::toLinearEncoding(srcType);
-  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
-
-  // Verify subsequent operands match opd[0].
-  for (int i = 1; i < numOperands; ++i) {
-    if (!isa<mlir::RankedTensorType>(op->getOperand(i).getType()))
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    // Verify opd[0] is valid.
+    int numOperands = op->getNumOperands();
+    if (op->getNumOperands() < 1)
       return failure();
-    if (rankedTType(op->getOperand(i)).getRank() != rank)
+    auto src = op->getOperand(0);
+    if (!isa<mlir::RankedTensorType>(src.getType()))
       return failure();
-    if (getRefinedShapePerCTATile(op->getOperand(i).getType()) !=
-        srcShapePerCtaTile)
+    auto srcType = rankedTType(src);
+    auto rank = srcType.getRank();
+    if (rank != 2) { // TODO(dtanner) remove me
       return failure();
-  }
-
-  // Result tensor.
-  auto res = op->getResult(0);
-  if (!isa<mlir::RankedTensorType>(res.getType()))
-    return failure();
-  auto resType = rankedTType(res);
-  auto resShape = resType.getShape();
-  if (resShape != srcShape)
-    return failure();
-
-  LDBG("rewriteElementWiseOp(): " << op);
-
-  // DEBUG check if concat op results in correct linear layout
-  auto leRes = ttg::toLinearEncoding(resType);
-  auto llRes = leRes.getLinearLayout();
-
-  auto resEncoding = resType.getEncoding();
-  auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
-
-  // Calculate refined shapes.
-  SmallVector<int64_t> refinedShape;
-  SmallVector<int64_t> numReps;
-  for (int i = 0; i < rank; ++i) {
-    // src and res can have different refineable shapes if different layouts.
-    refinedShape.push_back(
-        std::max(srcShapePerCtaTile[i], resShapePerCtaTile[i]));
-    numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
-  }
-
-  if (product<int64_t>(numReps) == 1)
-    return success();
-
-  // Create refined ops.
-  auto refinedTensorTypeSrc = RankedTensorType::get(
-      refinedShape, srcType.getElementType(), srcEncoding);
-  auto refinedTensorTypeRes = RankedTensorType::get(
-      refinedShape, resType.getElementType(), resEncoding);
-
-  rewriter.setInsertionPointAfter(op);
-  SmallVector<Value> refinedOps;
-  SmallVector<int64_t> offset(rank, 0);
-  int outerIdx = 0; // rank-1;
-  int innerIdx = 1; // rank-2;
-
-  auto sliceOperation = [&]() {
-    SmallVector<Value> slicedOperands;
-    for (int opdIdx = 0; opdIdx < numOperands; ++opdIdx) {
-      auto slicedOperand = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          op.getLoc(), Type{refinedTensorTypeSrc},
-          Value{op->getOperand(opdIdx)}, offset);
-      slicedOperands.push_back(slicedOperand);
     }
-    auto refinedOp = rewriter.create<OpTy>(op.getLoc(), refinedTensorTypeRes,
-                                           slicedOperands);
-    refinedOps.push_back(refinedOp->getResult(0));
-  };
 
-  for (int i = 0; i < numReps[outerIdx]; ++i) {
-    offset[outerIdx] = i * refinedShape[outerIdx];
+    auto srcShape = srcType.getShape();
+    auto srcEncoding = srcType.getEncoding();
+    auto srcLL = ttg::toLinearEncoding(srcType);
+    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
 
-    if (rank == 2) {
-      for (int j = 0; j < numReps[innerIdx]; ++j) {
-        offset[innerIdx] = j * refinedShape[innerIdx];
+    // Verify subsequent operands match opd[0].
+    for (int i = 1; i < numOperands; ++i) {
+      if (!isa<mlir::RankedTensorType>(op->getOperand(i).getType()))
+        return failure();
+      if (rankedTType(op->getOperand(i)).getRank() != rank)
+        return failure();
+      if (getRefinedShapePerCTATile(op->getOperand(i).getType()) !=
+          srcShapePerCtaTile)
+        return failure();
+    }
+
+    // Result tensor.
+    auto res = op->getResult(0);
+    if (!isa<mlir::RankedTensorType>(res.getType()))
+      return failure();
+    auto resType = rankedTType(res);
+    auto resShape = resType.getShape();
+    if (resShape != srcShape)
+      return failure();
+
+    LDBG("rewriteElementWiseOp(): " << op);
+
+    // DEBUG check if concat op results in correct linear layout
+    auto leRes = ttg::toLinearEncoding(resType);
+    auto llRes = leRes.getLinearLayout();
+
+    auto resEncoding = resType.getEncoding();
+    auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
+
+    // Calculate refined shapes.
+    SmallVector<int64_t> refinedShape;
+    SmallVector<int64_t> numReps;
+    for (int i = 0; i < rank; ++i) {
+      // src and res can have different refineable shapes if different layouts.
+      refinedShape.push_back(
+          std::max(srcShapePerCtaTile[i], resShapePerCtaTile[i]));
+      numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
+    }
+
+    if (product<int64_t>(numReps) == 1)
+      return success();
+
+    // Create refined ops.
+    auto refinedTensorTypeSrc = RankedTensorType::get(
+        refinedShape, srcType.getElementType(), srcEncoding);
+    auto refinedTensorTypeRes = RankedTensorType::get(
+        refinedShape, resType.getElementType(), resEncoding);
+
+    rewriter.setInsertionPointAfter(op);
+    SmallVector<Value> refinedOps;
+    SmallVector<int64_t> offset(rank, 0);
+    int outerIdx = 0; // rank-1;
+    int innerIdx = 1; // rank-2;
+
+    auto sliceOperation = [&]() {
+      SmallVector<Value> slicedOperands;
+      for (int opdIdx = 0; opdIdx < numOperands; ++opdIdx) {
+        auto slicedOperand = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+            op.getLoc(), Type{refinedTensorTypeSrc},
+            Value{op->getOperand(opdIdx)}, offset);
+        slicedOperands.push_back(slicedOperand);
+      }
+      auto refinedOp = rewriter.create<OpTy>(op.getLoc(), refinedTensorTypeRes,
+                                             slicedOperands);
+      refinedOps.push_back(refinedOp->getResult(0));
+    };
+
+    for (int i = 0; i < numReps[outerIdx]; ++i) {
+      offset[outerIdx] = i * refinedShape[outerIdx];
+
+      if (rank == 2) {
+        for (int j = 0; j < numReps[innerIdx]; ++j) {
+          offset[innerIdx] = j * refinedShape[innerIdx];
+          sliceOperation();
+        }
+      } else {
+        assert(rank == 1 && "rank is expected to be `1`");
         sliceOperation();
       }
-    } else {
-      assert(rank == 1 && "rank is expected to be `1`");
-      sliceOperation();
     }
+
+    // Concat slices.
+    auto resultType = op->getResultTypes()[0];
+    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+        op.getLoc(), resultType, refinedOps, concatDims);
+
+    auto origOpResult = op.getResult();
+    origOpResult.replaceAllUsesWith(concatOp);
+    LDBG("rewriteElementWiseOp() - SUCCESS " << op);
+    rewriter.replaceOp(op, concatOp);
+
+    return success();
   }
-
-  // Concat slices.
-  auto resultType = op->getResultTypes()[0];
-  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-      op.getLoc(), resultType, refinedOps, concatDims);
-
-  // DEBUG check if concat op results in correct linear layout
-  auto leConcat = ttg::toLinearEncoding(rankedTType(concatOp->getResult(0)));
-  auto llConcat = leConcat.getLinearLayout();
-
-  auto origOpResult = op.getResult();
-  origOpResult.replaceAllUsesWith(concatOp);
-  LDBG("rewriteElementWiseOp() - SUCCESS " << op);
-  op.erase();
-
-  return success();
-}
+};
 
 // Refine ExpandDims ops.
 // Since expanding dims increases tensor rank,
@@ -835,110 +868,117 @@ LogicalResult rewriteElementWiseOp(OpBuilder &rewriter, OpTy op) {
 // <M> -> <M/m> -> <M/m x 1> -> <Mx1>.
 // TODO(dtanner) only need to support 1D sliceLayout input, same as
 // ViewOpToLLVM.cpp ?
-LogicalResult rewriteExpandDimsOp(OpBuilder &rewriter,
-                                  triton::ExpandDimsOp op) {
-  int numOperands = op->getNumOperands();
-  if (op->getNumOperands() != 1)
-    return failure();
-  auto src = op->getOperand(0);
-  if (!isa<mlir::RankedTensorType>(src.getType()))
-    return failure();
-  auto srcType = rankedTType(src);
-  if (srcType.getElementTypeBitWidth() == 1)
-    return failure();
+struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
+  ExpandDimsOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  auto rank = srcType.getRank();
-  auto srcShape = srcType.getShape();
-  auto srcEncoding = srcType.getEncoding();
-  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+  LogicalResult matchAndRewrite(triton::ExpandDimsOp op,
+                                PatternRewriter &rewriter) const override {
+    int numOperands = op->getNumOperands();
+    if (op->getNumOperands() != 1)
+      return failure();
+    auto src = op->getOperand(0);
+    if (!isa<mlir::RankedTensorType>(src.getType()))
+      return failure();
+    auto srcType = rankedTType(src);
+    if (srcType.getElementTypeBitWidth() == 1)
+      return failure();
 
-  auto ll = triton::gpu::toLinearEncoding(srcType);
+    auto rank = srcType.getRank();
+    auto srcShape = srcType.getShape();
+    auto srcEncoding = srcType.getEncoding();
+    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
 
-  // Calculate refined shape.
-  SmallVector<int64_t> refinedSrcShape;
-  SmallVector<int64_t> numReps;
-  for (int i = 0; i < rank; ++i) {
-    refinedSrcShape.push_back(srcShapePerCtaTile[i]);
-    numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
-  }
+    auto ll = triton::gpu::toLinearEncoding(srcType);
 
-  if (product<int64_t>(numReps) == 1)
-    return success();
-
-  auto refinedResultShape = refinedSrcShape;
-  refinedResultShape.insert(refinedResultShape.begin() + op.getAxis(), 1);
-  auto refinedSrcTensorType = RankedTensorType::get(
-      refinedSrcShape, srcType.getElementType(), srcEncoding);
-
-  // Create refined ops.
-  rewriter.setInsertionPointAfter(op);
-  SmallVector<Value> refinedReduces;
-  SmallVector<int64_t> offset(rank, 0);
-
-  auto sliceOperation = [&]() {
-    auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-        op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
-        offset);
-
-    auto sliceRes = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
-        slicedOp->getResult(0));
-
-    auto sliceResTy = sliceRes.getType();
-    Attribute refinedResultEncoding;
-
-    if (auto refinedSrcEncoding = sliceResTy.getEncoding()) {
-      if (cast<DialectInferLayoutInterface>(&srcEncoding.getDialect())
-              ->inferExpandDimsOpEncoding(refinedSrcEncoding, op.getAxis(),
-                                          refinedResultEncoding, op.getLoc())
-              .failed()) {
-        return emitOptionalError(op.getLoc(),
-                                 "Failed to infer layout for ExpandDimsOp");
-      }
+    // Calculate refined shape.
+    SmallVector<int64_t> refinedSrcShape;
+    SmallVector<int64_t> numReps;
+    for (int i = 0; i < rank; ++i) {
+      refinedSrcShape.push_back(srcShapePerCtaTile[i]);
+      numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
     }
 
-    auto sliceResTensorType = RankedTensorType::get(
-        refinedResultShape, sliceResTy.getElementType(), refinedResultEncoding);
+    if (product<int64_t>(numReps) == 1)
+      return success();
 
-    auto refinedOp = rewriter.create<triton::ExpandDimsOp>(
-        op.getLoc(), sliceResTensorType, sliceRes, op.getAxis());
+    auto refinedResultShape = refinedSrcShape;
+    refinedResultShape.insert(refinedResultShape.begin() + op.getAxis(), 1);
+    auto refinedSrcTensorType = RankedTensorType::get(
+        refinedSrcShape, srcType.getElementType(), srcEncoding);
 
-    refinedReduces.push_back(refinedOp->getResult(0));
-    return success();
-  };
+    // Create refined ops.
+    rewriter.setInsertionPointAfter(op);
+    SmallVector<Value> refinedReduces;
+    SmallVector<int64_t> offset(rank, 0);
 
-  for (int i = 0; i < numReps[rank - 1]; ++i) {
-    offset[rank - 1] = i * refinedSrcShape[rank - 1];
+    auto sliceOperation = [&]() {
+      auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
+          offset);
 
-    // TODO(dtanner) how to iterate over Nd array?
-    if (rank == 2) {
-      for (int j = 0; j < numReps[rank - 2]; ++j) {
-        offset[rank - 2] = j * refinedSrcShape[rank - 2];
+      auto sliceRes =
+          ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
+              slicedOp->getResult(0));
+
+      auto sliceResTy = sliceRes.getType();
+      Attribute refinedResultEncoding;
+
+      if (auto refinedSrcEncoding = sliceResTy.getEncoding()) {
+        if (cast<DialectInferLayoutInterface>(&srcEncoding.getDialect())
+                ->inferExpandDimsOpEncoding(refinedSrcEncoding, op.getAxis(),
+                                            refinedResultEncoding, op.getLoc())
+                .failed()) {
+          return emitOptionalError(op.getLoc(),
+                                   "Failed to infer layout for ExpandDimsOp");
+        }
+      }
+
+      auto sliceResTensorType =
+          RankedTensorType::get(refinedResultShape, sliceResTy.getElementType(),
+                                refinedResultEncoding);
+
+      auto refinedOp = rewriter.create<triton::ExpandDimsOp>(
+          op.getLoc(), sliceResTensorType, sliceRes, op.getAxis());
+
+      refinedReduces.push_back(refinedOp->getResult(0));
+      return success();
+    };
+
+    for (int i = 0; i < numReps[rank - 1]; ++i) {
+      offset[rank - 1] = i * refinedSrcShape[rank - 1];
+
+      // TODO(dtanner) how to iterate over Nd array?
+      if (rank == 2) {
+        for (int j = 0; j < numReps[rank - 2]; ++j) {
+          offset[rank - 2] = j * refinedSrcShape[rank - 2];
+          if (llvm::failed(sliceOperation()))
+            return failure();
+        }
+      } else {
+        assert(rank == 1 && "rank is expected to be `1`");
         if (llvm::failed(sliceOperation()))
           return failure();
       }
-    } else {
-      assert(rank == 1 && "rank is expected to be `1`");
-      if (llvm::failed(sliceOperation()))
-        return failure();
     }
+
+    // Concat refined ops.
+    auto reduceResultType = op->getResultTypes()[0];
+    // Expand dims of numReps also before concat.
+    numReps.insert(numReps.begin() + op.getAxis(), 1);
+    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+        op.getLoc(), reduceResultType, refinedReduces, concatDims);
+    auto origOpResult = op.getResult();
+
+    auto checkLL = triton::gpu::toLinearEncoding(
+        cast<mlir::RankedTensorType>(refinedReduces.front().getType()));
+
+    origOpResult.replaceAllUsesWith(concatOp);
+    rewriter.eraseOp(op);
+    return success();
   }
-
-  // Concat refined ops.
-  auto reduceResultType = op->getResultTypes()[0];
-  // Expand dims of numReps also before concat.
-  numReps.insert(numReps.begin() + op.getAxis(), 1);
-  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-      op.getLoc(), reduceResultType, refinedReduces, concatDims);
-  auto origOpResult = op.getResult();
-
-  auto checkLL = triton::gpu::toLinearEncoding(
-      cast<mlir::RankedTensorType>(refinedReduces.front().getType()));
-
-  origOpResult.replaceAllUsesWith(concatOp);
-  op.erase();
-  return success();
-}
+};
 
 // Refine Broadcast ops.
 // Since inputs are roughtly 1D and outputs are roughly 2D,
@@ -955,106 +995,104 @@ LogicalResult rewriteExpandDimsOp(OpBuilder &rewriter,
 //        \             <64x32>   /
 //         -> <64x1> -> <64x32>  /
 //                      <64x32> /
-LogicalResult rewriteBroadcastOp(OpBuilder &rewriter, BroadcastOp op) {
-  // src tensor e.g. <128x1>.
-  int numOperands = op->getNumOperands();
-  if (op->getNumOperands() != 1)
-    return failure();
-  auto src = op->getOperand(0);
-  if (!isa<mlir::RankedTensorType>(src.getType()))
-    return failure();
-  auto srcType = rankedTType(src);
-  auto rank = srcType.getRank();
-  if (rank != 2)
-    return failure();
-  if (srcType.getElementTypeBitWidth() == 1)
-    return failure();
-  auto srcShape = srcType.getShape();
-  auto srcEncoding = srcType.getEncoding();
-  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+struct BroadcastOpPattern : public OpRewritePattern<BroadcastOp> {
+  BroadcastOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
 
-  // Result tensor e.g. <128x64>.
-  auto res = op->getResult(0);
-  if (!isa<mlir::RankedTensorType>(res.getType()))
-    return failure();
-  auto resType = rankedTType(res);
-  auto resShape = resType.getShape();
-  auto resEncoding = resType.getEncoding();
-  auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
+  LogicalResult matchAndRewrite(BroadcastOp op,
+                                PatternRewriter &rewriter) const override {
+    // src tensor e.g. <128x1>.
+    int numOperands = op->getNumOperands();
+    if (op->getNumOperands() != 1)
+      return failure();
+    auto src = op->getOperand(0);
+    if (!isa<mlir::RankedTensorType>(src.getType()))
+      return failure();
+    auto srcType = rankedTType(src);
+    auto rank = srcType.getRank();
+    if (rank != 2)
+      return failure();
+    if (srcType.getElementTypeBitWidth() == 1)
+      return failure();
+    auto srcShape = srcType.getShape();
+    auto srcEncoding = srcType.getEncoding();
+    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
 
-  // numReps
-  SmallVector<int64_t> refinedSrcShape;
-  SmallVector<int64_t> refinedResShape;
-  SmallVector<int64_t> numReps;
-  for (int i = 0; i < rank; ++i) {
-    refinedSrcShape.push_back(srcShapePerCtaTile[i]);
-    refinedResShape.push_back(resShapePerCtaTile[i]);
-    numReps.push_back(resShape[i] / resShapePerCtaTile[i]);
-  }
+    // Result tensor e.g. <128x64>.
+    auto res = op->getResult(0);
+    if (!isa<mlir::RankedTensorType>(res.getType()))
+      return failure();
+    auto resType = rankedTType(res);
+    auto resShape = resType.getShape();
+    auto resEncoding = resType.getEncoding();
+    auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
 
-  if (product<int64_t>(numReps) == 1)
-    return success();
-
-  // Determine indices and values of reps.
-  // numRepsSrc is the non-one size, because the src can be sliced.
-  // numRepsRes is the one size, because the result will be repeated.
-  unsigned numRepsSrcIdx = 0; // <*128x 1>
-  unsigned numRepsResIdx = 1; // < 128x*1>
-  if (refinedSrcShape[numRepsSrcIdx] == 1) {
-    numRepsSrcIdx = 1; // < 1x*64>
-    numRepsResIdx = 0; // <*1x 64>
-  }
-  unsigned numRepsSrc = numReps[numRepsSrcIdx];
-  unsigned numRepsRes = numReps[numRepsResIdx];
-
-  // Refined src/result tensor types.
-  auto refinedSrcTensorType = RankedTensorType::get(
-      refinedSrcShape, srcType.getElementType(), srcEncoding);
-  auto refinedResTensorType = RankedTensorType::get(
-      refinedResShape, srcType.getElementType(), srcEncoding);
-
-  // Create refined ops.
-  rewriter.setInsertionPointAfter(op);
-  SmallVector<Value> refinedBroadcasts;
-  SmallVector<int64_t> offset(rank, 0);
-  for (int i = 0; i < numRepsSrc; ++i) {
-    offset[numRepsSrcIdx] = i * refinedSrcShape[numRepsSrcIdx];
-    // Create slice.
-    auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-        op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
-        offset);
-    auto sliceRes = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
-        slicedOp->getResult(0));
-    auto sliceResTensorType = RankedTensorType::get(
-        refinedResShape, srcType.getElementType(), resEncoding);
-    for (int j = 0; j < numRepsRes; ++j) {
-      // Create broadcast.
-      auto broadcastOp = rewriter.create<triton::BroadcastOp>(
-          op.getLoc(), sliceResTensorType, sliceRes);
-      refinedBroadcasts.push_back(broadcastOp->getResult(0));
+    // numReps
+    SmallVector<int64_t> refinedSrcShape;
+    SmallVector<int64_t> refinedResShape;
+    SmallVector<int64_t> numReps;
+    for (int i = 0; i < rank; ++i) {
+      refinedSrcShape.push_back(srcShapePerCtaTile[i]);
+      refinedResShape.push_back(resShapePerCtaTile[i]);
+      numReps.push_back(resShape[i] / resShapePerCtaTile[i]);
     }
+
+    if (product<int64_t>(numReps) == 1)
+      return success();
+
+    // Determine indices and values of reps.
+    // numRepsSrc is the non-one size, because the src can be sliced.
+    // numRepsRes is the one size, because the result will be repeated.
+    unsigned numRepsSrcIdx = 0; // <*128x 1>
+    unsigned numRepsResIdx = 1; // < 128x*1>
+    if (refinedSrcShape[numRepsSrcIdx] == 1) {
+      numRepsSrcIdx = 1; // < 1x*64>
+      numRepsResIdx = 0; // <*1x 64>
+    }
+    unsigned numRepsSrc = numReps[numRepsSrcIdx];
+    unsigned numRepsRes = numReps[numRepsResIdx];
+
+    // Refined src/result tensor types.
+    auto refinedSrcTensorType = RankedTensorType::get(
+        refinedSrcShape, srcType.getElementType(), srcEncoding);
+    auto refinedResTensorType = RankedTensorType::get(
+        refinedResShape, srcType.getElementType(), srcEncoding);
+
+    // Create refined ops.
+    rewriter.setInsertionPointAfter(op);
+    SmallVector<Value> refinedBroadcasts;
+    SmallVector<int64_t> offset(rank, 0);
+    for (int i = 0; i < numRepsSrc; ++i) {
+      offset[numRepsSrcIdx] = i * refinedSrcShape[numRepsSrcIdx];
+      // Create slice.
+      auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
+          offset);
+      auto sliceRes =
+          ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
+              slicedOp->getResult(0));
+      auto sliceResTensorType = RankedTensorType::get(
+          refinedResShape, srcType.getElementType(), resEncoding);
+      for (int j = 0; j < numRepsRes; ++j) {
+        // Create broadcast.
+        auto broadcastOp = rewriter.create<triton::BroadcastOp>(
+            op.getLoc(), sliceResTensorType, sliceRes);
+        refinedBroadcasts.push_back(broadcastOp->getResult(0));
+      }
+    }
+
+    // Concat refined ops.
+    auto reduceResultType = op->getResultTypes()[0];
+    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+        op.getLoc(), reduceResultType, refinedBroadcasts, concatDims);
+
+    auto origOpResult = op.getResult();
+    origOpResult.replaceAllUsesWith(concatOp);
+    rewriter.eraseOp(op);
+    return success();
   }
-
-  // Concat refined ops.
-  auto reduceResultType = op->getResultTypes()[0];
-  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-      op.getLoc(), reduceResultType, refinedBroadcasts, concatDims);
-
-  auto origOpResult = op.getResult();
-  origOpResult.replaceAllUsesWith(concatOp);
-  op.erase();
-  return success();
-}
-
-// Refine Element-Wise Ops.
-#define REFINE_ELEMENTWISE_OP(OP_TYPE)                                         \
-  block->walk([&](OP_TYPE op) {                                                \
-    OpBuilder rewriter(op->getContext());                                      \
-    if (failed(rewriteElementWiseOp<OP_TYPE>(rewriter, op))) {                 \
-      LDBG("failed to refine binary op: " << *op);                             \
-    }                                                                          \
-  });
+};
 
 struct TritonAMDGPURefineOps
     : public TritonAMDGPURefineOpsBase<TritonAMDGPURefineOps> {
@@ -1071,113 +1109,168 @@ struct TritonAMDGPURefineOps
       return signalPassFailure();
     }
 
-    func->walk([&](amdgpu::InstructionSchedHint hint) {
-      if (hint.getVariant() != amdgpu::SchedHint::refine_ops) {
-        return WalkResult::advance();
-      }
+    RewritePatternSet patterns(context);
+    patterns.add<LocalLoadOpPattern>(context, /*benefit=*/1);
+    patterns.add<DotOpPattern>(context, /*benefit=*/1);
+    patterns.add<LoadOpPattern>(context, /*benefit=*/1);
+    patterns.add<LocalStoreOpPattern>(context, /*benefit=*/1);
+    patterns.add<ReduceOpPattern>(context, /*benefit=*/1);
+    patterns.add<ExpandDimsOpPattern>(context, /*benefit=*/1);
+    patterns.add<BroadcastOpPattern>(context, /*benefit=*/1);
 
-      auto *block = hint->getBlock();
+    // Elementwise patterns
+#define REFINE_ELEMENTWISE_OP(OP_TYPE)                                         \
+  patterns.add<ElementWiseOpPattern<OP_TYPE>>(context, /*benefit=*/1);
 
-      block->walk([&](triton::gpu::LocalLoadOp localLoadOp) {
-        OpBuilder rewriter(localLoadOp->getContext());
-        if (localLoadOp->getNumOperands() == 1) {
-          if (failed(rewriteLocalLoad(rewriter, localLoadOp))) {
-            LDBG("failed to refine ttg.localLoad: " << *localLoadOp);
-          }
-        }
-      });
+    REFINE_ELEMENTWISE_OP(math::RsqrtOp)
+    REFINE_ELEMENTWISE_OP(math::Exp2Op)
+    REFINE_ELEMENTWISE_OP(arith::TruncFOp)
+    REFINE_ELEMENTWISE_OP(arith::ExtFOp)
+    REFINE_ELEMENTWISE_OP(arith::FPToSIOp)
+    REFINE_ELEMENTWISE_OP(arith::SIToFPOp)
+    REFINE_ELEMENTWISE_OP(triton::FpToFpOp)
+    REFINE_ELEMENTWISE_OP(triton::PreciseSqrtOp)
+    REFINE_ELEMENTWISE_OP(math::SqrtOp)
+    REFINE_ELEMENTWISE_OP(math::ExpOp)
+    REFINE_ELEMENTWISE_OP(arith::SubIOp)
+    REFINE_ELEMENTWISE_OP(arith::AddIOp)
+    REFINE_ELEMENTWISE_OP(arith::MulIOp)
+    REFINE_ELEMENTWISE_OP(arith::DivSIOp)
+    REFINE_ELEMENTWISE_OP(arith::DivUIOp)
+    REFINE_ELEMENTWISE_OP(arith::RemFOp)
+    REFINE_ELEMENTWISE_OP(arith::RemSIOp)
+    REFINE_ELEMENTWISE_OP(arith::RemUIOp)
+    REFINE_ELEMENTWISE_OP(arith::AndIOp)
+    REFINE_ELEMENTWISE_OP(arith::OrIOp)
+    REFINE_ELEMENTWISE_OP(arith::XOrIOp)
+    REFINE_ELEMENTWISE_OP(arith::ShLIOp)
+    REFINE_ELEMENTWISE_OP(arith::ShRSIOp)
+    REFINE_ELEMENTWISE_OP(arith::ShRUIOp)
+    REFINE_ELEMENTWISE_OP(arith::MinNumFOp)
+    REFINE_ELEMENTWISE_OP(arith::MaxNumFOp)
+    REFINE_ELEMENTWISE_OP(arith::MinSIOp)
+    REFINE_ELEMENTWISE_OP(arith::MaxSIOp)
+    REFINE_ELEMENTWISE_OP(arith::MinUIOp)
+    REFINE_ELEMENTWISE_OP(arith::MaxUIOp)
+    REFINE_ELEMENTWISE_OP(arith::AddFOp)
+    REFINE_ELEMENTWISE_OP(arith::SubFOp)
+    REFINE_ELEMENTWISE_OP(arith::MulFOp)
+    REFINE_ELEMENTWISE_OP(arith::DivFOp)
+    REFINE_ELEMENTWISE_OP(arith::MaximumFOp)
+    REFINE_ELEMENTWISE_OP(arith::MinimumFOp)
+    REFINE_ELEMENTWISE_OP(triton::gpu::ConvertLayoutOp)
 
-      block->walk([&](triton::DotOp dotOp) {
-        OpBuilder rewriter(dotOp->getContext());
-        // TODO: extend to WMMA instructions
-        if (failed(rewriteMFMA(rewriter, dotOp))) {
-          LDBG("failed to refine tt.dotOp: " << *dotOp);
-        }
-      });
+#undef REFINE_ELEMENTWISE_OP
 
-      block->walk([&](triton::LoadOp loadOp) {
-        OpBuilder rewriter(loadOp->getContext());
-        if (loadOp->getNumOperands() == 1) {
-          if (failed(rewriteLoadOp(rewriter, loadOp))) {
-            LDBG("failed to refine tt.loadOp: " << *loadOp);
-          }
-        }
-      });
+    walkAndApplyPatterns(func, std::move(patterns));
 
-      block->walk([&](triton::gpu::LocalStoreOp storeOp) {
-        OpBuilder rewriter(storeOp->getContext());
-        if (storeOp->getNumOperands() == 2) {
-          if (failed(rewriteLocalStoreOp(rewriter, storeOp))) {
-            LDBG("failed to refine ttg.localLoadOp: " << *storeOp);
-          }
-        }
-      });
+    // func->walk([&](amdgpu::InstructionSchedHint hint) {
+    //   if (hint.getVariant() != amdgpu::SchedHint::refine_ops) {
+    //     return WalkResult::advance();
+    //   }
 
-      block->walk([&](triton::ReduceOp reduceOp) {
-        OpBuilder rewriter(reduceOp->getContext());
-        if (failed(rewriteReduceOp(rewriter, reduceOp))) {
-          LDBG("failed to refine tt.reduce: " << *reduceOp);
-        }
-      });
+    //   auto *block = hint->getBlock();
 
-      // Refine Unary Element-Wise Ops.
-      REFINE_ELEMENTWISE_OP(math::RsqrtOp)
-      REFINE_ELEMENTWISE_OP(math::Exp2Op)
-      REFINE_ELEMENTWISE_OP(arith::TruncFOp)
-      REFINE_ELEMENTWISE_OP(arith::ExtFOp)
-      REFINE_ELEMENTWISE_OP(arith::FPToSIOp)
-      REFINE_ELEMENTWISE_OP(arith::SIToFPOp)
-      REFINE_ELEMENTWISE_OP(triton::FpToFpOp)
-      REFINE_ELEMENTWISE_OP(triton::PreciseSqrtOp)
-      REFINE_ELEMENTWISE_OP(math::SqrtOp)
-      REFINE_ELEMENTWISE_OP(math::ExpOp)
-      REFINE_ELEMENTWISE_OP(arith::SubIOp)
-      REFINE_ELEMENTWISE_OP(arith::AddIOp)
-      REFINE_ELEMENTWISE_OP(arith::MulIOp)
-      REFINE_ELEMENTWISE_OP(arith::DivSIOp)
-      REFINE_ELEMENTWISE_OP(arith::DivUIOp)
-      REFINE_ELEMENTWISE_OP(arith::RemFOp)
-      REFINE_ELEMENTWISE_OP(arith::RemSIOp)
-      REFINE_ELEMENTWISE_OP(arith::RemUIOp)
-      REFINE_ELEMENTWISE_OP(arith::AndIOp)
-      REFINE_ELEMENTWISE_OP(arith::OrIOp)
-      REFINE_ELEMENTWISE_OP(arith::XOrIOp)
-      REFINE_ELEMENTWISE_OP(arith::ShLIOp)
-      REFINE_ELEMENTWISE_OP(arith::ShRSIOp)
-      REFINE_ELEMENTWISE_OP(arith::ShRUIOp)
-      REFINE_ELEMENTWISE_OP(arith::MinNumFOp)
-      REFINE_ELEMENTWISE_OP(arith::MaxNumFOp)
-      REFINE_ELEMENTWISE_OP(arith::MinSIOp)
-      REFINE_ELEMENTWISE_OP(arith::MaxSIOp)
-      REFINE_ELEMENTWISE_OP(arith::MinUIOp)
-      REFINE_ELEMENTWISE_OP(arith::MaxUIOp)
-      REFINE_ELEMENTWISE_OP(arith::AddFOp)
-      REFINE_ELEMENTWISE_OP(arith::SubFOp)
-      REFINE_ELEMENTWISE_OP(arith::MulFOp)
-      REFINE_ELEMENTWISE_OP(arith::DivFOp)
-      REFINE_ELEMENTWISE_OP(arith::MaximumFOp)
-      REFINE_ELEMENTWISE_OP(arith::MinimumFOp)
-      REFINE_ELEMENTWISE_OP(triton::gpu::ConvertLayoutOp)
+    // block->walk([&](triton::gpu::LocalLoadOp localLoadOp) {
+    //   OpBuilder rewriter(localLoadOp->getContext());
+    //   if (localLoadOp->getNumOperands() == 1) {
+    //     if (failed(rewriteLocalLoad(rewriter, localLoadOp))) {
+    //       LDBG("failed to refine ttg.localLoad: " << *localLoadOp);
+    //     }
+    //   }
+    // });
 
-      // Refine ExpandDimsOp: 128 -> 128x1
-      block->walk([&](triton::ExpandDimsOp op) {
-        OpBuilder rewriter(op->getContext());
-        if (failed(rewriteExpandDimsOp(rewriter, op))) {
-          LDBG("failed to refine tt.expand_dims: " << *op);
-        }
-      });
+    // block->walk([&](triton::DotOp dotOp) {
+    //   OpBuilder rewriter(dotOp->getContext());
+    //   // TODO: extend to WMMA instructions
+    //   if (failed(rewriteMFMA(rewriter, dotOp))) {
+    //     LDBG("failed to refine tt.dotOp: " << *dotOp);
+    //   }
+    // });
 
-#if 0
-      // Refine BroadcastOp: 128x1 -> 128x64
-      block->walk([&](triton::BroadcastOp op) {
-        OpBuilder rewriter(op->getContext());
-        if (failed(rewriteBroadcastOp(rewriter, op))) {
-          LDBG("failed to refine tt.broadcast: " << *op);
-        }
-      });
-#endif
-      return WalkResult::advance();
-    });
+    // block->walk([&](triton::LoadOp loadOp) {
+    //   OpBuilder rewriter(loadOp->getContext());
+    //   if (loadOp->getNumOperands() == 1) {
+    //     if (failed(rewriteLoadOp(rewriter, loadOp))) {
+    //       LDBG("failed to refine tt.loadOp: " << *loadOp);
+    //     }
+    //   }
+    // });
+
+    // block->walk([&](triton::gpu::LocalStoreOp storeOp) {
+    //   OpBuilder rewriter(storeOp->getContext());
+    //   if (storeOp->getNumOperands() == 2) {
+    //     if (failed(rewriteLocalStoreOp(rewriter, storeOp))) {
+    //       LDBG("failed to refine ttg.localLoadOp: " << *storeOp);
+    //     }
+    //   }
+    // });
+
+    // block->walk([&](triton::ReduceOp reduceOp) {
+    //   OpBuilder rewriter(reduceOp->getContext());
+    //   if (failed(rewriteReduceOp(rewriter, reduceOp))) {
+    //     LDBG("failed to refine tt.reduce: " << *reduceOp);
+    //   }
+    // });
+
+    // Refine Unary Element-Wise Ops.
+    // REFINE_ELEMENTWISE_OP(math::RsqrtOp)
+    // REFINE_ELEMENTWISE_OP(math::Exp2Op)
+    // REFINE_ELEMENTWISE_OP(arith::TruncFOp)
+    // REFINE_ELEMENTWISE_OP(arith::ExtFOp)
+    // REFINE_ELEMENTWISE_OP(arith::FPToSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::SIToFPOp)
+    // REFINE_ELEMENTWISE_OP(triton::FpToFpOp)
+    // REFINE_ELEMENTWISE_OP(triton::PreciseSqrtOp)
+    // REFINE_ELEMENTWISE_OP(math::SqrtOp)
+    // REFINE_ELEMENTWISE_OP(math::ExpOp)
+    // REFINE_ELEMENTWISE_OP(arith::SubIOp)
+    // REFINE_ELEMENTWISE_OP(arith::AddIOp)
+    // REFINE_ELEMENTWISE_OP(arith::MulIOp)
+    // REFINE_ELEMENTWISE_OP(arith::DivSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::DivUIOp)
+    // REFINE_ELEMENTWISE_OP(arith::RemFOp)
+    // REFINE_ELEMENTWISE_OP(arith::RemSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::RemUIOp)
+    // REFINE_ELEMENTWISE_OP(arith::AndIOp)
+    // REFINE_ELEMENTWISE_OP(arith::OrIOp)
+    // REFINE_ELEMENTWISE_OP(arith::XOrIOp)
+    // REFINE_ELEMENTWISE_OP(arith::ShLIOp)
+    // REFINE_ELEMENTWISE_OP(arith::ShRSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::ShRUIOp)
+    // REFINE_ELEMENTWISE_OP(arith::MinNumFOp)
+    // REFINE_ELEMENTWISE_OP(arith::MaxNumFOp)
+    // REFINE_ELEMENTWISE_OP(arith::MinSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::MaxSIOp)
+    // REFINE_ELEMENTWISE_OP(arith::MinUIOp)
+    // REFINE_ELEMENTWISE_OP(arith::MaxUIOp)
+    // REFINE_ELEMENTWISE_OP(arith::AddFOp)
+    // REFINE_ELEMENTWISE_OP(arith::SubFOp)
+    // REFINE_ELEMENTWISE_OP(arith::MulFOp)
+    // REFINE_ELEMENTWISE_OP(arith::DivFOp)
+    // REFINE_ELEMENTWISE_OP(arith::MaximumFOp)
+    // REFINE_ELEMENTWISE_OP(arith::MinimumFOp)
+    // REFINE_ELEMENTWISE_OP(triton::gpu::ConvertLayoutOp)
+
+    // // Refine ExpandDimsOp: 128 -> 128x1
+    // block->walk([&](triton::ExpandDimsOp op) {
+    //   OpBuilder rewriter(op->getContext());
+    //   if (failed(rewriteExpandDimsOp(rewriter, op))) {
+    //     LDBG("failed to refine tt.expand_dims: " << *op);
+    //   }
+    // });
+
+    // #if 0
+    //       // Refine BroadcastOp: 128x1 -> 128x64
+    //       block->walk([&](triton::BroadcastOp op) {
+    //         OpBuilder rewriter(op->getContext());
+    //         if (failed(rewriteBroadcastOp(rewriter, op))) {
+    //           LDBG("failed to refine tt.broadcast: " << *op);
+    //         }
+    //       });
+    // #endif
+    //   return WalkResult::advance();
+    // });
   }
 
 private:

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -92,104 +92,99 @@ inline bool isRowMajor(::llvm::ArrayRef<unsigned> order) {
   return order[rank - 1] == 0;
 }
 
-struct LocalLoadOpPattern : public OpRewritePattern<triton::gpu::LocalLoadOp> {
-  LocalLoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+LogicalResult rewriteLocalLoad(PatternRewriter &rewriter,
+                               triton::gpu::LocalLoadOp op) {
+  auto *ctx = op->getContext();
+  auto loc = op->getLoc();
 
-  LogicalResult matchAndRewrite(triton::gpu::LocalLoadOp op,
-                                PatternRewriter &rewriter) const override {
-    auto *ctx = op->getContext();
-    auto loc = op->getLoc();
+  auto resultType = cast<RankedTensorType>(op.getType());
+  auto resultElementType = resultType.getElementType();
+  auto resultEncode = cast<DotOperandEncodingAttr>(resultType.getEncoding());
+  auto resultShape = resultType.getShape();
 
-    auto resultType = cast<RankedTensorType>(op.getType());
-    auto resultElementType = resultType.getElementType();
-    auto resultEncode = cast<DotOperandEncodingAttr>(resultType.getEncoding());
-    auto resultShape = resultType.getShape();
+  const auto rank = resultShape.size();
+  assert(rank == 2);
 
-    const auto rank = resultShape.size();
-    assert(rank == 2);
+  auto opIdx = resultEncode.getOpIdx();
+  const int kDimIdx = opIdx == 0 ? rank - 1 : rank - 2;
+  const int nonKDimIdx = opIdx == 0 ? rank - 2 : rank - 1;
 
-    auto opIdx = resultEncode.getOpIdx();
-    const int kDimIdx = opIdx == 0 ? rank - 1 : rank - 2;
-    const int nonKDimIdx = opIdx == 0 ? rank - 2 : rank - 1;
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(resultEncode.getParent());
+  int kWidth = resultEncode.getKWidth();
+  auto numReps = mfmaLayout.getRepForOperand(resultShape, kWidth, opIdx);
 
-    auto mfmaLayout = cast<AMDMfmaEncodingAttr>(resultEncode.getParent());
-    int kWidth = resultEncode.getKWidth();
-    auto numReps = mfmaLayout.getRepForOperand(resultShape, kWidth, opIdx);
+  // indices into 3D numReps
+  int kRepsIdx = opIdx == 0 ? 2 : 1;
+  int nonKRepsIdx = opIdx == 0 ? 1 : 2;
+  int bRepsIdx = 0;
 
-    // indices into 3D numReps
-    int kRepsIdx = opIdx == 0 ? 2 : 1;
-    int nonKRepsIdx = opIdx == 0 ? 1 : 2;
-    int bRepsIdx = 0;
+  // 2D shape which drops batch dimension.
+  SmallVector<int64_t> numReps2D = {numReps[1], numReps[2]};
 
-    // 2D shape which drops batch dimension.
-    SmallVector<int64_t> numReps2D = {numReps[1], numReps[2]};
+  auto numRepsNonK = numReps[nonKRepsIdx];
+  auto numRepsK = numReps[kRepsIdx];
+  auto numRepsB = numReps[bRepsIdx];
 
-    auto numRepsNonK = numReps[nonKRepsIdx];
-    auto numRepsK = numReps[kRepsIdx];
-    auto numRepsB = numReps[bRepsIdx];
-
-    auto memDesc = op->getOperand(0);
-    auto memDescType = cast<ttg::MemDescType>(memDesc.getType());
-    auto memDescEncoding = memDescType.getEncoding();
-    SmallVector<unsigned int> order;
-    if (auto enc = dyn_cast<triton::gpu::SwizzledSharedEncodingAttr>(
-            memDescEncoding)) {
-      order = decltype(order)(enc.getOrder());
-    }
-    if (auto enc = dyn_cast<triton::gpu::AMDRotatingSharedEncodingAttr>(
-            memDescEncoding)) {
-      order = decltype(order)(enc.getOrder());
-    }
-    assert(!order.empty());
-
-    SmallVector<int64_t> refinedShape = {resultShape[0] / numReps2D[0],
-                                         resultShape[1] / numReps2D[1]};
-    LDBG("refinedShape: " << refinedShape[0] << "x" << refinedShape[1]);
-
-    auto refinedTensorType =
-        RankedTensorType::get(refinedShape, resultElementType, resultEncode);
-
-    constexpr bool mutableMemory = true;
-    auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
-    auto subviewType = ttg::MemDescType::get(
-        refinedShape, memDescType.getElementType(), memDescType.getEncoding(),
-        sharedMemorySpace, mutableMemory, memDescType.getAllocShape());
-
-    rewriter.setInsertionPointAfter(op);
-    SmallVector<Value> subtiles;
-    for (int32_t i = 0; i < numReps2D[0]; ++i) {
-      for (int32_t j = 0; j < numReps2D[1]; ++j) {
-        int32_t offset0 = i * refinedShape[0];
-        int32_t offset1 = j * refinedShape[1];
-        auto offset = createOffset({}, {offset0, offset1}, rewriter, loc);
-        auto refinedView = rewriter.create<ttg::MemDescSubviewOp>(
-            loc, subviewType, memDesc, offset);
-        LDBG("RefinedLocalLoadSubvew: " << *refinedView);
-
-        auto refinedLoad = rewriter.create<ttg::LocalLoadOp>(
-            loc, refinedTensorType, refinedView);
-        subtiles.push_back(refinedLoad);
-      }
-    }
-
-    // concat dims is correct shape 8x1 vs 1x8, else gives wrong output shape.
-    std::vector<int64_t> loweringOrder(numReps2D.size());
-    int64_t counter = 0;
-    auto increment = [&counter](int64_t &val) { val = counter++; };
-    if (opIdx == 0)
-      std::for_each(loweringOrder.rbegin(), loweringOrder.rend(), increment);
-    else
-      std::for_each(loweringOrder.begin(), loweringOrder.end(), increment);
-
-    auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
-        loc, resultType, subtiles, numReps2D, loweringOrder);
-    LDBG("ConcatOp: " << *joinedResult);
-
-    rewriter.replaceOp(op, joinedResult);
-    return success();
+  auto memDesc = op->getOperand(0);
+  auto memDescType = cast<ttg::MemDescType>(memDesc.getType());
+  auto memDescEncoding = memDescType.getEncoding();
+  SmallVector<unsigned int> order;
+  if (auto enc =
+          dyn_cast<triton::gpu::SwizzledSharedEncodingAttr>(memDescEncoding)) {
+    order = decltype(order)(enc.getOrder());
   }
-};
+  if (auto enc = dyn_cast<triton::gpu::AMDRotatingSharedEncodingAttr>(
+          memDescEncoding)) {
+    order = decltype(order)(enc.getOrder());
+  }
+  assert(!order.empty());
+
+  SmallVector<int64_t> refinedShape = {resultShape[0] / numReps2D[0],
+                                       resultShape[1] / numReps2D[1]};
+  LDBG("refinedShape: " << refinedShape[0] << "x" << refinedShape[1]);
+
+  auto refinedTensorType =
+      RankedTensorType::get(refinedShape, resultElementType, resultEncode);
+
+  constexpr bool mutableMemory = true;
+  auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+  auto subviewType = ttg::MemDescType::get(
+      refinedShape, memDescType.getElementType(), memDescType.getEncoding(),
+      sharedMemorySpace, mutableMemory, memDescType.getAllocShape());
+
+  rewriter.setInsertionPointAfter(op);
+  SmallVector<Value> subtiles;
+  for (int32_t i = 0; i < numReps2D[0]; ++i) {
+    for (int32_t j = 0; j < numReps2D[1]; ++j) {
+      int32_t offset0 = i * refinedShape[0];
+      int32_t offset1 = j * refinedShape[1];
+      auto offset = createOffset({}, {offset0, offset1}, rewriter, loc);
+      auto refinedView = rewriter.create<ttg::MemDescSubviewOp>(
+          loc, subviewType, memDesc, offset);
+      LDBG("RefinedLocalLoadSubvew: " << *refinedView);
+
+      auto refinedLoad = rewriter.create<ttg::LocalLoadOp>(
+          loc, refinedTensorType, refinedView);
+      subtiles.push_back(refinedLoad);
+    }
+  }
+
+  // concat dims is correct shape 8x1 vs 1x8, else gives wrong output shape.
+  std::vector<int64_t> loweringOrder(numReps2D.size());
+  int64_t counter = 0;
+  auto increment = [&counter](int64_t &val) { val = counter++; };
+  if (opIdx == 0)
+    std::for_each(loweringOrder.rbegin(), loweringOrder.rend(), increment);
+  else
+    std::for_each(loweringOrder.begin(), loweringOrder.end(), increment);
+
+  auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
+      loc, resultType, subtiles, numReps2D, loweringOrder);
+  LDBG("ConcatOp: " << *joinedResult);
+
+  rewriter.replaceOp(op, joinedResult);
+  return success();
+}
 
 struct DotOpMFMAConverter {
   AMDMfmaEncodingAttr mfmaLayout;
@@ -476,41 +471,35 @@ struct DotOpMFMAConverter {
 
 inline RankedTensorType rankedTType(Value tensor) {
   return cast<RankedTensorType>(tensor.getType());
-};
+}
 
-struct DotOpPattern : public OpRewritePattern<triton::DotOp> {
-  DotOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
-
-  LogicalResult matchAndRewrite(triton::DotOp op,
-                                PatternRewriter &rewriter) const override {
-    if (!(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
-          isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()))) {
-      LDBG("Both $a and %b should be DotOperand layout");
-      return failure();
-    }
-
-    auto cTensorTy = rankedTType(op.getC());
-    auto dTensorTy = rankedTType(op.getD());
-    if (!isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding())) {
-      LDBG("Currently, we only support $c with a mfma layout");
-      return failure();
-    }
-
-    if (!(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
-          cTensorTy.getShape()[1] == dTensorTy.getShape()[1])) {
-      LDBG("DotOp's $c operand should pass the same number of values as $d");
-      return failure();
-    }
-
-    auto loc = op.getLoc();
-    auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
-        cast<RankedTensorType>(op.getResult().getType()).getEncoding());
-
-    DotOpMFMAConverter converter(mfmaLayout, rewriter, loc);
-    return converter.convert(op, DotOpAdaptor(op));
+LogicalResult rewriteMFMA(PatternRewriter &rewriter, triton::DotOp op) {
+  if (!(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
+        isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()))) {
+    LDBG("Both $a and %b should be DotOperand layout");
+    return failure();
   }
-};
+
+  auto cTensorTy = rankedTType(op.getC());
+  auto dTensorTy = rankedTType(op.getD());
+  if (!isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding())) {
+    LDBG("Currently, we only support $c with a mfma layout");
+    return failure();
+  }
+
+  if (!(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
+        cTensorTy.getShape()[1] == dTensorTy.getShape()[1])) {
+    LDBG("DotOp's $c operand should pass the same number of values as $d");
+    return failure();
+  }
+
+  auto loc = op.getLoc();
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(op.getResult().getType()).getEncoding());
+
+  DotOpMFMAConverter converter(mfmaLayout, rewriter, loc);
+  return converter.convert(op, DotOpAdaptor(op));
+}
 
 struct RefinedBlock {
   RefinedBlock(ArrayRef<int64_t> shape, Type elemType,
@@ -548,190 +537,171 @@ struct RefinedBlock {
   RankedTensorType tensorType;
 };
 
-struct LoadOpPattern : public OpRewritePattern<triton::LoadOp> {
-  LoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+LogicalResult rewriteLoadOp(PatternRewriter &rewriter, triton::LoadOp loadOp) {
+  auto ctx = loadOp->getContext();
+  auto loc = loadOp.getLoc();
 
-  LogicalResult matchAndRewrite(triton::LoadOp loadOp,
-                                PatternRewriter &rewriter) const override {
-    auto ctx = loadOp->getContext();
-    auto loc = loadOp.getLoc();
+  Value origSrc = loadOp->getOperand(0);
+  Value origResult = loadOp.getResult();
+  Type origResultType = loadOp.getResult().getType();
+  auto origPtrs = rankedTType(origSrc);
+  auto origShape = origPtrs.getShape();
+  auto elemType = origPtrs.getElementType();
+  auto encoding = dyn_cast<BlockedEncodingAttr>(origPtrs.getEncoding());
+  if (encoding == nullptr)
+    return failure();
 
-    Value origSrc = loadOp->getOperand(0);
-    Value origResult = loadOp.getResult();
-    Type origResultType = loadOp.getResult().getType();
-    auto origPtrs = rankedTType(origSrc);
-    auto origShape = origPtrs.getShape();
-    auto elemType = origPtrs.getElementType();
-    auto encoding = dyn_cast<BlockedEncodingAttr>(origPtrs.getEncoding());
-    if (encoding == nullptr)
-      return failure();
+  RefinedBlock refinedBlock(origShape, elemType, encoding);
 
-    RefinedBlock refinedBlock(origShape, elemType, encoding);
+  rewriter.setInsertionPointAfter(loadOp);
+  SmallVector<Value> refinedTensors;
 
-    rewriter.setInsertionPointAfter(loadOp);
-    SmallVector<Value> refinedTensors;
+  Value mask = loadOp.getMask();
+  Value other = loadOp.getOther();
+  auto boundaryCheck = loadOp.getBoundaryCheck();
+  auto padding = loadOp.getPadding();
+  auto cache = loadOp.getCache();
+  auto evict = loadOp.getEvict();
+  auto isVolatile = loadOp.getIsVolatile();
 
-    Value mask = loadOp.getMask();
-    Value other = loadOp.getOther();
-    auto boundaryCheck = loadOp.getBoundaryCheck();
-    auto padding = loadOp.getPadding();
-    auto cache = loadOp.getCache();
-    auto evict = loadOp.getEvict();
-    auto isVolatile = loadOp.getIsVolatile();
-
-    AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
-    for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
-         ++linearIdx) {
-      auto coords = coordsMapper.map(linearIdx);
-      SmallVector<int64_t> offset(refinedBlock.numDims, 0);
-      for (auto [dim, coord] : llvm::enumerate(coords)) {
-        offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
-      }
-
-      auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
-
-      auto refinedTensor = rewriter.create<triton::LoadOp>(
-          loc, slice, mask, other, boundaryCheck, padding, cache, evict,
-          isVolatile);
-      refinedTensors.push_back(refinedTensor);
+  AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
+  for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
+       ++linearIdx) {
+    auto coords = coordsMapper.map(linearIdx);
+    SmallVector<int64_t> offset(refinedBlock.numDims, 0);
+    for (auto [dim, coord] : llvm::enumerate(coords)) {
+      offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
     }
 
-    auto concatDims = DenseI64ArrayAttr::get(ctx, refinedBlock.numPerDims);
-    auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
-        loc, origResultType, refinedTensors, concatDims);
+    auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+        loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
 
-    origResult.replaceAllUsesWith(joinedResult);
-    return success();
+    auto refinedTensor =
+        rewriter.create<triton::LoadOp>(loc, slice, mask, other, boundaryCheck,
+                                        padding, cache, evict, isVolatile);
+    refinedTensors.push_back(refinedTensor);
   }
-};
 
-struct LocalStoreOpPattern
-    : public OpRewritePattern<triton::gpu::LocalStoreOp> {
-  LocalStoreOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+  auto concatDims = DenseI64ArrayAttr::get(ctx, refinedBlock.numPerDims);
+  auto joinedResult = rewriter.create<triton::amdgpu::ConcatOp>(
+      loc, origResultType, refinedTensors, concatDims);
 
-  LogicalResult matchAndRewrite(triton::gpu::LocalStoreOp loadStoreOp,
-                                PatternRewriter &rewriter) const override {
-    auto ctx = loadStoreOp->getContext();
-    auto loc = loadStoreOp.getLoc();
+  origResult.replaceAllUsesWith(joinedResult);
+  return success();
+}
 
-    Value origSrc = loadStoreOp->getOperand(0);
-    auto origMemViewOp =
-        cast<ttg::MemDescSubviewOp>(loadStoreOp->getOperand(1).getDefiningOp());
-    Value origMemView = origMemViewOp->getOperand(0);
-    Value selectValue = origMemViewOp.getOffsets().front();
+LogicalResult rewriteLocalStoreOp(PatternRewriter &rewriter,
+                                  triton::gpu::LocalStoreOp loadStoreOp) {
+  auto ctx = loadStoreOp->getContext();
+  auto loc = loadStoreOp.getLoc();
 
-    auto origSrcType = rankedTType(origSrc);
-    auto blockEncoding =
-        dyn_cast<BlockedEncodingAttr>(origSrcType.getEncoding());
-    if (blockEncoding == nullptr)
-      return failure();
+  Value origSrc = loadStoreOp->getOperand(0);
+  auto origMemViewOp =
+      cast<ttg::MemDescSubviewOp>(loadStoreOp->getOperand(1).getDefiningOp());
+  Value origMemView = origMemViewOp->getOperand(0);
+  Value selectValue = origMemViewOp.getOffsets().front();
 
-    auto origMemViewType = cast<ttg::MemDescType>(origMemView.getType());
-    auto sharedEncoding = cast<triton::gpu::SwizzledSharedEncodingAttr>(
-        origMemViewType.getEncoding());
-    if (sharedEncoding == nullptr)
-      return failure();
+  auto origSrcType = rankedTType(origSrc);
+  auto blockEncoding = dyn_cast<BlockedEncodingAttr>(origSrcType.getEncoding());
+  if (blockEncoding == nullptr)
+    return failure();
 
-    RefinedBlock refinedBlock(origSrcType.getShape(),
-                              origSrcType.getElementType(), blockEncoding);
+  auto origMemViewType = cast<ttg::MemDescType>(origMemView.getType());
+  auto sharedEncoding = cast<triton::gpu::SwizzledSharedEncodingAttr>(
+      origMemViewType.getEncoding());
+  if (sharedEncoding == nullptr)
+    return failure();
 
-    constexpr bool mutableMemory = true;
-    auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+  RefinedBlock refinedBlock(origSrcType.getShape(),
+                            origSrcType.getElementType(), blockEncoding);
 
-    auto subviewType = ttg::MemDescType::get(
-        refinedBlock.refinedShape, refinedBlock.elemType, sharedEncoding,
-        sharedMemorySpace, mutableMemory, origMemViewType.getAllocShape());
+  constexpr bool mutableMemory = true;
+  auto sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
 
-    rewriter.setInsertionPointAfter(loadStoreOp);
-    AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
-    for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
-         ++linearIdx) {
-      auto coords = coordsMapper.map(linearIdx);
-      SmallVector<int64_t> offset(refinedBlock.numDims, 0);
-      for (auto [dim, coord] : llvm::enumerate(coords)) {
-        offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
-      }
-      auto offsetValues = createOffset({selectValue}, offset, rewriter, loc);
-      auto slicedSharedMemView = rewriter.create<ttg::MemDescSubviewOp>(
-          loc, subviewType, origMemView, offsetValues);
+  auto subviewType = ttg::MemDescType::get(
+      refinedBlock.refinedShape, refinedBlock.elemType, sharedEncoding,
+      sharedMemorySpace, mutableMemory, origMemViewType.getAllocShape());
 
-      auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
-
-      rewriter.create<ttg::LocalStoreOp>(loc, slice, slicedSharedMemView);
+  rewriter.setInsertionPointAfter(loadStoreOp);
+  AMD::CoordinateMapper coordsMapper(refinedBlock.numPerDims);
+  for (size_t linearIdx = 0; linearIdx < refinedBlock.numSubTiles;
+       ++linearIdx) {
+    auto coords = coordsMapper.map(linearIdx);
+    SmallVector<int64_t> offset(refinedBlock.numDims, 0);
+    for (auto [dim, coord] : llvm::enumerate(coords)) {
+      offset[dim] = coord * refinedBlock.elementsPerWorkGroup[dim];
     }
+    auto offsetValues = createOffset({selectValue}, offset, rewriter, loc);
+    auto slicedSharedMemView = rewriter.create<ttg::MemDescSubviewOp>(
+        loc, subviewType, origMemView, offsetValues);
 
-    rewriter.eraseOp(loadStoreOp);
-    return success();
+    auto slice = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+        loc, Type{refinedBlock.tensorType}, Value{origSrc}, offset);
+
+    rewriter.create<ttg::LocalStoreOp>(loc, slice, slicedSharedMemView);
   }
-};
+
+  rewriter.eraseOp(loadStoreOp);
+  return success();
+}
 
 // Reduce ops have different intput and output shapes and produce
 // sliced layouts.
 // This currently only supports 2d inputs.
-struct ReduceOpPattern : public OpRewritePattern<triton::ReduceOp> {
-  ReduceOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+LogicalResult rewriteReduceOp(PatternRewriter &rewriter, triton::ReduceOp op) {
+  auto ctx = op->getContext();
+  auto loc = op.getLoc();
+  uint32_t axisReduce = op.getAxis();
+  uint32_t axisNonReduce = (axisReduce + 1) % 2;
+  if (op.getNumOperands() != 1)
+    return failure();
 
-  LogicalResult matchAndRewrite(triton::ReduceOp op,
-                                PatternRewriter &rewriter) const override {
-    auto ctx = op->getContext();
-    auto loc = op.getLoc();
-    uint32_t axisReduce = op.getAxis();
-    uint32_t axisNonReduce = (axisReduce + 1) % 2;
-    if (op.getNumOperands() != 1)
-      return failure();
+  // Calculate refined shape.
+  auto src = op->getOperand(0);
+  auto srcType = rankedTType(src);
+  if (srcType.getRank() != 2)
+    return failure();
+  auto srcShape = srcType.getShape();
+  auto srcEncoding = srcType.getEncoding();
+  auto srcShapePerCtaTile = triton::gpu::getShapePerCTATile(srcType);
+  SmallVector<int64_t> repShape = {srcShape[0] / srcShapePerCtaTile[0],
+                                   srcShape[1] / srcShapePerCtaTile[1]};
+  int numReps = repShape[axisNonReduce];
+  SmallVector<int64_t> refinedSrcShape = {srcShape[0], srcShape[1]};
+  refinedSrcShape[axisNonReduce] /= numReps;
+  int64_t elementsPerRep = refinedSrcShape[axisNonReduce];
+  auto elemTy = srcType.getElementType();
+  auto refinedTensorType =
+      RankedTensorType::get(refinedSrcShape, elemTy, srcEncoding);
 
-    // Calculate refined shape.
-    auto src = op->getOperand(0);
-    auto srcType = rankedTType(src);
-    if (srcType.getRank() != 2)
-      return failure();
-    auto srcShape = srcType.getShape();
-    auto srcEncoding = srcType.getEncoding();
-    auto srcShapePerCtaTile = triton::gpu::getShapePerCTATile(srcType);
-    SmallVector<int64_t> repShape = {srcShape[0] / srcShapePerCtaTile[0],
-                                     srcShape[1] / srcShapePerCtaTile[1]};
-    int numReps = repShape[axisNonReduce];
-    SmallVector<int64_t> refinedSrcShape = {srcShape[0], srcShape[1]};
-    refinedSrcShape[axisNonReduce] /= numReps;
-    int64_t elementsPerRep = refinedSrcShape[axisNonReduce];
-    auto elemTy = srcType.getElementType();
-    auto refinedTensorType =
-        RankedTensorType::get(refinedSrcShape, elemTy, srcEncoding);
-
-    // Create refined ops.
-    rewriter.setInsertionPointAfter(op);
-    SmallVector<Value> refinedReduces;
-    for (int i = 0; i < numReps; ++i) {
-      SmallVector<int64_t> offset(refinedSrcShape.size(), 0);
-      offset[axisReduce] = 0;
-      offset[axisNonReduce] = i * elementsPerRep;
-      auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          loc, Type{refinedTensorType}, Value{src}, offset);
-      auto reduceOp = rewriter.create<triton::ReduceOp>(
-          loc, ValueRange{sliceOp}, axisReduce);
-      IRMapping mapping;
-      mapping.map(reduceOp.getOperand(0), sliceOp);
-      op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);
-      refinedReduces.push_back(reduceOp->getResult(0));
-    }
-
-    // Concat reduce slices.
-    auto reduceResultType = op.getResultTypes()[0];
-    SmallVector<int64_t> concatDimShape = {numReps};
-    auto concatDims = DenseI64ArrayAttr::get(ctx, concatDimShape);
-    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-        loc, reduceResultType, refinedReduces, concatDims);
-    auto origOpResult = op.getResult();
-    origOpResult.replaceAllUsesWith(concatOp);
-    rewriter.eraseOp(op);
-    return success();
+  // Create refined ops.
+  rewriter.setInsertionPointAfter(op);
+  SmallVector<Value> refinedReduces;
+  for (int i = 0; i < numReps; ++i) {
+    SmallVector<int64_t> offset(refinedSrcShape.size(), 0);
+    offset[axisReduce] = 0;
+    offset[axisNonReduce] = i * elementsPerRep;
+    auto sliceOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+        loc, Type{refinedTensorType}, Value{src}, offset);
+    auto reduceOp =
+        rewriter.create<triton::ReduceOp>(loc, ValueRange{sliceOp}, axisReduce);
+    IRMapping mapping;
+    mapping.map(reduceOp.getOperand(0), sliceOp);
+    op.getCombineOp().cloneInto(&reduceOp->getRegion(0), mapping);
+    refinedReduces.push_back(reduceOp->getResult(0));
   }
-};
+
+  // Concat reduce slices.
+  auto reduceResultType = op.getResultTypes()[0];
+  SmallVector<int64_t> concatDimShape = {numReps};
+  auto concatDims = DenseI64ArrayAttr::get(ctx, concatDimShape);
+  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+      loc, reduceResultType, refinedReduces, concatDims);
+  auto origOpResult = op.getResult();
+  origOpResult.replaceAllUsesWith(concatOp);
+  rewriter.eraseOp(op);
+  return success();
+}
 
 SmallVector<unsigned> getRefinedShapePerCTATile(Type type) {
   auto tensorType = cast<mlir::RankedTensorType>(type);
@@ -741,125 +711,119 @@ SmallVector<unsigned> getRefinedShapePerCTATile(Type type) {
 // Refine ops with distributed layouts.
 // Assumes same layout for operands.
 template <typename OpTy>
-struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
-  ElementWiseOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern<OpTy>(context, benefit) {}
+LogicalResult rewriteElementWiseOp(PatternRewriter &rewriter, OpTy op) {
+  // Verify opd[0] is valid.
+  int numOperands = op->getNumOperands();
+  if (op->getNumOperands() < 1)
+    return failure();
+  auto src = op->getOperand(0);
+  if (!isa<mlir::RankedTensorType>(src.getType()))
+    return failure();
+  auto srcType = rankedTType(src);
+  auto rank = srcType.getRank();
+  if (rank != 2) { // TODO(dtanner) remove me
+    return failure();
+  }
 
-  LogicalResult matchAndRewrite(OpTy op,
-                                PatternRewriter &rewriter) const override {
-    // Verify opd[0] is valid.
-    int numOperands = op->getNumOperands();
-    if (op->getNumOperands() < 1)
+  auto srcShape = srcType.getShape();
+  auto srcEncoding = srcType.getEncoding();
+  auto srcLL = ttg::toLinearEncoding(srcType);
+  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+
+  // Verify subsequent operands match opd[0].
+  for (int i = 1; i < numOperands; ++i) {
+    if (!isa<mlir::RankedTensorType>(op->getOperand(i).getType()))
       return failure();
-    auto src = op->getOperand(0);
-    if (!isa<mlir::RankedTensorType>(src.getType()))
+    if (rankedTType(op->getOperand(i)).getRank() != rank)
       return failure();
-    auto srcType = rankedTType(src);
-    auto rank = srcType.getRank();
-    if (rank != 2) { // TODO(dtanner) remove me
+    if (getRefinedShapePerCTATile(op->getOperand(i).getType()) !=
+        srcShapePerCtaTile)
       return failure();
+  }
+
+  // Result tensor.
+  auto res = op->getResult(0);
+  if (!isa<mlir::RankedTensorType>(res.getType()))
+    return failure();
+  auto resType = rankedTType(res);
+  auto resShape = resType.getShape();
+  if (resShape != srcShape)
+    return failure();
+
+  LDBG("rewriteElementWiseOp(): " << op);
+
+  // DEBUG check if concat op results in correct linear layout
+  auto leRes = ttg::toLinearEncoding(resType);
+  auto llRes = leRes.getLinearLayout();
+
+  auto resEncoding = resType.getEncoding();
+  auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
+
+  // Calculate refined shapes.
+  SmallVector<int64_t> refinedShape;
+  SmallVector<int64_t> numReps;
+  for (int i = 0; i < rank; ++i) {
+    // src and res can have different refineable shapes if different layouts.
+    refinedShape.push_back(
+        std::max(srcShapePerCtaTile[i], resShapePerCtaTile[i]));
+    numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
+  }
+
+  if (product<int64_t>(numReps) == 1)
+    return success();
+
+  // Create refined ops.
+  auto refinedTensorTypeSrc = RankedTensorType::get(
+      refinedShape, srcType.getElementType(), srcEncoding);
+  auto refinedTensorTypeRes = RankedTensorType::get(
+      refinedShape, resType.getElementType(), resEncoding);
+
+  rewriter.setInsertionPointAfter(op);
+  SmallVector<Value> refinedOps;
+  SmallVector<int64_t> offset(rank, 0);
+  int outerIdx = 0; // rank-1;
+  int innerIdx = 1; // rank-2;
+
+  auto sliceOperation = [&]() {
+    SmallVector<Value> slicedOperands;
+    for (int opdIdx = 0; opdIdx < numOperands; ++opdIdx) {
+      auto slicedOperand = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+          op.getLoc(), Type{refinedTensorTypeSrc},
+          Value{op->getOperand(opdIdx)}, offset);
+      slicedOperands.push_back(slicedOperand);
     }
+    auto refinedOp = rewriter.create<OpTy>(op.getLoc(), refinedTensorTypeRes,
+                                           slicedOperands);
+    refinedOps.push_back(refinedOp->getResult(0));
+  };
 
-    auto srcShape = srcType.getShape();
-    auto srcEncoding = srcType.getEncoding();
-    auto srcLL = ttg::toLinearEncoding(srcType);
-    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+  for (int i = 0; i < numReps[outerIdx]; ++i) {
+    offset[outerIdx] = i * refinedShape[outerIdx];
 
-    // Verify subsequent operands match opd[0].
-    for (int i = 1; i < numOperands; ++i) {
-      if (!isa<mlir::RankedTensorType>(op->getOperand(i).getType()))
-        return failure();
-      if (rankedTType(op->getOperand(i)).getRank() != rank)
-        return failure();
-      if (getRefinedShapePerCTATile(op->getOperand(i).getType()) !=
-          srcShapePerCtaTile)
-        return failure();
-    }
-
-    // Result tensor.
-    auto res = op->getResult(0);
-    if (!isa<mlir::RankedTensorType>(res.getType()))
-      return failure();
-    auto resType = rankedTType(res);
-    auto resShape = resType.getShape();
-    if (resShape != srcShape)
-      return failure();
-
-    LDBG("rewriteElementWiseOp(): " << op);
-
-    // DEBUG check if concat op results in correct linear layout
-    auto leRes = ttg::toLinearEncoding(resType);
-    auto llRes = leRes.getLinearLayout();
-
-    auto resEncoding = resType.getEncoding();
-    auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
-
-    // Calculate refined shapes.
-    SmallVector<int64_t> refinedShape;
-    SmallVector<int64_t> numReps;
-    for (int i = 0; i < rank; ++i) {
-      // src and res can have different refineable shapes if different layouts.
-      refinedShape.push_back(
-          std::max(srcShapePerCtaTile[i], resShapePerCtaTile[i]));
-      numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
-    }
-
-    if (product<int64_t>(numReps) == 1)
-      return success();
-
-    // Create refined ops.
-    auto refinedTensorTypeSrc = RankedTensorType::get(
-        refinedShape, srcType.getElementType(), srcEncoding);
-    auto refinedTensorTypeRes = RankedTensorType::get(
-        refinedShape, resType.getElementType(), resEncoding);
-
-    rewriter.setInsertionPointAfter(op);
-    SmallVector<Value> refinedOps;
-    SmallVector<int64_t> offset(rank, 0);
-    int outerIdx = 0; // rank-1;
-    int innerIdx = 1; // rank-2;
-
-    auto sliceOperation = [&]() {
-      SmallVector<Value> slicedOperands;
-      for (int opdIdx = 0; opdIdx < numOperands; ++opdIdx) {
-        auto slicedOperand = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-            op.getLoc(), Type{refinedTensorTypeSrc},
-            Value{op->getOperand(opdIdx)}, offset);
-        slicedOperands.push_back(slicedOperand);
-      }
-      auto refinedOp = rewriter.create<OpTy>(op.getLoc(), refinedTensorTypeRes,
-                                             slicedOperands);
-      refinedOps.push_back(refinedOp->getResult(0));
-    };
-
-    for (int i = 0; i < numReps[outerIdx]; ++i) {
-      offset[outerIdx] = i * refinedShape[outerIdx];
-
-      if (rank == 2) {
-        for (int j = 0; j < numReps[innerIdx]; ++j) {
-          offset[innerIdx] = j * refinedShape[innerIdx];
-          sliceOperation();
-        }
-      } else {
-        assert(rank == 1 && "rank is expected to be `1`");
+    if (rank == 2) {
+      for (int j = 0; j < numReps[innerIdx]; ++j) {
+        offset[innerIdx] = j * refinedShape[innerIdx];
         sliceOperation();
       }
+    } else {
+      assert(rank == 1 && "rank is expected to be `1`");
+      sliceOperation();
     }
-
-    // Concat slices.
-    auto resultType = op->getResultTypes()[0];
-    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-        op.getLoc(), resultType, refinedOps, concatDims);
-
-    auto origOpResult = op.getResult();
-    origOpResult.replaceAllUsesWith(concatOp);
-    LDBG("rewriteElementWiseOp() - SUCCESS " << op);
-    rewriter.replaceOp(op, concatOp);
-
-    return success();
   }
-};
+
+  // Concat slices.
+  auto resultType = op->getResultTypes()[0];
+  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+      op.getLoc(), resultType, refinedOps, concatDims);
+
+  auto origOpResult = op.getResult();
+  origOpResult.replaceAllUsesWith(concatOp);
+  LDBG("rewriteElementWiseOp() - SUCCESS " << op);
+  rewriter.replaceOp(op, concatOp);
+
+  return success();
+}
 
 // Refine ExpandDims ops.
 // Since expanding dims increases tensor rank,
@@ -868,117 +832,110 @@ struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
 // <M> -> <M/m> -> <M/m x 1> -> <Mx1>.
 // TODO(dtanner) only need to support 1D sliceLayout input, same as
 // ViewOpToLLVM.cpp ?
-struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
-  ExpandDimsOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit) {}
+LogicalResult rewriteExpandDimsOp(PatternRewriter &rewriter,
+                                  triton::ExpandDimsOp op) {
+  int numOperands = op->getNumOperands();
+  if (op->getNumOperands() != 1)
+    return failure();
+  auto src = op->getOperand(0);
+  if (!isa<mlir::RankedTensorType>(src.getType()))
+    return failure();
+  auto srcType = rankedTType(src);
+  if (srcType.getElementTypeBitWidth() == 1)
+    return failure();
 
-  LogicalResult matchAndRewrite(triton::ExpandDimsOp op,
-                                PatternRewriter &rewriter) const override {
-    int numOperands = op->getNumOperands();
-    if (op->getNumOperands() != 1)
-      return failure();
-    auto src = op->getOperand(0);
-    if (!isa<mlir::RankedTensorType>(src.getType()))
-      return failure();
-    auto srcType = rankedTType(src);
-    if (srcType.getElementTypeBitWidth() == 1)
-      return failure();
+  auto rank = srcType.getRank();
+  auto srcShape = srcType.getShape();
+  auto srcEncoding = srcType.getEncoding();
+  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
 
-    auto rank = srcType.getRank();
-    auto srcShape = srcType.getShape();
-    auto srcEncoding = srcType.getEncoding();
-    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+  auto ll = triton::gpu::toLinearEncoding(srcType);
 
-    auto ll = triton::gpu::toLinearEncoding(srcType);
+  // Calculate refined shape.
+  SmallVector<int64_t> refinedSrcShape;
+  SmallVector<int64_t> numReps;
+  for (int i = 0; i < rank; ++i) {
+    refinedSrcShape.push_back(srcShapePerCtaTile[i]);
+    numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
+  }
 
-    // Calculate refined shape.
-    SmallVector<int64_t> refinedSrcShape;
-    SmallVector<int64_t> numReps;
-    for (int i = 0; i < rank; ++i) {
-      refinedSrcShape.push_back(srcShapePerCtaTile[i]);
-      numReps.push_back(srcShape[i] / srcShapePerCtaTile[i]);
+  if (product<int64_t>(numReps) == 1)
+    return success();
+
+  auto refinedResultShape = refinedSrcShape;
+  refinedResultShape.insert(refinedResultShape.begin() + op.getAxis(), 1);
+  auto refinedSrcTensorType = RankedTensorType::get(
+      refinedSrcShape, srcType.getElementType(), srcEncoding);
+
+  // Create refined ops.
+  rewriter.setInsertionPointAfter(op);
+  SmallVector<Value> refinedReduces;
+  SmallVector<int64_t> offset(rank, 0);
+
+  auto sliceOperation = [&]() {
+    auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+        op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
+        offset);
+
+    auto sliceRes = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
+        slicedOp->getResult(0));
+
+    auto sliceResTy = sliceRes.getType();
+    Attribute refinedResultEncoding;
+
+    if (auto refinedSrcEncoding = sliceResTy.getEncoding()) {
+      if (cast<DialectInferLayoutInterface>(&srcEncoding.getDialect())
+              ->inferExpandDimsOpEncoding(refinedSrcEncoding, op.getAxis(),
+                                          refinedResultEncoding, op.getLoc())
+              .failed()) {
+        return emitOptionalError(op.getLoc(),
+                                 "Failed to infer layout for ExpandDimsOp");
+      }
     }
 
-    if (product<int64_t>(numReps) == 1)
-      return success();
+    auto sliceResTensorType = RankedTensorType::get(
+        refinedResultShape, sliceResTy.getElementType(), refinedResultEncoding);
 
-    auto refinedResultShape = refinedSrcShape;
-    refinedResultShape.insert(refinedResultShape.begin() + op.getAxis(), 1);
-    auto refinedSrcTensorType = RankedTensorType::get(
-        refinedSrcShape, srcType.getElementType(), srcEncoding);
+    auto refinedOp = rewriter.create<triton::ExpandDimsOp>(
+        op.getLoc(), sliceResTensorType, sliceRes, op.getAxis());
 
-    // Create refined ops.
-    rewriter.setInsertionPointAfter(op);
-    SmallVector<Value> refinedReduces;
-    SmallVector<int64_t> offset(rank, 0);
+    refinedReduces.push_back(refinedOp->getResult(0));
+    return success();
+  };
 
-    auto sliceOperation = [&]() {
-      auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
-          offset);
+  for (int i = 0; i < numReps[rank - 1]; ++i) {
+    offset[rank - 1] = i * refinedSrcShape[rank - 1];
 
-      auto sliceRes =
-          ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
-              slicedOp->getResult(0));
-
-      auto sliceResTy = sliceRes.getType();
-      Attribute refinedResultEncoding;
-
-      if (auto refinedSrcEncoding = sliceResTy.getEncoding()) {
-        if (cast<DialectInferLayoutInterface>(&srcEncoding.getDialect())
-                ->inferExpandDimsOpEncoding(refinedSrcEncoding, op.getAxis(),
-                                            refinedResultEncoding, op.getLoc())
-                .failed()) {
-          return emitOptionalError(op.getLoc(),
-                                   "Failed to infer layout for ExpandDimsOp");
-        }
-      }
-
-      auto sliceResTensorType =
-          RankedTensorType::get(refinedResultShape, sliceResTy.getElementType(),
-                                refinedResultEncoding);
-
-      auto refinedOp = rewriter.create<triton::ExpandDimsOp>(
-          op.getLoc(), sliceResTensorType, sliceRes, op.getAxis());
-
-      refinedReduces.push_back(refinedOp->getResult(0));
-      return success();
-    };
-
-    for (int i = 0; i < numReps[rank - 1]; ++i) {
-      offset[rank - 1] = i * refinedSrcShape[rank - 1];
-
-      // TODO(dtanner) how to iterate over Nd array?
-      if (rank == 2) {
-        for (int j = 0; j < numReps[rank - 2]; ++j) {
-          offset[rank - 2] = j * refinedSrcShape[rank - 2];
-          if (llvm::failed(sliceOperation()))
-            return failure();
-        }
-      } else {
-        assert(rank == 1 && "rank is expected to be `1`");
+    // TODO(dtanner) how to iterate over Nd array?
+    if (rank == 2) {
+      for (int j = 0; j < numReps[rank - 2]; ++j) {
+        offset[rank - 2] = j * refinedSrcShape[rank - 2];
         if (llvm::failed(sliceOperation()))
           return failure();
       }
+    } else {
+      assert(rank == 1 && "rank is expected to be `1`");
+      if (llvm::failed(sliceOperation()))
+        return failure();
     }
-
-    // Concat refined ops.
-    auto reduceResultType = op->getResultTypes()[0];
-    // Expand dims of numReps also before concat.
-    numReps.insert(numReps.begin() + op.getAxis(), 1);
-    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-        op.getLoc(), reduceResultType, refinedReduces, concatDims);
-    auto origOpResult = op.getResult();
-
-    auto checkLL = triton::gpu::toLinearEncoding(
-        cast<mlir::RankedTensorType>(refinedReduces.front().getType()));
-
-    origOpResult.replaceAllUsesWith(concatOp);
-    rewriter.eraseOp(op);
-    return success();
   }
-};
+
+  // Concat refined ops.
+  auto reduceResultType = op->getResultTypes()[0];
+  // Expand dims of numReps also before concat.
+  numReps.insert(numReps.begin() + op.getAxis(), 1);
+  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+      op.getLoc(), reduceResultType, refinedReduces, concatDims);
+  auto origOpResult = op.getResult();
+
+  auto checkLL = triton::gpu::toLinearEncoding(
+      cast<mlir::RankedTensorType>(refinedReduces.front().getType()));
+
+  origOpResult.replaceAllUsesWith(concatOp);
+  rewriter.eraseOp(op);
+  return success();
+}
 
 // Refine Broadcast ops.
 // Since inputs are roughtly 1D and outputs are roughly 2D,
@@ -995,102 +952,218 @@ struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
 //        \             <64x32>   /
 //         -> <64x1> -> <64x32>  /
 //                      <64x32> /
+LogicalResult rewriteBroadcastOp(PatternRewriter &rewriter, BroadcastOp op) {
+  // src tensor e.g. <128x1>.
+  int numOperands = op->getNumOperands();
+  if (op->getNumOperands() != 1)
+    return failure();
+  auto src = op->getOperand(0);
+  if (!isa<mlir::RankedTensorType>(src.getType()))
+    return failure();
+  auto srcType = rankedTType(src);
+  auto rank = srcType.getRank();
+  if (rank != 2)
+    return failure();
+  if (srcType.getElementTypeBitWidth() == 1)
+    return failure();
+  auto srcShape = srcType.getShape();
+  auto srcEncoding = srcType.getEncoding();
+  auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
+
+  // Result tensor e.g. <128x64>.
+  auto res = op->getResult(0);
+  if (!isa<mlir::RankedTensorType>(res.getType()))
+    return failure();
+  auto resType = rankedTType(res);
+  auto resShape = resType.getShape();
+  auto resEncoding = resType.getEncoding();
+  auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
+
+  // numReps
+  SmallVector<int64_t> refinedSrcShape;
+  SmallVector<int64_t> refinedResShape;
+  SmallVector<int64_t> numReps;
+  for (int i = 0; i < rank; ++i) {
+    refinedSrcShape.push_back(srcShapePerCtaTile[i]);
+    refinedResShape.push_back(resShapePerCtaTile[i]);
+    numReps.push_back(resShape[i] / resShapePerCtaTile[i]);
+  }
+
+  if (product<int64_t>(numReps) == 1)
+    return success();
+
+  // Determine indices and values of reps.
+  // numRepsSrc is the non-one size, because the src can be sliced.
+  // numRepsRes is the one size, because the result will be repeated.
+  unsigned numRepsSrcIdx = 0; // <*128x 1>
+  unsigned numRepsResIdx = 1; // < 128x*1>
+  if (refinedSrcShape[numRepsSrcIdx] == 1) {
+    numRepsSrcIdx = 1; // < 1x*64>
+    numRepsResIdx = 0; // <*1x 64>
+  }
+  unsigned numRepsSrc = numReps[numRepsSrcIdx];
+  unsigned numRepsRes = numReps[numRepsResIdx];
+
+  // Refined src/result tensor types.
+  auto refinedSrcTensorType = RankedTensorType::get(
+      refinedSrcShape, srcType.getElementType(), srcEncoding);
+  auto refinedResTensorType = RankedTensorType::get(
+      refinedResShape, srcType.getElementType(), srcEncoding);
+
+  // Create refined ops.
+  rewriter.setInsertionPointAfter(op);
+  SmallVector<Value> refinedBroadcasts;
+  SmallVector<int64_t> offset(rank, 0);
+  for (int i = 0; i < numRepsSrc; ++i) {
+    offset[numRepsSrcIdx] = i * refinedSrcShape[numRepsSrcIdx];
+    // Create slice.
+    auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
+        op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
+        offset);
+    auto sliceRes = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
+        slicedOp->getResult(0));
+    auto sliceResTensorType = RankedTensorType::get(
+        refinedResShape, srcType.getElementType(), resEncoding);
+    for (int j = 0; j < numRepsRes; ++j) {
+      // Create broadcast.
+      auto broadcastOp = rewriter.create<triton::BroadcastOp>(
+          op.getLoc(), sliceResTensorType, sliceRes);
+      refinedBroadcasts.push_back(broadcastOp->getResult(0));
+    }
+  }
+
+  // Concat refined ops.
+  auto reduceResultType = op->getResultTypes()[0];
+  auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
+  auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
+      op.getLoc(), reduceResultType, refinedBroadcasts, concatDims);
+
+  auto origOpResult = op.getResult();
+  origOpResult.replaceAllUsesWith(concatOp);
+  rewriter.eraseOp(op);
+  return success();
+}
+
+struct LocalLoadOpPattern : public OpRewritePattern<triton::gpu::LocalLoadOp> {
+  LocalLoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::gpu::LocalLoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1) {
+      return failure();
+    }
+    auto result = rewriteLocalLoad(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine ttg.localLoad: " << *op);
+    }
+    return result;
+  }
+};
+
+struct DotOpPattern : public OpRewritePattern<triton::DotOp> {
+  DotOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::DotOp op,
+                                PatternRewriter &rewriter) const override {
+    auto result = rewriteMFMA(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine tt.Dot: " << *op);
+    }
+    return result;
+  }
+};
+
+struct LoadOpPattern : public OpRewritePattern<triton::LoadOp> {
+  LoadOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::LoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1) {
+      return failure();
+    }
+    auto result = rewriteLoadOp(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine tt.loadOp: " << *op);
+    }
+    return result;
+  }
+};
+
+struct LocalStoreOpPattern
+    : public OpRewritePattern<triton::gpu::LocalStoreOp> {
+  LocalStoreOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::gpu::LocalStoreOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2) {
+      return failure();
+    }
+    auto result = rewriteLocalStoreOp(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine ttg.localLoadOp: " << *op);
+    }
+    return result;
+  }
+};
+
+struct ReduceOpPattern : public OpRewritePattern<triton::ReduceOp> {
+  ReduceOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::ReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    auto result = rewriteReduceOp(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine tt.reduce: " << *op);
+    }
+    return result;
+  }
+};
+
+template <typename OpTy>
+struct ElementWiseOpPattern : public OpRewritePattern<OpTy> {
+  ElementWiseOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern<OpTy>(context, benefit) {}
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    auto result = rewriteElementWiseOp<OpTy>(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine elementwise op: " << *op);
+    }
+    return result;
+  }
+};
+
+struct ExpandDimsOpPattern : public OpRewritePattern<triton::ExpandDimsOp> {
+  ExpandDimsOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(triton::ExpandDimsOp op,
+                                PatternRewriter &rewriter) const override {
+    auto result = rewriteExpandDimsOp(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine tt.expand_dims: " << *op);
+    }
+    return result;
+  }
+};
+
 struct BroadcastOpPattern : public OpRewritePattern<BroadcastOp> {
   BroadcastOpPattern(MLIRContext *context, PatternBenefit benefit = 1)
       : OpRewritePattern(context, benefit) {}
 
   LogicalResult matchAndRewrite(BroadcastOp op,
                                 PatternRewriter &rewriter) const override {
-    // src tensor e.g. <128x1>.
-    int numOperands = op->getNumOperands();
-    if (op->getNumOperands() != 1)
-      return failure();
-    auto src = op->getOperand(0);
-    if (!isa<mlir::RankedTensorType>(src.getType()))
-      return failure();
-    auto srcType = rankedTType(src);
-    auto rank = srcType.getRank();
-    if (rank != 2)
-      return failure();
-    if (srcType.getElementTypeBitWidth() == 1)
-      return failure();
-    auto srcShape = srcType.getShape();
-    auto srcEncoding = srcType.getEncoding();
-    auto srcShapePerCtaTile = getRefinedShapePerCTATile(srcType);
-
-    // Result tensor e.g. <128x64>.
-    auto res = op->getResult(0);
-    if (!isa<mlir::RankedTensorType>(res.getType()))
-      return failure();
-    auto resType = rankedTType(res);
-    auto resShape = resType.getShape();
-    auto resEncoding = resType.getEncoding();
-    auto resShapePerCtaTile = getRefinedShapePerCTATile(resType);
-
-    // numReps
-    SmallVector<int64_t> refinedSrcShape;
-    SmallVector<int64_t> refinedResShape;
-    SmallVector<int64_t> numReps;
-    for (int i = 0; i < rank; ++i) {
-      refinedSrcShape.push_back(srcShapePerCtaTile[i]);
-      refinedResShape.push_back(resShapePerCtaTile[i]);
-      numReps.push_back(resShape[i] / resShapePerCtaTile[i]);
+    auto result = rewriteBroadcastOp(rewriter, op);
+    if (failed(result)) {
+      LDBG("failed to refine tt.broadcast: " << *op);
     }
-
-    if (product<int64_t>(numReps) == 1)
-      return success();
-
-    // Determine indices and values of reps.
-    // numRepsSrc is the non-one size, because the src can be sliced.
-    // numRepsRes is the one size, because the result will be repeated.
-    unsigned numRepsSrcIdx = 0; // <*128x 1>
-    unsigned numRepsResIdx = 1; // < 128x*1>
-    if (refinedSrcShape[numRepsSrcIdx] == 1) {
-      numRepsSrcIdx = 1; // < 1x*64>
-      numRepsResIdx = 0; // <*1x 64>
-    }
-    unsigned numRepsSrc = numReps[numRepsSrcIdx];
-    unsigned numRepsRes = numReps[numRepsResIdx];
-
-    // Refined src/result tensor types.
-    auto refinedSrcTensorType = RankedTensorType::get(
-        refinedSrcShape, srcType.getElementType(), srcEncoding);
-    auto refinedResTensorType = RankedTensorType::get(
-        refinedResShape, srcType.getElementType(), srcEncoding);
-
-    // Create refined ops.
-    rewriter.setInsertionPointAfter(op);
-    SmallVector<Value> refinedBroadcasts;
-    SmallVector<int64_t> offset(rank, 0);
-    for (int i = 0; i < numRepsSrc; ++i) {
-      offset[numRepsSrcIdx] = i * refinedSrcShape[numRepsSrcIdx];
-      // Create slice.
-      auto slicedOp = rewriter.create<triton::amdgpu::ExtractSliceOp>(
-          op.getLoc(), Type{refinedSrcTensorType}, Value{op->getOperand(0)},
-          offset);
-      auto sliceRes =
-          ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
-              slicedOp->getResult(0));
-      auto sliceResTensorType = RankedTensorType::get(
-          refinedResShape, srcType.getElementType(), resEncoding);
-      for (int j = 0; j < numRepsRes; ++j) {
-        // Create broadcast.
-        auto broadcastOp = rewriter.create<triton::BroadcastOp>(
-            op.getLoc(), sliceResTensorType, sliceRes);
-        refinedBroadcasts.push_back(broadcastOp->getResult(0));
-      }
-    }
-
-    // Concat refined ops.
-    auto reduceResultType = op->getResultTypes()[0];
-    auto concatDims = DenseI64ArrayAttr::get(op->getContext(), numReps);
-    auto concatOp = rewriter.create<triton::amdgpu::ConcatOp>(
-        op.getLoc(), reduceResultType, refinedBroadcasts, concatDims);
-
-    auto origOpResult = op.getResult();
-    origOpResult.replaceAllUsesWith(concatOp);
-    rewriter.eraseOp(op);
-    return success();
+    return result;
   }
 };
 
@@ -1161,119 +1234,8 @@ struct TritonAMDGPURefineOps
     REFINE_ELEMENTWISE_OP(triton::gpu::ConvertLayoutOp)
 
 #undef REFINE_ELEMENTWISE_OP
-
     walkAndApplyPatterns(func, std::move(patterns));
-
-    // func->walk([&](amdgpu::InstructionSchedHint hint) {
-    //   if (hint.getVariant() != amdgpu::SchedHint::refine_ops) {
-    //     return WalkResult::advance();
-    //   }
-
-    //   auto *block = hint->getBlock();
-
-    // block->walk([&](triton::gpu::LocalLoadOp localLoadOp) {
-    //   OpBuilder rewriter(localLoadOp->getContext());
-    //   if (localLoadOp->getNumOperands() == 1) {
-    //     if (failed(rewriteLocalLoad(rewriter, localLoadOp))) {
-    //       LDBG("failed to refine ttg.localLoad: " << *localLoadOp);
-    //     }
-    //   }
-    // });
-
-    // block->walk([&](triton::DotOp dotOp) {
-    //   OpBuilder rewriter(dotOp->getContext());
-    //   // TODO: extend to WMMA instructions
-    //   if (failed(rewriteMFMA(rewriter, dotOp))) {
-    //     LDBG("failed to refine tt.dotOp: " << *dotOp);
-    //   }
-    // });
-
-    // block->walk([&](triton::LoadOp loadOp) {
-    //   OpBuilder rewriter(loadOp->getContext());
-    //   if (loadOp->getNumOperands() == 1) {
-    //     if (failed(rewriteLoadOp(rewriter, loadOp))) {
-    //       LDBG("failed to refine tt.loadOp: " << *loadOp);
-    //     }
-    //   }
-    // });
-
-    // block->walk([&](triton::gpu::LocalStoreOp storeOp) {
-    //   OpBuilder rewriter(storeOp->getContext());
-    //   if (storeOp->getNumOperands() == 2) {
-    //     if (failed(rewriteLocalStoreOp(rewriter, storeOp))) {
-    //       LDBG("failed to refine ttg.localLoadOp: " << *storeOp);
-    //     }
-    //   }
-    // });
-
-    // block->walk([&](triton::ReduceOp reduceOp) {
-    //   OpBuilder rewriter(reduceOp->getContext());
-    //   if (failed(rewriteReduceOp(rewriter, reduceOp))) {
-    //     LDBG("failed to refine tt.reduce: " << *reduceOp);
-    //   }
-    // });
-
-    // Refine Unary Element-Wise Ops.
-    // REFINE_ELEMENTWISE_OP(math::RsqrtOp)
-    // REFINE_ELEMENTWISE_OP(math::Exp2Op)
-    // REFINE_ELEMENTWISE_OP(arith::TruncFOp)
-    // REFINE_ELEMENTWISE_OP(arith::ExtFOp)
-    // REFINE_ELEMENTWISE_OP(arith::FPToSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::SIToFPOp)
-    // REFINE_ELEMENTWISE_OP(triton::FpToFpOp)
-    // REFINE_ELEMENTWISE_OP(triton::PreciseSqrtOp)
-    // REFINE_ELEMENTWISE_OP(math::SqrtOp)
-    // REFINE_ELEMENTWISE_OP(math::ExpOp)
-    // REFINE_ELEMENTWISE_OP(arith::SubIOp)
-    // REFINE_ELEMENTWISE_OP(arith::AddIOp)
-    // REFINE_ELEMENTWISE_OP(arith::MulIOp)
-    // REFINE_ELEMENTWISE_OP(arith::DivSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::DivUIOp)
-    // REFINE_ELEMENTWISE_OP(arith::RemFOp)
-    // REFINE_ELEMENTWISE_OP(arith::RemSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::RemUIOp)
-    // REFINE_ELEMENTWISE_OP(arith::AndIOp)
-    // REFINE_ELEMENTWISE_OP(arith::OrIOp)
-    // REFINE_ELEMENTWISE_OP(arith::XOrIOp)
-    // REFINE_ELEMENTWISE_OP(arith::ShLIOp)
-    // REFINE_ELEMENTWISE_OP(arith::ShRSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::ShRUIOp)
-    // REFINE_ELEMENTWISE_OP(arith::MinNumFOp)
-    // REFINE_ELEMENTWISE_OP(arith::MaxNumFOp)
-    // REFINE_ELEMENTWISE_OP(arith::MinSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::MaxSIOp)
-    // REFINE_ELEMENTWISE_OP(arith::MinUIOp)
-    // REFINE_ELEMENTWISE_OP(arith::MaxUIOp)
-    // REFINE_ELEMENTWISE_OP(arith::AddFOp)
-    // REFINE_ELEMENTWISE_OP(arith::SubFOp)
-    // REFINE_ELEMENTWISE_OP(arith::MulFOp)
-    // REFINE_ELEMENTWISE_OP(arith::DivFOp)
-    // REFINE_ELEMENTWISE_OP(arith::MaximumFOp)
-    // REFINE_ELEMENTWISE_OP(arith::MinimumFOp)
-    // REFINE_ELEMENTWISE_OP(triton::gpu::ConvertLayoutOp)
-
-    // // Refine ExpandDimsOp: 128 -> 128x1
-    // block->walk([&](triton::ExpandDimsOp op) {
-    //   OpBuilder rewriter(op->getContext());
-    //   if (failed(rewriteExpandDimsOp(rewriter, op))) {
-    //     LDBG("failed to refine tt.expand_dims: " << *op);
-    //   }
-    // });
-
-    // #if 0
-    //       // Refine BroadcastOp: 128x1 -> 128x64
-    //       block->walk([&](triton::BroadcastOp op) {
-    //         OpBuilder rewriter(op->getContext());
-    //         if (failed(rewriteBroadcastOp(rewriter, op))) {
-    //           LDBG("failed to refine tt.broadcast: " << *op);
-    //         }
-    //       });
-    // #endif
-    //   return WalkResult::advance();
-    // });
   }
-
-private:
 };
 
 } // namespace

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -42,7 +42,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   });
   m.def("add_refine_amdgpu_ops",
         [](mlir::PassManager &pm, const std::string &arch) {
-          pm.addPass(mlir::createTritonAMDGPURefineOpsPass(arch));
+          pm.addNestedPass<mlir::triton::FuncOp>(
+              mlir::createTritonAMDGPURefineOpsPass(arch));
         });
   m.def("add_reschedule_amdgpu_ops",
         [](mlir::PassManager &pm, const std::string &arch) {


### PR DESCRIPTION
This PR:
- makes Refine pass FuncOp based, instead of ModuleOp
- replaces walkers with PatternRewriters