### PR TITLE
[release/internal/3.0.x] Upgrade pybind11 version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1, "pybind11>=2.13.1"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1, "pybind11>=2.13.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "pybind11>=2.13.1"]
 
 [tool.yapf]
 based_on_style = "pep8"


### PR DESCRIPTION
Upgrade pybind11 version (although the change that really helped with pybind11 version is https://github.com/ROCm/triton/commit/458819268bd8f4e9e78a2e1319288924d8a3beea)
Relates to https://github.com/ROCm/pytorch/pull/2267