### PR TITLE
[release/3.2] [cherry-pick] [AMD] Add missing stdbool.h include (#7383)

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Cherry-pick of https://github.com/triton-lang/triton/pull/7383

driver.c uses bools but does not include the relevant header.
This patch adds stdbool.h as an include, this resolves compilation issues with some rocm versions.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It fixes a compilation bug`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
