### PR TITLE
Improve shared layout for Wmma's operands

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -311,24 +311,33 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
 
         // ---- begin WMMA ----
         if (mlir::isa<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
-          if (dotOpEnc.getOpIdx() == 0) {
-            const int numBanks = 32;
-            const int bankBitWidth = 32;
+          int kDimIndex = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
+          bool isKContig = order[0] == kDimIndex;
 
-            // number of inner dimension rows per one pattern repeat
-            int innerDimLength = shape[order[0]];
-            int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeWidthInBit;
-
-            int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
-            int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
-            int maxPhase = 16 / perPhase;
-
-            return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
-          } else {
-            // Do not swizzle in case k dimension is not innermost.
-            // In this case accesses will go in different banks even without swizzling.
+          if (!isKContig) {
+            // Do not swizzle. In this case accesses will go in different banks even
+            // without swizzling.
             return get(context, 1, 1, 1, order, CTALayout);
           }
+
+          // kWidth: the number of elements each thread loads from shared memory in
+          // preparation for wmma instructions.
+          auto kWidth = dotOpEnc.getKWidth();
+          // max vectorization size for ds_load is 128 bits
+          int vectorSize = std::min(kWidth * typeWidthInBit, 128u) / typeWidthInBit;
+
+          const int numBanks = 32;
+          const int bankBitWidth = 32;
+          const int simdWidth = 16;
+
+          // Number of inner dimension rows per one pattern repeat
+          int innerDimLength = shape[order[0]];
+          int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeWidthInBit;
+
+          int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
+          int maxPhase = std::max(std::min(simdWidth / perPhase, innerDimLength / vectorSize), 1);
+
+          return get(context, vectorSize, perPhase, maxPhase, order, CTALayout);
         }
 
 


### PR DESCRIPTION
1. Enable swizzling for Wmma's B operand
2. Refine the formula for vectorSize/perPhase/maxPhase

