### PR TITLE
Bypass LDS for scale B operand for skinny gemms

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -250,6 +250,9 @@ void eraseLoopCarriedValues(scf::ForOp &loop, llvm::BitVector indices);
 
 // Get a boolean if the Value is an arith::ConstantOp
 std::optional<bool> getBoolFromConstant(Value cst);
+
+// Convert \param op operands and results to layout \param encoding.
+void convertOpEncoding(Attribute encoding, Operation *op);
 } // namespace mlir
 
 namespace mlir::triton {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -219,10 +219,26 @@ struct CanonicalizeConvertFromConvert
   matchAndRewrite(ConvertLayoutOp op,
                   PatternRewriter &rewriter) const override {
     // Convert to the same layout is redundant.
-    if (op->getResultTypes() == op->getOperandTypes()) {
+    auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+    auto resTy = cast<RankedTensorType>(op.getResult().getType());
+    auto dstEnc = resTy.getEncoding();
+    auto srcEnc = srcTy.getEncoding();
+
+    mlir::triton::LinearLayout srcOpLayout = mlir::triton::gpu::toLinearLayout(
+        srcTy.getShape(), srcTy.getEncoding());
+    mlir::triton::LinearLayout dstOpLayout = mlir::triton::gpu::toLinearLayout(
+        resTy.getShape(), resTy.getEncoding());
+
+    if (srcTy.getElementType() == resTy.getElementType() &&
+        srcTy.getShape() == resTy.getShape() && srcOpLayout == dstOpLayout) {
       rewriter.replaceOp(op, op->getOperands());
       return success();
     }
+
+    // if (op->getResultTypes() == op->getOperandTypes()) {
+    //   rewriter.replaceOp(op, op->getOperands());
+    //   return success();
+    // }
 
     // We don't handle conversions to DotOperandEncodingAttr.  This is a
     // heuristic to accommodate fused attention.

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -185,7 +185,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     // 4. Convert the output of this new memory op back to L1
     // 5. Replace all the uses of the original memory op by the new one
     for (auto &kv : layoutMap) {
-      coalesceOp(kv.second, kv.first);
+      convertOpEncoding(kv.second, kv.first);
     }
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -110,49 +110,6 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
                                  tensorType.getElementType(), encoding);
   }
 
-  void coalesceOp(Attribute encoding, Operation *op) {
-    OpBuilder builder(op);
-    // Convert operands
-    // For load/store with tensor pointers, we don't have to change the
-    // operands' type, we do this by changing the outputs' type of
-    // `make_tensor_ptr`
-    SmallVector<Value, 4> newArgs;
-    for (auto operand : op->getOperands()) {
-      auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
-      if (tensorType &&
-          !isa<triton::gpu::SharedEncodingTrait>(tensorType.getEncoding())) {
-        Type newType = getNewType(tensorType, encoding);
-        newArgs.push_back(builder.create<triton::gpu::ConvertLayoutOp>(
-            op->getLoc(), newType, operand));
-      } else {
-        newArgs.push_back(operand);
-      }
-    }
-
-    // Convert output types
-    SmallVector<Type, 4> newTypes;
-    for (auto t : op->getResultTypes()) {
-      bool isAsync = isa<triton::gpu::AsyncCopyGlobalToLocalOp>(op);
-      newTypes.push_back(isAsync ? t : getNewType(t, encoding));
-    }
-
-    // Construct new op with the new encoding
-    Operation *newOp =
-        builder.create(op->getLoc(), op->getName().getIdentifier(), newArgs,
-                       newTypes, op->getAttrs());
-
-    // Cast the results back to the original layout
-    for (size_t i = 0; i < op->getNumResults(); i++) {
-      Value newResult = newOp->getResult(i);
-      if (newTypes[i] != op->getResultTypes()[i]) {
-        newResult = builder.create<triton::gpu::ConvertLayoutOp>(
-            op->getLoc(), op->getResult(i).getType(), newResult);
-      }
-      op->getResult(i).replaceAllUsesWith(newResult);
-    }
-    op->erase();
-  }
-
   void runOnOperation() override {
     // Run axis info analysis
     ModuleOp moduleOp = getOperation();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1108,6 +1108,54 @@ getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
   return attr;
 }
 
+static Type getNewType(Type type, Attribute encoding) {
+  RankedTensorType tensorType = cast<RankedTensorType>(type);
+  return RankedTensorType::get(tensorType.getShape(),
+                               tensorType.getElementType(), encoding);
+}
+
+void convertOpEncoding(Attribute encoding, Operation *op) {
+  OpBuilder builder(op);
+  // Convert operands
+  // For load/store with tensor pointers, we don't have to change the
+  // operands' type, we do this by changing the outputs' type of
+  // `make_tensor_ptr`
+  SmallVector<Value, 4> newArgs;
+  for (auto operand : op->getOperands()) {
+    auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
+    if (tensorType && !isa<triton::gpu::SwizzledSharedEncodingAttr>(
+                          tensorType.getEncoding())) {
+      Type newType = getNewType(tensorType, encoding);
+      newArgs.push_back(builder.create<triton::gpu::ConvertLayoutOp>(
+          op->getLoc(), newType, operand));
+    } else {
+      newArgs.push_back(operand);
+    }
+  }
+
+  // Convert output types
+  SmallVector<Type, 4> newTypes;
+  for (auto t : op->getResultTypes()) {
+    bool isAsync = isa<triton::gpu::AsyncCopyGlobalToLocalOp>(op);
+    newTypes.push_back(isAsync ? t : getNewType(t, encoding));
+  }
+
+  // Construct new op with the new encoding
+  Operation *newOp = builder.create(op->getLoc(), op->getName().getIdentifier(),
+                                    newArgs, newTypes, op->getAttrs());
+
+  // Cast the results back to the original layout
+  for (size_t i = 0; i < op->getNumResults(); i++) {
+    Value newResult = newOp->getResult(i);
+    if (newTypes[i] != op->getResultTypes()[i]) {
+      newResult = builder.create<triton::gpu::ConvertLayoutOp>(
+          op->getLoc(), op->getResult(i).getType(), newResult);
+    }
+    op->getResult(i).replaceAllUsesWith(newResult);
+  }
+  op->erase();
+}
+
 namespace {
 
 /// Detect dead arguments in scf.for op by assuming all the values are dead and

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -901,12 +901,12 @@ LogicalResult convertScaledMFMA(triton::DotScaledOp op,
   assert(((aScale && bScale) || (!aScale && !bScale)) &&
          "Single scale is not supported");
 
-  if (aScale && bScale) {
-    assert(
-        isa<LinearEncodingAttr>(aScale.getType().getEncoding()) &&
-        isa<LinearEncodingAttr>(bScale.getType().getEncoding()) &&
-        "If scales exist, both LhsScale and RhsScale should be linear layout.");
-  }
+  // if (aScale && bScale) {
+  //   assert(
+  //       isa<LinearEncodingAttr>(aScale.getType().getEncoding()) &&
+  //       isa<LinearEncodingAttr>(bScale.getType().getEncoding()) &&
+  //       "If scales exist, both LhsScale and RhsScale should be linear layout.");
+  // }
 
   auto cTensorTy = op.getC().getType();
   auto dTensorTy = op.getD().getType();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -8,7 +8,9 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/TypeSwitch.h"
 #include <memory>
 
@@ -71,8 +73,9 @@ SmallVector<unsigned, 3> warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape,
   ///     but cannot bypass LDS since both A and B tensor are shared
   ///     among waves.
   /// For now, we will let the shape to decide warpsPerCTA
-  // if (preshuffleScales)
-  //   return {1, static_cast<unsigned>(numWarps)};
+  bool bypassLDS = tools::getBoolEnv("TRITON_HIP_BYPASS_LDS_FOR_SCALES");
+  if (preshuffleScales && bypassLDS)
+    return {1, static_cast<unsigned>(numWarps)};
 
   // Case 1: Early exit for batched matmul
   if (rank == 3)
@@ -767,6 +770,22 @@ public:
   }
 };
 
+SmallVector<triton::LoadOp> getAllLoadOpsReachingOp(Operation *op) {
+  SmallVector<triton::LoadOp> loadOpsVec;
+  SetVector<Operation *> backwardSlice;
+  BackwardSliceOptions opt;
+  opt.omitBlockArguments = true;
+  getBackwardSlice(op, &backwardSlice, opt);
+
+  for (auto op : backwardSlice) {
+    if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
+      loadOpsVec.push_back(loadOp);
+    }
+  }
+
+  return loadOpsVec;
+}
+
 class ScaledBlockedToScaledMFMAF8F6F4 final
     : public OpRewritePattern<triton::DotScaledOp> {
   int mfmaVersion;
@@ -849,6 +868,41 @@ public:
     if (preshuffleScales) {
       tilesPerWarp[0] = oldShape[0] >= 32 ? 2 : 1;
       tilesPerWarp[1] = oldShape[1] >= 32 ? 2 : 1;
+    }
+
+    bool bypassLDS = tools::getBoolEnv("TRITON_HIP_BYPASS_LDS_FOR_SCALES");
+    // Change blocked layout of scaleB load to enable bypassing LDS
+    // optimization.
+    if (bypassLDS && preshuffleScales) {
+      // 1) Find the single load op that reaches dotOp.getBScale()
+      auto scaleBOp = dotOp.getBScale().getDefiningOp();
+      auto loadInsts = getAllLoadOpsReachingOp(scaleBOp);
+      assert(loadInsts.size() == 1 &&
+             "Expected exactly one load reaching scaleBOp");
+
+      auto scaleBLoad = loadInsts.front();
+      auto loadType =
+          dyn_cast<RankedTensorType>(scaleBLoad.getResult().getType());
+      auto loadShape = loadType.getShape();
+      assert(loadShape.size() == 2 && "Expected a 2D tensor here");
+
+      // 2) Compute new threadsPerWarp parameter
+      SmallVector<unsigned, 2> threadsPerWarpNew(2);
+      constexpr int numThreads = 64;
+      constexpr int sizePerThreadPreshuffle = 4;
+      threadsPerWarpNew[1] = std::min(
+          static_cast<int>(loadShape[1] / sizePerThreadPreshuffle), numThreads);
+      threadsPerWarpNew[0] = numThreads / threadsPerWarpNew[1];
+
+      // 3) Build a new BlockedEncodingAttr
+      auto blockedEnc =
+          dyn_cast<ttg::BlockedEncodingAttr>(loadType.getEncoding());
+      auto newBlockedEnc = ttg::BlockedEncodingAttr::get(
+          ctx, {1, 4}, threadsPerWarpNew, blockedEnc.getWarpsPerCTA(),
+          blockedEnc.getOrder(), blockedEnc.getCTALayout());
+
+      // 4) Apply the new encoding to the load
+      convertOpEncoding(newBlockedEnc, scaleBLoad);
     }
 
     // Always use transposed mfma layout. This enables larger vectorization

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -672,11 +672,10 @@ void StreamPipeliner::assignMemoryLayouts() {
     if (isa<tt::DotOpInterface>(use)) {
       // Only use shared memory when feeding into a dot op.
       loadInfo.usedByDot = true;
-      // If the max continugous bits we can read is < 32, buffer in registers.
-      bool bypassLDS = width < 32;
       // Skip LDS for the scale B tensor when warpsPerCTA is {1, numWarps} and
       // the load layout matches the expected layout for scale B in the
       // dotScaled op.
+      bool bypassLDS = false;
       if (auto scaledDot = dyn_cast<tt::DotScaledOp>(use)) {
         auto scaleB = scaledDot.getBScale();
         SetVector<Operation *> slices;
@@ -701,12 +700,12 @@ void StreamPipeliner::assignMemoryLayouts() {
           mlir::triton::LinearLayout scaleBLayout =
               mlir::triton::gpu::toLinearLayout(scaleBTy.getShape(),
                                                 scaleBTy.getEncoding());
-          bypassLDS = bypassLDS ||
-                      (warpsPerCTA[0] == 1 && reshapedLayout == scaleBLayout);
+          bypassLDS = warpsPerCTA[0] == 1 && reshapedLayout == scaleBLayout;
         }
       }
 
-      if (!bypassLDS) {
+      // If the max continugous bits we can read is < 32, buffer in registers.
+      if (width >= 32 && !bypassLDS) {
         loadInfo.sharedEncoding =
             getSharedEncIfAllUsersAreDotEnc(op->getResult(0)).value_or(nullptr);
       }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -14,6 +14,7 @@
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
+#include "triton/Tools/LayoutUtils.h"
 
 //===----------------------------------------------------------------------===//
 // This file will create a schedule that will be handed over to the pipeline
@@ -672,7 +673,40 @@ void StreamPipeliner::assignMemoryLayouts() {
       // Only use shared memory when feeding into a dot op.
       loadInfo.usedByDot = true;
       // If the max continugous bits we can read is < 32, buffer in registers.
-      if (width >= 32) {
+      bool bypassLDS = width < 32;
+      // Skip LDS for the scale B tensor when warpsPerCTA is {1, numWarps} and
+      // the load layout matches the expected layout for scale B in the
+      // dotScaled op.
+      if (auto scaledDot = dyn_cast<tt::DotScaledOp>(use)) {
+        auto scaleB = scaledDot.getBScale();
+        SetVector<Operation *> slices;
+        mlir::getForwardSlice(op, &slices);
+        if (llvm::find_if(slices, [&](Operation *depOp) {
+              return scaleB.getDefiningOp() == depOp;
+            }) != slices.end()) {
+
+          auto scaleBTy = dyn_cast<RankedTensorType>(scaleB.getType());
+          auto dotTy = dyn_cast<RankedTensorType>(scaledDot.getType());
+          auto mfmaEnc = cast<ttg::AMDMfmaEncodingAttr>(dotTy.getEncoding());
+          auto warpsPerCTA = mfmaEnc.getWarpsPerCTA();
+
+          auto loadOpTy = dyn_cast<RankedTensorType>(loadOp.getType());
+
+          mlir::triton::LinearLayout loadOpLayout =
+              mlir::triton::gpu::toLinearLayout(loadOpTy.getShape(),
+                                                loadOpTy.getEncoding());
+          auto reshapedLayout = reshapeLayout(loadOp.getContext(), loadOpLayout,
+                                              scaleBTy.getShape());
+
+          mlir::triton::LinearLayout scaleBLayout =
+              mlir::triton::gpu::toLinearLayout(scaleBTy.getShape(),
+                                                scaleBTy.getEncoding());
+          bypassLDS = bypassLDS ||
+                      (warpsPerCTA[0] == 1 && reshapedLayout == scaleBLayout);
+        }
+      }
+
+      if (!bypassLDS) {
         loadInfo.sharedEncoding =
             getSharedEncIfAllUsersAreDotEnc(op->getResult(0)).value_or(nullptr);
       }


### PR DESCRIPTION
Skip LDS for the scale B tensor when warpsPerCTA is {1, numWarps} and 
the load layout matches the expected layout for scale B in the  dotScaled op.
