### PR TITLE
Adding additional scheduling infrastructure and heuristics.

### DIFF
--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -10,6 +10,9 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
+#undef LLVM_DEBUG
+#define LLVM_DEBUG(X) X
+
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-refine-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -105,11 +108,11 @@ SmallVector<unsigned, 3> getMfmasPerRep(const ArrayRef<int64_t> &ctaTile,
       static_cast<unsigned>(repTile[2] / mfmaShape[2])};
   LDBG("mfmasPerRep: " << mfmasPerRep[0] << "x" << mfmasPerRep[1] << "x"
                        << mfmasPerRep[2]);
-  if (mfmasPerRep[0] < 1 || mfmasPerRep[1] < 1 || mfmasPerRep[2] < 1) {
-    llvm::errs() << "DotTiling::getMfmasPerRep() - Invalid combination of "
-                    "ctaTile, warpsPerCta and mfmaShape.\n";
-    return SmallVector<unsigned, 3>({1, 1, 1});
-  }
+  // It is valid for a cta or warp tile to be so small that it doesn't
+  // fully utilize an mfma op. Therefore we round up numReps.
+  mfmasPerRep[0] = std::max(1U, mfmasPerRep[0]);
+  mfmasPerRep[1] = std::max(1U, mfmasPerRep[1]);
+  mfmasPerRep[2] = std::max(1U, mfmasPerRep[2]);
   return mfmasPerRep;
 }
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -10,9 +10,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
-// #undef LLVM_DEBUG
-// #define LLVM_DEBUG(X) X
-
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-dot-tiling"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -34,18 +31,14 @@ SmallVector<uint32_t> getWarpShapeForDotOp(DotOp dotOp) {
   auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
   MLIRContext *ctx = dotOp->getContext();
   Value a = dotOp.getA();
-  // Value b = dotOp.getB();
   Value d = dotOp.getD();
   auto aTensorTy = cast<RankedTensorType>(a.getType());
   auto encodeA = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
-  // auto bTensorTy = cast<RankedTensorType>(b.getType());
   auto dTensorTy = cast<RankedTensorType>(d.getType());
   auto elemTyA = aTensorTy.getElementType();
-  // auto elemTyB = bTensorTy.getElementType();
   auto mDim = mfmaLayout.getMDim();
   auto nDim = mfmaLayout.getNDim();
   auto shapeA = aTensorTy.getShape();
-  // auto shapeB = bTensorTy.getShape();
   auto shapeD = dTensorTy.getShape();
   SmallVector<uint32_t> ctaTile = {static_cast<uint32_t>(shapeD[0]),
                                    static_cast<uint32_t>(shapeD[1]),
@@ -57,7 +50,6 @@ SmallVector<uint32_t> getWarpShapeForDotOp(DotOp dotOp) {
 
 // Get Shape of assembly instructions, e.g. mfma/wmma 16x16x32.
 SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
-  // Get mfma op type.
   auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
       cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
   MLIRContext *ctx = dotOp->getContext();
@@ -70,7 +62,6 @@ SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
   auto mDim = mfmaLayout.getMDim();
   auto nDim = mfmaLayout.getNDim();
   const auto kDimOperandSize = aTensorTy.getShape().back();
-  // auto kDim = mfmaLayout.getKDim();
   auto mfmaVersion = mfmaLayout.getVersion();
   bool allowXF32 =
       dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -72,17 +72,15 @@ SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
                                /*withScale=*/false, allowXF32);
   if (failed(maybeMfmaInsn))
     llvm::report_fatal_error("No match found in MFMA database\n");
-  return SmallVector<uint32_t, 3>(
-      {maybeMfmaInsn->mDim, maybeMfmaInsn->nDim, maybeMfmaInsn->kDim});
+  return {maybeMfmaInsn->mDim, maybeMfmaInsn->nDim, maybeMfmaInsn->kDim};
 }
 
 // Get number of assembly instructions [per wave] for dot op.
 SmallVector<uint32_t> getAsmNumRepsForDotOp(DotOp dotOp) {
   auto dotShape = getWarpShapeForDotOp(dotOp);
   auto mfmaShape = getAsmShapeForDotOp(dotOp);
-  return SmallVector<uint32_t>({dotShape[0] / mfmaShape[0],
-                                dotShape[1] / mfmaShape[1],
-                                dotShape[2] / mfmaShape[2]});
+  return {dotShape[0] / mfmaShape[0], dotShape[1] / mfmaShape[1],
+          dotShape[2] / mfmaShape[2]};
 }
 
 unsigned getCyclesPerMfma(DotOp dotOp) {

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -14,7 +14,7 @@
 // #define LLVM_DEBUG(X) X
 
 #undef DEBUG_TYPE
-#define DEBUG_TYPE "tritonamdgpu-refine-ops"
+#define DEBUG_TYPE "tritonamdgpu-dot-tiling"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
@@ -26,6 +26,74 @@ namespace {
 /*
  TODO - this needs to be MUCH more official.
 */
+
+// Return warp shape of dot op, e.g. 16x16x128 if kPack>1
+SmallVector<uint32_t> getWarpShapeForDotOp(DotOp dotOp) {
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
+  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+  MLIRContext *ctx = dotOp->getContext();
+  Value a = dotOp.getA();
+  // Value b = dotOp.getB();
+  Value d = dotOp.getD();
+  auto aTensorTy = cast<RankedTensorType>(a.getType());
+  auto encodeA = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
+  // auto bTensorTy = cast<RankedTensorType>(b.getType());
+  auto dTensorTy = cast<RankedTensorType>(d.getType());
+  auto elemTyA = aTensorTy.getElementType();
+  // auto elemTyB = bTensorTy.getElementType();
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  auto shapeA = aTensorTy.getShape();
+  // auto shapeB = bTensorTy.getShape();
+  auto shapeD = dTensorTy.getShape();
+  SmallVector<uint32_t> ctaTile = {static_cast<uint32_t>(shapeD[0]),
+                                   static_cast<uint32_t>(shapeD[1]),
+                                   static_cast<uint32_t>(shapeA[1])};
+  SmallVector<uint32_t> warpTile = {ctaTile[0] / warpsPerCTA[0],
+                                    ctaTile[1] / warpsPerCTA[1], ctaTile[2]};
+  return warpTile;
+}
+
+// Get Shape of assembly instructions, e.g. mfma/wmma 16x16x32.
+SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
+  // Get mfma op type.
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
+  MLIRContext *ctx = dotOp->getContext();
+  Value a = dotOp.getA();
+  Value b = dotOp.getB();
+  auto aTensorTy = cast<RankedTensorType>(a.getType());
+  auto bTensorTy = cast<RankedTensorType>(b.getType());
+  auto elemTyA = aTensorTy.getElementType();
+  auto elemTyB = bTensorTy.getElementType();
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  const auto kDimOperandSize = aTensorTy.getShape().back();
+  // auto kDim = mfmaLayout.getKDim();
+  auto mfmaVersion = mfmaLayout.getVersion();
+  bool allowXF32 =
+      dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
+
+  FailureOr<MfmaIntrinsic> maybeMfmaInsn =
+      MfmaIntrinsic::selectFor(dotOp->getLoc(), mfmaVersion, mDim, nDim,
+                               kDimOperandSize, elemTyA, elemTyB,
+                               /*withScale=*/false, allowXF32);
+  if (failed(maybeMfmaInsn))
+    llvm::report_fatal_error("No match found in MFMA database\n");
+  return SmallVector<uint32_t, 3>(
+      {maybeMfmaInsn->mDim, maybeMfmaInsn->nDim, maybeMfmaInsn->kDim});
+}
+
+// Get number of assembly instructions [per wave] for dot op.
+SmallVector<uint32_t> getAsmNumRepsForDotOp(DotOp dotOp) {
+  auto dotShape = getWarpShapeForDotOp(dotOp);
+  auto mfmaShape = getAsmShapeForDotOp(dotOp);
+  return SmallVector<uint32_t>({dotShape[0] / mfmaShape[0],
+                                dotShape[1] / mfmaShape[1],
+                                dotShape[2] / mfmaShape[2]});
+}
+
 unsigned getCyclesPerMfma(DotOp dotOp) {
   // Get mfma op type.
   auto mfmaLayout = cast<AMDMfmaEncodingAttr>(

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -10,8 +10,8 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
-#undef LLVM_DEBUG
-#define LLVM_DEBUG(X) X
+// #undef LLVM_DEBUG
+// #define LLVM_DEBUG(X) X
 
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-refine-ops"

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -105,10 +105,12 @@ StringRef toString(MachineModelResourcePipe pipe) {
 */
 struct MachineModelOpProperties {
 
-  MachineModelOpProperties(MachineModelResourcePipe pipe, int32_t sequencerBusy,
-                           StringRef inputName, int32_t pipeBusyAfterSequencer = 0)
-      : resourcePipe(pipe), cyclesSequencerBusy(sequencerBusy),
-        cyclesPipeBusyAfterSequencer(pipeBusyAfterSequencer), name(inputName) {}
+  MachineModelOpProperties(MachineModelResourcePipe resourcePipe,
+                           int32_t cyclesSequencerBusy, StringRef name,
+                           int32_t cyclesPipeBusyAfterSequencer = 0)
+      : resourcePipe(resourcePipe), cyclesSequencerBusy(cyclesSequencerBusy),
+        cyclesPipeBusyAfterSequencer(cyclesPipeBusyAfterSequencer), name(name) {
+  }
 
   // To which resource pipe does this op map.
   MachineModelResourcePipe resourcePipe;
@@ -336,9 +338,11 @@ struct MachineState {
   // Queries pipeReadyCycle.
   int32_t getCyclesUntilPipeReadyForOp(MachineModelOpProperties properties) {
     if (topDown)
-      return std::max(0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()));
-    return std::max(0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()) +
-          properties.cyclesPipeBusyAfterSequencer);
+      return std::max(
+          0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()));
+    return std::max(
+        0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()) +
+               properties.cyclesPipeBusyAfterSequencer);
   }
 
   // Calculates when data will be ready; examples provided above.
@@ -397,15 +401,15 @@ struct MachineState {
     assert(target && other);
     int32_t readyCycle = getCurrentCycle();
     if (topDown) {
-      auto op = target;
-      MachineModelOpProperties properties = machineModel->getOpProperties(op);
+      MachineModelOpProperties properties =
+          machineModel->getOpProperties(target);
       // When scheduling top-down, assume that other has already been scheduled;
       // therefore time was already stepped forward by seqBusy.
       // readyCycle += properties.cyclesSequencerBusy;
       readyCycle += calcCyclesUntilDataReady(other);
     } else {
-      auto op = other;
-      MachineModelOpProperties properties = machineModel->getOpProperties(op);
+      MachineModelOpProperties properties =
+          machineModel->getOpProperties(other);
       // When scheduling bottom-up, the data latency doesn't apply until after
       // the op's seqBusy, so add that to data ready time.
       readyCycle += properties.cyclesSequencerBusy;
@@ -439,7 +443,8 @@ struct MachineState {
   MachineModel *machineModel;
   // Tracks pipe readiness differently for TopDown vs BottomUp.
   // BottomUp: tracks the cycle during which pipe was last used.
-  // TopDown: tracks the cycle last used + prev op's cyclesPipeBusyAfterSequencer.
+  // TopDown: tracks the cycle last used + prev op's
+  // cyclesPipeBusyAfterSequencer.
   SmallVector<int32_t, numResourcePipes> pipeReadyCycle;
   DenseMap<Operation *, int32_t> opDataReadyCycle;
   bool topDown;

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -1,0 +1,462 @@
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+// #undef LLVM_DEBUG
+// #define LLVM_DEBUG(X) X
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-scheduler-machine-model"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+/*******************************************************************************
+  Relatively simple machine model which enabled the scheduler passes to create a
+  "not bad" op schedule optimized for both performance and resource allocation.
+  To achieve this, the scheduler needs to know things like how many independent
+  DotOps should there be between a LocalLoadOp and it's dependent DotOp. It is
+  assumed that DotOps are the most important, that memory ops whcih feed them
+  are in a close second, and all other ops are tertiary in importance. Therefore
+  it essentially only model ops as being dot, load/stores, nop, and other.
+
+  To achieve this there is
+  (1) MachineModel which stores basic properties of the most important ops,
+  such as how many cycles does it take to execute, and which can co-execute.
+  (2) MachineState tracker which stores, during scheduling, the hypothetical
+  state of the machine to know which ops are best scheduled next.
+  For example, when a dot is scheduled BottomUp, store at what time can the
+  dependent LocalLoadOp be scheduled.
+
+  However, to give even an approximate interleaving of memory op with dot
+  and other ops, we need some minimal information regarding the hardware
+  execution of the ops.
+  Information needed to schedule ops:
+  - LDS read data latency.
+  - LDS write data latency.
+  - Buffer load data latency.
+  - Buffer load data latency.
+  - Cycles to execute an mfma, and how many of those cycles can
+    another non-mfma op co-execute?
+ ******************************************************************************/
+
+namespace {
+
+/*
+  Resource piplines track when ops can be co-executed,
+  meaning an mfma and Lds op can work at the same time
+  since they map to different resources.
+*/
+enum MachineModelResourcePipe : uint32_t {
+  // None is used for nops like concat and extract_slice.
+  None = 0,
+  Mfma = 1,
+  Lds = 2,
+  Global = 3,
+  // Other is used for everything else; most are probably valu
+  // but we don't want to distinguish further to keep the model simple.
+  Other = 4,
+};
+constexpr uint32_t numResourcePipes = 5;
+
+StringRef toString(MachineModelResourcePipe pipe) {
+  switch (pipe) {
+  case None:
+    return "0";
+  case Mfma:
+    return "M";
+  case Lds:
+    return "L";
+  case Global:
+    return "G";
+  case Other:
+    return "O";
+  }
+};
+
+/*
+  MachineModel Op Properties
+  Basic properties of the hardware instruction which the ttg ops
+  best map to.
+  For example, mfma_16x16x16 on MI300X
+  - Takes 8 cycles to issue.
+  - Also keeps the mfma pipe busy for an additional 8 cycles
+  Therefore 4 back-to-back mfmas will take 4*16=64 cycles since
+  they're each taking up 16 cycles of the mfma pipe.
+  And 1 mfma, 1 lds op, 1 mfma, 1 other op only takes 4*16=32 cycles
+  since the mfmas took 16 cycles but the other ops mapped to different
+  hardware pipes and could be co-executed for free.
+
+  This complexity of modeling co-execution of ops is necessary
+  for determining, e.g., at the top of a loop, how many LoadOps
+  can be grouped with how many DotOps, since the LoadOps need
+  to increment their addresses and then can co-execute with
+  the DotOps.
+*/
+struct MachineModelOpProperties {
+
+  MachineModelOpProperties(MachineModelResourcePipe pipe, int32_t seqBusy,
+                           StringRef n, int32_t pipeBusyAfterSeq = 0)
+      : resourcePipe(pipe), cyclesSeqBusy(seqBusy),
+        cyclesPipeBusyAfterSeq(pipeBusyAfterSeq), name(n) {}
+
+  // To which resource pipe does this op map.
+  MachineModelResourcePipe resourcePipe;
+
+  // Op blocks all other ops from issuing.
+  int32_t cyclesSeqBusy;
+
+  /*
+    How long to wait before issuing another op to same
+    resource pipe even after sequencer issues.
+    E.g. mfma "takes" 16 cycles, but this is broken into 4 cycles that the
+    sequencer is busy issuing the mfma, and 12 more cycles that the
+    mfma pipe is still busy but other pipes can be used.
+  */
+  int32_t cyclesPipeBusyAfterSeq;
+
+  // To be used for debugging, e.g. saying that op was
+  // assumed to map to 16 v_pk_add_fp32 instructions.
+  StringRef name;
+};
+
+/*
+  Abstract base class for querying op properties based on GPU generation.
+  Each new generation of hardware inherits from the previous,
+  therefore each new geneation only needs to override ops with new properties.
+  Most ops we don't yet care about, so most ops will fall back to whatever
+  the most common instruction is, e.g., 4 cycles of valu.
+*/
+struct MachineModel {
+
+  virtual MachineModelOpProperties getOpProperties(Operation *op) = 0;
+
+  /*
+    Models how many cycles does it take between issuing a memory
+    op and when the data is ready.
+    This is currently modeled based on pipe and not on op since
+    it is assumed, e.g., that ds_read_b32 has same latency
+    as ds_read_b64.
+    It is also assumed that read and writes to a pipe are the same.
+  */
+  virtual int32_t getDataLatency(MachineModelResourcePipe pipe) {
+    switch (pipe) {
+    case Lds:
+      return 80;
+    case Global:
+      // 1M cycles is dummy value to push buffer loads as early as possible.
+      return 1000000;
+    default:
+      return 0;
+    }
+  };
+
+  virtual ~MachineModel() = default;
+};
+
+// MI250
+struct MachineModelGFX90A : MachineModel {
+  MachineModelOpProperties getOpProperties(Operation *op) {
+    if (llvm::isa<triton::gpu::MemDescSubviewOp, triton::gpu::MemDescTransOp,
+                  tt::amdgpu::ExtractSliceOp, ROCDL::SchedBarrier,
+                  tt::amdgpu::ConcatOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::None, 0, "nop");
+    }
+    // Fallback is 4 cycles.
+    return MachineModelOpProperties(MachineModelResourcePipe::Other, 4, "valu");
+  }
+};
+
+// MI300
+// TODO(dtanner) these all need to reflect how many asm instructions
+// are in the op and how large the tensors are (_b64 vs _b128)
+struct MachineModelGFX942 : MachineModelGFX90A {
+
+  MachineModelOpProperties getOpProperties(Operation *op) {
+    // When specifying that memory ops should be spaced "2 mfmas apart"
+    // Since the second is co-scheduled with a mfma, don't include the pipe busy
+    // time for the 2nd.
+    int32_t mfmaCycles1 = 1 * 16 - 12;
+    int32_t mfmaCycles2 = 2 * 16 - 12;
+    int32_t mfmaCycles3 = 3 * 16 - 12;
+    int32_t mfmaCycles4 = 4 * 16 - 12;
+
+    // Mfma
+    if (isa<triton::DotOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::Mfma, 4,
+                                      "mfma_16x16x16", 12);
+
+      // LDS Ops
+    } else if (isa<triton::gpu::LocalLoadOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::Lds, 4,
+                                      "ds_read_b128", mfmaCycles1);
+    } else if (isa<triton::gpu::LocalStoreOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::Lds, 40,
+                                      "ds_write_b128", mfmaCycles2);
+    } else if (isa<mlir::gpu::BarrierOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::Lds, 8,
+                                      "s_barrier");
+
+      // Global Memory Ops
+    } else if (isa<triton::LoadOp, triton::amdgpu::BufferLoadOp>(op)) {
+      return MachineModelOpProperties(MachineModelResourcePipe::Global, 4,
+                                      "buffer_load", mfmaCycles2);
+    }
+
+    // Fallback to MI250.
+    return MachineModelGFX90A::getOpProperties(op);
+  }
+};
+
+/*
+  MachineState tracks what has and will happen on the GPU as a result of the
+  scheduling process.
+
+  The primary functions called by the scheduler are
+  - scheduleOp(op) which updates the machine state based on the op being
+  scheduled.
+  - getCyclesUntilOpReady(op) which return how soon the machine will be ready
+      to schedule the op (without wasting cycles).
+  - updateOpDataReady(op, op) which allows the scheduler to tell the machine
+  that there is a non def/use dependency (e.g. bar) which requires one op to
+  wait for the other.
+
+  The machine state consists of pipeReadyCycle[pipe] and opDataReadyCycle[op]
+  which track when these resources will be ready. pipeReadyCycle[pipe] tracks
+  how long ago the last op was scheduled to the pipe and therefore when will the
+  pipe be ready for the next op. E.g. after scheduling an mfma, the mfma pipe
+  will busy for several cycles but other pipes (lds or valu) are free to
+  execute. opDataReadyCycle[op] stores when data will be ready for memory ops,
+  e.g. after a LocalLoadOp it's children won't have their data until X cycles
+  later.
+
+  Because actual machine execution is always TopDown, but scheduling can be
+  either direction, the above state has slightly different meanings based on
+  direction.
+
+  (1) TopDown Pipe Example:
+  pipeReadyCycle[pipe] tracks at which cycle the pipe will be ready,
+    which is the cycle it was last used + prev op's pipeBusyAfterSeq.
+  E.g. currentCycle=16 scheduleOp(mfma)
+    - currentCycle advances to 20 b/c mfma seqBusy=4.
+    - pipeReadyCycle[mfma] set to 32 b/c mfma's pipeBusyAfterSeq=16.
+      Later, getCyclesUntilPipeReadyForOp() will know that the pipe
+      is ready at t=32.
+
+  (2) BottomUp Pipe Example:
+  pipeReadyCycle[pipe] tracks which cycle the pipe was last used;
+    we can't add the pipeBusyAfterSeq for the op which comes above it
+    since we haven't determined it yet for BottomUp.
+  E.g. currentCycle=16 scheduleOp(mfma)
+    - currentCycle advances to 20 b/c mfma seqBusy=4.
+    - pipeReadyCycle[mfma] set to 20 b/c only stores last used.
+  Later, getCyclesUntilPipeReadyForOp() will know that the pipe was last
+  used at t=20, then it will determine if the next op scheduled will be
+  done with the pipe by t=20 based on it's pipeBusyAfterSeq.
+
+  (3) TopDown Data Example:
+    opDataReadyCycle tracks at which future cycle the data for an op will be
+    ready. E.g. currentCycle=16 scheduleOp(load) will record op->children need
+    to wait until t=16+updateOpDataReady(load).
+
+  (4) BottomUp Data Example:
+    Same as TopDown, except that insteady of recording when children will be
+    ready, it records when parents (the load ops) will be ready to be issued.
+*/
+struct MachineState {
+  MachineState(MachineModel *model, bool topDown)
+      : currentCycle(0), machineModel(model), topDown(topDown) {
+    for (int32_t i = 0; i < numResourcePipes; ++i) {
+      pipeReadyCycle.push_back(0);
+    }
+    reset();
+  }
+
+  // Assume we need to wait for ds_writes, ds_reads and buffer_loads at the top
+  // of the loop.
+  void reset() {
+    currentCycle = 0;
+    for (int32_t i = 0; i < numResourcePipes; ++i) {
+      pipeReadyCycle[i] = 0;
+    }
+    opDataReadyCycle.clear();
+  }
+
+  /*
+    When op is scheduled,
+    - Calculate how many cycles elapsed, update currentCycle.
+    - Update when the used pipe will be ready.
+    - Update when the op's parents/children will be ready
+      based on data latencies.
+  */
+  void scheduleOp(Operation *op) {
+    // record time before stepping forward
+    MachineModelOpProperties properties = machineModel->getOpProperties(op);
+    int32_t elapsedCycles = scheduleOpCalcElapsedCycles(op);
+    currentCycle += elapsedCycles;
+    scheduleOpUpdatePipesReady(properties);
+    scheduleOpUpdateDepsReady(op);
+  }
+
+  // Calculates how many cycles forward time is advanced as a result of
+  // scheduling op. Elapsed time will be cycles until data and pipe are ready +
+  // cyclesSeqBusy.
+  int32_t scheduleOpCalcElapsedCycles(Operation *op) {
+    MachineModelOpProperties properties = machineModel->getOpProperties(op);
+    MachineModelResourcePipe pipe = properties.resourcePipe;
+    // If resource pipe or data weren't ready, need to first wait for them
+    // before issuing op.
+    int32_t elapsedCycles =
+        getCyclesUntilOpReady(op) + properties.cyclesSeqBusy;
+    return elapsedCycles;
+  }
+
+  // Returns cycles until op will be ready to issue;
+  // called from scheduler and used for elapsed cycles.
+  // Queries both pipeReadyCycle and opDataReadyCycle.
+  int32_t getCyclesUntilOpReady(Operation *op) {
+    MachineModelOpProperties properties = machineModel->getOpProperties(op);
+    int32_t cycles = std::max(getCyclesUntilDataReady(op),
+                              getCyclesUntilPipeReadyForOp(properties));
+    // LDBG("getCyclesUntilOpReady=" << cycles);
+    return cycles;
+  }
+
+  // Calculates when pipe will be ready; examples provided above.
+  // Queries pipeReadyCycle.
+  int32_t getCyclesUntilPipeReadyForOp(MachineModelOpProperties properties) {
+    int32_t readyCycle;
+    if (topDown) {
+      readyCycle =
+          (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle());
+    } else {
+      readyCycle =
+          (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()) +
+          properties.cyclesPipeBusyAfterSeq;
+    }
+    readyCycle = std::max(0, readyCycle);
+    return readyCycle;
+  }
+
+  // Calculates when data will be ready; examples provided above.
+  // Queries opDataReadyCycle.
+  int32_t getCyclesUntilDataReady(Operation *op) {
+    auto find = opDataReadyCycle.find(op);
+    int32_t cycle = 0;
+    if (find != opDataReadyCycle.end()) {
+      cycle = std::max(0, find->getSecond() - getCurrentCycle());
+    }
+    return cycle;
+  }
+
+  // Update when pipes will be ready, based on op getting scheduled.
+  // Writes to pipeReadyCycle.
+  void scheduleOpUpdatePipesReady(MachineModelOpProperties properties) {
+    MachineModelResourcePipe pipe = properties.resourcePipe;
+    if (topDown) {
+      pipeReadyCycle[pipe] =
+          getCurrentCycle() + properties.cyclesPipeBusyAfterSeq;
+    } else {
+      pipeReadyCycle[pipe] = getCurrentCycle();
+    }
+  }
+
+  // Update when parents/children (based on direction) data will be ready.
+  // Writes to opDataReadyCycle.
+  void scheduleOpUpdateDepsReady(Operation *op) {
+    if (topDown) {
+      for (auto result : op->getResults()) {
+        for (auto child : result.getUsers()) {
+          updateOpDataReady(child, op);
+        }
+      }
+    } else {
+      for (auto operand : op->getOperands()) {
+        auto parent = operand.getDefiningOp();
+        if (parent) {
+          updateOpDataReady(parent, op);
+        }
+      }
+    }
+  }
+
+  /*
+    Updates when target will be ready based on it's
+    dependency with other and the data latency.
+    Call from above and from scheduler.
+    TopDown: target=child, other=parent.
+    BottomUp: target=parent, other=child.
+    Writes to opDataReadyCycle.
+  */
+  void updateOpDataReady(Operation *target, Operation *other) {
+    assert(target && other);
+    int32_t readyCycle = getCurrentCycle();
+    if (topDown) {
+      readyCycle += calcCyclesUntilDataReady(other);
+    } else {
+      readyCycle += calcCyclesUntilDataReady(target);
+    }
+    setDataReadyCycle(target, readyCycle);
+  }
+
+  int32_t getCurrentCycle() const { return currentCycle; }
+
+  // Calculates data latency cycles based on op's pipe.
+  int32_t calcCyclesUntilDataReady(Operation *op) {
+    MachineModelOpProperties properties = machineModel->getOpProperties(op);
+    MachineModelResourcePipe pipe = properties.resourcePipe;
+    int32_t cyclesUntilDataReady = machineModel->getDataLatency(pipe);
+    return cyclesUntilDataReady;
+  }
+
+  // Writes to opDataReadyCycle; keeps maximum since op will have to wait for
+  // all deps.
+  void setDataReadyCycle(Operation *op, int32_t c) {
+    auto find = opDataReadyCycle.find(op);
+    if (find != opDataReadyCycle.end()) {
+      opDataReadyCycle[op] = std::max(c, find->getSecond());
+    } else {
+      opDataReadyCycle[op] = c;
+    }
+  }
+
+  int32_t currentCycle;
+  MachineModel *machineModel;
+  // Tracks pipe readiness differently for TopDown vs BottomUp.
+  // BottomUp: tracks the cycle during which pipe was last used.
+  // TopDown: tracks the cycle last used + prev op's cyclesPipeBusyAfterSeq.
+  SmallVector<int32_t, numResourcePipes> pipeReadyCycle;
+  DenseMap<Operation *, int32_t> opDataReadyCycle;
+  bool topDown;
+};
+
+// Format: [@nodeId opName p={parent nodes} c={child nodes}]
+llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
+                              const MachineState &machine) {
+  out << "[t=" << machine.getCurrentCycle();
+  for (int32_t i = 1; i < numResourcePipes; ++i) {
+    out << ", " << toString(static_cast<MachineModelResourcePipe>(i));
+    out << "=" << machine.pipeReadyCycle[i];
+  }
+  out << "]";
+  if (false) {
+    for (auto entry : machine.opDataReadyCycle) {
+      out << "\t t=" << entry.getSecond() << " ready << "
+          << entry.getFirst()->getName() << "\n";
+    }
+  }
+  return out;
+}
+
+} // namespace

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h"
 #include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
 #include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -90,8 +91,8 @@ StringRef toString(MachineModelResourcePipe pipe) {
   Basic properties of the hardware instruction which the ttg ops
   best map to.
   For example, mfma_16x16x16 on MI300X
-  - Takes 8 cycles to issue.
-  - Also keeps the mfma pipe busy for an additional 8 cycles
+  - Takes 4 cycles to issue.
+  - Also keeps the mfma pipe busy for an additional 12 cycles
   Therefore 4 back-to-back mfmas will take 4*16=64 cycles since
   they're each taking up 16 cycles of the mfma pipe.
   And 1 mfma, 1 lds op, 1 mfma, 1 other op only takes 4*16=32 cycles
@@ -143,8 +144,8 @@ struct MachineModel {
   virtual MachineModelOpProperties getOpProperties(Operation *op) = 0;
 
   /*
-    Models how many cycles does it take between issuing a memory
-    op and when the data is ready.
+    Models how many cycles does it take between completing issuing
+    a memory op (seqBusy done) and when the data is ready.
     This is currently modeled based on pipe and not on op since
     it is assumed, e.g., that ds_read_b32 has same latency
     as ds_read_b64.
@@ -187,23 +188,32 @@ struct MachineModelGFX942 : MachineModelGFX90A {
     // When specifying that memory ops should be spaced "2 mfmas apart"
     // Since the second is co-scheduled with a mfma, don't include the pipe busy
     // time for the 2nd.
-    int32_t mfmaCycles1 = 1 * 16 - 12;
-    int32_t mfmaCycles2 = 2 * 16 - 12;
-    int32_t mfmaCycles3 = 3 * 16 - 12;
-    int32_t mfmaCycles4 = 4 * 16 - 12;
 
     // Mfma
-    if (isa<triton::DotOp>(op)) {
-      return MachineModelOpProperties(MachineModelResourcePipe::Mfma, 4,
-                                      "mfma_16x16x16", 12);
+    if (auto dotOp = dyn_cast<triton::DotOp>(op)) {
+      auto numRepsVec = getAsmNumRepsForDotOp(dotOp);
+      if (false) {
+        auto dotShape = getWarpShapeForDotOp(dotOp);
+        LDBG("dotWarpShape: " << dotShape[0] << "x" << dotShape[1] << "x"
+                              << dotShape[2]);
+        auto mfmaShape = getAsmShapeForDotOp(dotOp);
+        LDBG("mfmaShape: " << mfmaShape[0] << "x" << mfmaShape[1] << "x"
+                           << mfmaShape[2]);
+        LDBG("numRepsVec: " << numRepsVec[0] << "x" << numRepsVec[1] << "x"
+                            << numRepsVec[2]);
+      }
+      auto numReps = product<uint32_t>(numRepsVec);
+      return MachineModelOpProperties(MachineModelResourcePipe::Mfma,
+                                      4 * numReps, "mfma_16x16x16",
+                                      12 * numReps);
 
       // LDS Ops
     } else if (isa<triton::gpu::LocalLoadOp>(op)) {
       return MachineModelOpProperties(MachineModelResourcePipe::Lds, 4,
-                                      "ds_read_b128", mfmaCycles1);
+                                      "ds_read_b128", 4);
     } else if (isa<triton::gpu::LocalStoreOp>(op)) {
       return MachineModelOpProperties(MachineModelResourcePipe::Lds, 40,
-                                      "ds_write_b128", mfmaCycles2);
+                                      "ds_write_b128", 32);
     } else if (isa<mlir::gpu::BarrierOp>(op)) {
       return MachineModelOpProperties(MachineModelResourcePipe::Lds, 8,
                                       "s_barrier");
@@ -211,7 +221,7 @@ struct MachineModelGFX942 : MachineModelGFX90A {
       // Global Memory Ops
     } else if (isa<triton::LoadOp, triton::amdgpu::BufferLoadOp>(op)) {
       return MachineModelOpProperties(MachineModelResourcePipe::Global, 4,
-                                      "buffer_load", mfmaCycles2);
+                                      "buffer_load", 20);
     }
 
     // Fallback to MI250.
@@ -267,8 +277,8 @@ struct MachineModelGFX942 : MachineModelGFX90A {
 
   (3) TopDown Data Example:
     opDataReadyCycle tracks at which future cycle the data for an op will be
-    ready. E.g. currentCycle=16 scheduleOp(load) will record op->children need
-    to wait until t=16+updateOpDataReady(load).
+    ready. E.g. currentCycle=16, ds_read.seqBusy=4, scheduleOp(load) will record
+  op->children need to wait until t=16+4+updateOpDataReady(load).
 
   (4) BottomUp Data Example:
     Same as TopDown, except that insteady of recording when children will be
@@ -327,9 +337,12 @@ struct MachineState {
   // Queries both pipeReadyCycle and opDataReadyCycle.
   int32_t getCyclesUntilOpReady(Operation *op) {
     MachineModelOpProperties properties = machineModel->getOpProperties(op);
-    int32_t cycles = std::max(getCyclesUntilDataReady(op),
-                              getCyclesUntilPipeReadyForOp(properties));
-    // LDBG("getCyclesUntilOpReady=" << cycles);
+    int32_t data = getCyclesUntilDataReady(op);
+    int32_t pipe = getCyclesUntilPipeReadyForOp(properties);
+    int32_t cycles = std::max(data, pipe);
+    if (false)
+      LDBG("getCyclesUntilOpReady: data=" << data << ", pipe=" << pipe << " - "
+                                          << *op);
     return cycles;
   }
 
@@ -392,19 +405,32 @@ struct MachineState {
   }
 
   /*
-    Updates when target will be ready based on it's
-    dependency with other and the data latency.
-    Call from above and from scheduler.
-    TopDown: target=child, other=parent.
-    BottomUp: target=parent, other=child.
-    Writes to opDataReadyCycle.
+    Updates when target will be ready based on data latency, comprised of
+    - current time when gpu will start issuing memory op
+    - cycles it takes to "complete issuing the memory op", e.g.
+      - ds_read takes 4 cycles to issue
+      - ds_write takes 40 cycles to issue
+    - dependency with other and the data latency, e.g. 80 cycles between
+    ds_write and gpu.barrier. Called from above and from scheduler. TopDown:
+    target=child, other=parent. BottomUp: target=parent, other=child. Writes to
+    opDataReadyCycle.
   */
   void updateOpDataReady(Operation *target, Operation *other) {
     assert(target && other);
     int32_t readyCycle = getCurrentCycle();
     if (topDown) {
+      auto op = target;
+      MachineModelOpProperties properties = machineModel->getOpProperties(op);
+      // When scheduling top-down, assume that other has already been scheduled;
+      // therefore time was already stepped forward by seqBusy.
+      // readyCycle += properties.cyclesSeqBusy;
       readyCycle += calcCyclesUntilDataReady(other);
     } else {
+      auto op = other;
+      MachineModelOpProperties properties = machineModel->getOpProperties(op);
+      // When scheduling bottom-up, the data latency doesn't apply until after
+      // the op's seqBusy, so add that to data ready time.
+      readyCycle += properties.cyclesSeqBusy;
       readyCycle += calcCyclesUntilDataReady(target);
     }
     setDataReadyCycle(target, readyCycle);
@@ -450,10 +476,10 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
     out << "=" << machine.pipeReadyCycle[i];
   }
   out << "]";
-  if (false) {
+  if (true) {
     for (auto entry : machine.opDataReadyCycle) {
-      out << "\t t=" << entry.getSecond() << " ready << "
-          << entry.getFirst()->getName() << "\n";
+      out << "\n\t t=" << entry.getSecond() << " ready "
+          << entry.getFirst()->getName();
     }
   }
   return out;

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -84,6 +84,7 @@ StringRef toString(MachineModelResourcePipe pipe) {
   case Other:
     return "O";
   }
+  return "?";
 };
 
 /*

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -11,9 +11,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
-// #undef LLVM_DEBUG
-// #define LLVM_DEBUG(X) X
-
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-scheduler-machine-model"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -108,16 +105,16 @@ StringRef toString(MachineModelResourcePipe pipe) {
 */
 struct MachineModelOpProperties {
 
-  MachineModelOpProperties(MachineModelResourcePipe pipe, int32_t seqBusy,
-                           StringRef n, int32_t pipeBusyAfterSeq = 0)
-      : resourcePipe(pipe), cyclesSeqBusy(seqBusy),
-        cyclesPipeBusyAfterSeq(pipeBusyAfterSeq), name(n) {}
+  MachineModelOpProperties(MachineModelResourcePipe pipe, int32_t sequencerBusy,
+                           StringRef inputName, int32_t pipeBusyAfterSequencer = 0)
+      : resourcePipe(pipe), cyclesSequencerBusy(sequencerBusy),
+        cyclesPipeBusyAfterSequencer(pipeBusyAfterSequencer), name(inputName) {}
 
   // To which resource pipe does this op map.
   MachineModelResourcePipe resourcePipe;
 
   // Op blocks all other ops from issuing.
-  int32_t cyclesSeqBusy;
+  int32_t cyclesSequencerBusy;
 
   /*
     How long to wait before issuing another op to same
@@ -126,7 +123,7 @@ struct MachineModelOpProperties {
     sequencer is busy issuing the mfma, and 12 more cycles that the
     mfma pipe is still busy but other pipes can be used.
   */
-  int32_t cyclesPipeBusyAfterSeq;
+  int32_t cyclesPipeBusyAfterSequencer;
 
   // To be used for debugging, e.g. saying that op was
   // assumed to map to 16 v_pk_add_fp32 instructions.
@@ -142,6 +139,7 @@ struct MachineModelOpProperties {
 */
 struct MachineModel {
 
+  MachineModel() = default;
   virtual MachineModelOpProperties getOpProperties(Operation *op) = 0;
 
   /*
@@ -193,16 +191,6 @@ struct MachineModelGFX942 : MachineModelGFX90A {
     // Mfma
     if (auto dotOp = dyn_cast<triton::DotOp>(op)) {
       auto numRepsVec = getAsmNumRepsForDotOp(dotOp);
-      if (false) {
-        auto dotShape = getWarpShapeForDotOp(dotOp);
-        LDBG("dotWarpShape: " << dotShape[0] << "x" << dotShape[1] << "x"
-                              << dotShape[2]);
-        auto mfmaShape = getAsmShapeForDotOp(dotOp);
-        LDBG("mfmaShape: " << mfmaShape[0] << "x" << mfmaShape[1] << "x"
-                           << mfmaShape[2]);
-        LDBG("numRepsVec: " << numRepsVec[0] << "x" << numRepsVec[1] << "x"
-                            << numRepsVec[2]);
-      }
       auto numReps = product<uint32_t>(numRepsVec);
       return MachineModelOpProperties(MachineModelResourcePipe::Mfma,
                                       4 * numReps, "mfma_16x16x16",
@@ -322,14 +310,14 @@ struct MachineState {
 
   // Calculates how many cycles forward time is advanced as a result of
   // scheduling op. Elapsed time will be cycles until data and pipe are ready +
-  // cyclesSeqBusy.
+  // cyclesSequencerBusy.
   int32_t scheduleOpCalcElapsedCycles(Operation *op) {
     MachineModelOpProperties properties = machineModel->getOpProperties(op);
     MachineModelResourcePipe pipe = properties.resourcePipe;
     // If resource pipe or data weren't ready, need to first wait for them
     // before issuing op.
     int32_t elapsedCycles =
-        getCyclesUntilOpReady(op) + properties.cyclesSeqBusy;
+        getCyclesUntilOpReady(op) + properties.cyclesSequencerBusy;
     return elapsedCycles;
   }
 
@@ -341,37 +329,26 @@ struct MachineState {
     int32_t data = getCyclesUntilDataReady(op);
     int32_t pipe = getCyclesUntilPipeReadyForOp(properties);
     int32_t cycles = std::max(data, pipe);
-    if (false)
-      LDBG("getCyclesUntilOpReady: data=" << data << ", pipe=" << pipe << " - "
-                                          << *op);
     return cycles;
   }
 
   // Calculates when pipe will be ready; examples provided above.
   // Queries pipeReadyCycle.
   int32_t getCyclesUntilPipeReadyForOp(MachineModelOpProperties properties) {
-    int32_t readyCycle;
-    if (topDown) {
-      readyCycle =
-          (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle());
-    } else {
-      readyCycle =
-          (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()) +
-          properties.cyclesPipeBusyAfterSeq;
-    }
-    readyCycle = std::max(0, readyCycle);
-    return readyCycle;
+    if (topDown)
+      return std::max(0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()));
+    return std::max(0, (pipeReadyCycle[properties.resourcePipe] - getCurrentCycle()) +
+          properties.cyclesPipeBusyAfterSequencer);
   }
 
   // Calculates when data will be ready; examples provided above.
   // Queries opDataReadyCycle.
   int32_t getCyclesUntilDataReady(Operation *op) {
     auto find = opDataReadyCycle.find(op);
-    int32_t cycle = 0;
     if (find != opDataReadyCycle.end()) {
-      cycle = std::max(0, find->getSecond() - getCurrentCycle());
+      return std::max(0, find->getSecond() - getCurrentCycle());
     }
-    return cycle;
+    return 0;
   }
 
   // Update when pipes will be ready, based on op getting scheduled.
@@ -380,7 +357,7 @@ struct MachineState {
     MachineModelResourcePipe pipe = properties.resourcePipe;
     if (topDown) {
       pipeReadyCycle[pipe] =
-          getCurrentCycle() + properties.cyclesPipeBusyAfterSeq;
+          getCurrentCycle() + properties.cyclesPipeBusyAfterSequencer;
     } else {
       pipeReadyCycle[pipe] = getCurrentCycle();
     }
@@ -424,14 +401,14 @@ struct MachineState {
       MachineModelOpProperties properties = machineModel->getOpProperties(op);
       // When scheduling top-down, assume that other has already been scheduled;
       // therefore time was already stepped forward by seqBusy.
-      // readyCycle += properties.cyclesSeqBusy;
+      // readyCycle += properties.cyclesSequencerBusy;
       readyCycle += calcCyclesUntilDataReady(other);
     } else {
       auto op = other;
       MachineModelOpProperties properties = machineModel->getOpProperties(op);
       // When scheduling bottom-up, the data latency doesn't apply until after
       // the op's seqBusy, so add that to data ready time.
-      readyCycle += properties.cyclesSeqBusy;
+      readyCycle += properties.cyclesSequencerBusy;
       readyCycle += calcCyclesUntilDataReady(target);
     }
     setDataReadyCycle(target, readyCycle);
@@ -462,7 +439,7 @@ struct MachineState {
   MachineModel *machineModel;
   // Tracks pipe readiness differently for TopDown vs BottomUp.
   // BottomUp: tracks the cycle during which pipe was last used.
-  // TopDown: tracks the cycle last used + prev op's cyclesPipeBusyAfterSeq.
+  // TopDown: tracks the cycle last used + prev op's cyclesPipeBusyAfterSequencer.
   SmallVector<int32_t, numResourcePipes> pipeReadyCycle;
   DenseMap<Operation *, int32_t> opDataReadyCycle;
   bool topDown;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -345,14 +345,6 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out, SchedDagNodeList &nodes) {
   }
   return out;
 }
-llvm::raw_ostream &
-operator<<(llvm::raw_ostream &out,
-           llvm::SmallVector<std::shared_ptr<SchedDagNode>> &nodes) {
-  for (auto node : nodes) {
-    out << *(node.get()) << "\n";
-  }
-  return out;
-}
 
 /******************************************************************************
   Categories of ops to facilitate scheduling.
@@ -542,18 +534,21 @@ struct SchedDag {
     }
   }
 
-  // Shallow copy constructor.
+  // Deep copy constructor; used for memory analysis.
   SchedDag(const SchedDag &dag)
-      : nodesHeap(dag.nodesHeap), nodeList(dag.nodeList), deps(dag.deps),
+      : nodeList(dag.nodeList), deps(dag.deps),
         nodeMap(dag.nodeMap) {
-    LDBG("SchedDag::CopyConstructor(shallow)");
+    // TODO(dtanner) - this needs to create new nodes on the heap
+    // for nodeList, then reconstruct deps and nodeMap with
+    // the new pointers.
+    LDBG("SchedDag(deep copy constructor)");
+    assert(false);
   }
 
   void addOp(Operation *op) {
-    std::shared_ptr<SchedDagNode> node = std::make_shared<SchedDagNode>(op);
-    nodeMap.insert({op, node.get()});
-    nodeList.push_back(node.get());
-    nodesHeap.push_back(std::move(node));
+    SchedDagNode *node = new SchedDagNode(op);
+    nodeMap.insert({op, node});
+    nodeList.push_back(node);
   }
 
   void addDeps(StringRef depTypeName, const DepSet &depSet) {
@@ -787,8 +782,6 @@ struct SchedDag {
     format["GlobalLoadOrder"] = std::make_pair("darkgreen", "solid");
     format["DotLdsOrder"] = std::make_pair("red", "solid");
     format["DotGlobalOrder"] = std::make_pair("blue", "solid");
-    // format["MemOrder"] = std::make_pair("blue", "solid");
-    // format["MemInterleave"] = std::make_pair("red", "solid");
 
     for (auto &depType : deps) {
       StringRef depTypeName = depType.getFirst();
@@ -813,9 +806,12 @@ struct SchedDag {
     return out;
   }
 
-  // SchedDagNodes as shared_ptrs for dealloc.
-  llvm::SmallVector<std::shared_ptr<SchedDagNode>> nodesHeap;
-  // SchedDagNodes as simple ptrs for everything else.
+  ~SchedDag() {
+    for (SchedDagNode *node : nodeList) {
+      delete node;
+    }
+  }
+
   SchedDagNodeList nodeList;
   DepMap deps;
   OpNodeMap nodeMap;
@@ -1433,37 +1429,6 @@ struct DotLdsOrderDependencyCalculator : DependencyCalculator {
   }
 };
 
-#if 0
-struct DotLdsOrderDependencyCalculator : DependencyCalculator {
-  DotLdsOrderDependencyCalculator() : DependencyCalculator("DotLdsOrder") {}
-
-  void calcDeps() {
-    SchedDagNode *prevDot = nullptr;
-    SchedDagNode *prevLds = nullptr;
-
-    for (auto node : dag->nodeList) {
-      if (nodeCategoryLds(node)) {
-        if (prevDot) {
-          SchedDep dep;
-          dep.parent = prevDot;
-          dep.child = node;
-          depSet.insert(dep);
-        }
-        prevLds = node;
-      } else if (isa<triton::DotOp>(node->getOp())) {
-        if (prevLds) {
-          SchedDep dep;
-          dep.parent = prevLds;
-          dep.child = node;
-          depSet.insert(dep);
-        }
-        prevDot = node;
-      }
-    }
-  }
-};
-#endif
-
 /******************************************************************************
   Add deps between dot ops and global ops.
 ******************************************************************************/
@@ -1973,10 +1938,9 @@ struct ApplySchedBarriers {
           builder.setInsertionPointAfter(op);
           Operation *schedBarOp =
               createSchedBarrier(builder, loc, schedBarMask);
-          std::shared_ptr<SchedDagNode> schedBarNode =
-              std::make_shared<SchedDagNode>(schedBarOp);
-          dag.nodesHeap.push_back(schedBarNode);
-          parentIter = dag.nodeList.insert(parentIter + 1, schedBarNode.get());
+          SchedDagNode *schedBarNode =
+              new SchedDagNode(schedBarOp);
+          parentIter = dag.nodeList.insert(parentIter + 1, schedBarNode);
           ++parentIter;
           return true;
         } else {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Pass/Pass.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h"
 #include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -29,7 +30,8 @@ namespace ttg = mlir::triton::gpu;
 
 /******************************************************************************
   Reschedule ttgir after refine-ops-pass to interleave refined ops at the ttgir
-  level.
+  level, and thereby improve llir order which will improve
+  scheduling and regalloc of backend compiler.
 
   The goals of rescheduling the basic block are:
   (1) Triton scheduling only needs to compliment LLVM scheduler,
@@ -40,13 +42,14 @@ namespace ttg = mlir::triton::gpu;
 
   Scheduling consists of multiple passes controlled by SchedManager:
   (1) Analyse the current op sequence.
-  (2) Create an additional sets of dependencies in SchedDag.
+  (2) Create additional sets of dependencies and priorities in SchedDag.
   (3) Reschedule based on ready-list,
       (a) Select best node based on heuristic.
       (b) Remove node and dependencies from nodes in SchedDag.
       (c) Update ready-list.
-  (4) Results in a new op sequence. Also, restore deps in SchedDag.
+  (4) Results in a new op sequence.
 ******************************************************************************/
+
 namespace {
 
 // TODO (ravil): Note, took function from `SchedInstructions.cpp`.
@@ -70,6 +73,38 @@ enum class SchedDirection { TopDown, BottomUp };
   child / dependent / src / scheduled after
 ******************************************************************************/
 
+/*
+  This stores a priority for scheduling one node vs another.
+  This is an optional parameter which a PriorityCalculator sets
+  and a SchedulingHeuristic might use.
+
+  For example, we want to get to a dot asap, so we want to analyze which are on
+  critical path. Also, we want to set the relative order of LocalLoadOps.
+*/
+enum class SchedDagNodePriorityType : uint32_t {
+  DotCriticalPath = 0,
+  LocalStoreCriticalPath = 1,
+  Size // Keep as last to know size().
+};
+using SchedDagNodePriorityDataType = float;
+using SchedDagNodePriority =
+    SmallVector<SchedDagNodePriorityDataType,
+                static_cast<uint32_t>(SchedDagNodePriorityType::Size)>;
+constexpr SchedDagNodePriorityDataType schedDagNodePriorityUnset =
+    std::numeric_limits<SchedDagNodePriorityDataType>::lowest();
+StringRef toString(SchedDagNodePriorityType type) {
+  switch (type) {
+  case SchedDagNodePriorityType::DotCriticalPath:
+    return "DotCriticalPath";
+  case SchedDagNodePriorityType::LocalStoreCriticalPath:
+    return "LocalStoreCriticalPath";
+  case SchedDagNodePriorityType::Size:
+    return "Size";
+  default:
+    return "ERROR";
+  }
+}
+
 /******************************************************************************
   SchedDagNode contains op, parents and children dependencies.
   Before scheduling nodes are created and dependencies are added.
@@ -79,16 +114,18 @@ enum class SchedDirection { TopDown, BottomUp };
   Nodes without children are ready to be scheduled if Direction=BottomUp.
 ******************************************************************************/
 struct SchedDagNode {
-  SchedDagNode(Operation *op) : op(op) {
+  SchedDagNode(Operation *op)
+      : op(op), priority(static_cast<uint32_t>(SchedDagNodePriorityType::Size),
+                         schedDagNodePriorityUnset) {
     static int32_t serialId = 0;
     id = serialId++;
     opStr = op->getName().getStringRef();
+    resetPriorities();
   }
 
-  // Copy constructor.
   SchedDagNode(const SchedDagNode &node)
       : op(node.op), id(node.id), opStr(node.opStr), children(node.children),
-        parents(node.parents) {}
+        parents(node.parents), priority(node.priority) {}
 
   // For DenseMapInfo to create empty/tombstone entries.
   SchedDagNode(int32_t i) : op(nullptr), id(i), opStr("") {}
@@ -102,9 +139,8 @@ struct SchedDagNode {
   int32_t numParents() { return parents.size(); }
 
   /*
-    When scheduling top-down, a node is ready to schedule when it has no
-    parents. When scheduling bottom-up, a node is ready to schedule when it has
-    no children.
+    TopDown: node is ready to schedule when it has no parents.
+    BottomUp: node is ready to schedule when it has no children.
   */
   template <SchedDirection Direction> bool isReady() {
     if constexpr (Direction == SchedDirection::TopDown) {
@@ -138,36 +174,50 @@ struct SchedDagNode {
     parents.clear();
   }
 
-  // Returns whether this is ancestor (by recursively checking children) of
-  // other; however this is too expensive for production.
-  bool isAncestor(SchedDagNode *other) const {
-    for (SchedDagNode *child : children) {
-      if (child == other) {
-        // This is ancestor of other if other is this' child.
-        return true;
-      } else if (child->isAncestor(other)) {
-        // This is ancestor of other if one of this' children are ancestor of
-        // other.
-        return true;
-      }
-    }
-    return false;
+  // Manipulate the node's priorities.
+  void setPriority(SchedDagNodePriorityType type,
+                   SchedDagNodePriorityDataType value) {
+    priority[static_cast<uint32_t>(type)] = value;
   }
-
-  // Returns whether this is posterity (by recursively checking parents) of
-  // other; however this is too expensive for production.
-  bool isPosterity(SchedDagNode *other) const {
+  SchedDagNodePriorityDataType
+  getPriority(SchedDagNodePriorityType type) const {
+    return priority[static_cast<uint32_t>(type)];
+  }
+  bool hasPriority(SchedDagNodePriorityType type) const {
+    return getPriority(type) != schedDagNodePriorityUnset;
+  }
+  void resetPriorities() {
+    for (uint32_t i = 0;
+         i < static_cast<uint32_t>(SchedDagNodePriorityType::Size); ++i) {
+      setPriority(static_cast<SchedDagNodePriorityType>(i),
+                  schedDagNodePriorityUnset);
+    }
+  }
+  void propagateHigherPriorityToParents(SchedDagNodePriorityType type) {
+    assert(hasPriority(type));
     for (SchedDagNode *parent : parents) {
-      if (parent == other) {
-        // This is posterity of other if other is this' parent.
-        return true;
-      } else if (parent->isPosterity(other)) {
-        // This is posterity of other if one of its parents are posterity of
-        // other.
-        return true;
+      // First time setting priorities of this type.
+      if (!parent->hasPriority(type) ||
+          getPriority(type) > parent->getPriority(type)) {
+        parent->setPriority(type, getPriority(type));
+        parent->propagateHigherPriorityToParents(type);
+      } else if (getPriority(type) == parent->getPriority(type)) {
+        // Second+ time setting priorities of this type.
+        parent->propagateHigherPriorityToParents(type);
       }
     }
-    return false;
+  }
+  void propagateLowerPriorityToChildren(SchedDagNodePriorityType type) {
+    assert(hasPriority(type));
+    for (SchedDagNode *child : children) {
+      if (!child->hasPriority(type) ||
+          getPriority(type) < child->getPriority(type)) {
+        child->setPriority(type, getPriority(type));
+        child->propagateLowerPriorityToChildren(type);
+      } else if (getPriority(type) == child->getPriority(type)) {
+        child->propagateLowerPriorityToChildren(type);
+      }
+    }
   }
 
   Operation *op;
@@ -180,6 +230,9 @@ struct SchedDagNode {
 
   // This node depends on parents; this node must be scheduled after parents.
   llvm::SetVector<SchedDagNode *> parents;
+  // Priorities are enumerated and optionally set by
+  // and used by SchedulingHeuristics.
+  SchedDagNodePriority priority;
 };
 
 struct SchedDagNodeDenseMapInfo : public llvm::DenseMapInfo<SchedDagNode> {
@@ -207,6 +260,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out, SchedDagNode &node) {
   out << "} c={";
   for (auto c : node.getChildren()) {
     out << "@" << c->id << " ";
+  }
+  out << "} pr={";
+  for (uint32_t i = 0;
+       i < static_cast<uint32_t>(SchedDagNodePriorityType::Size); ++i) {
+    SchedDagNodePriorityType type = static_cast<SchedDagNodePriorityType>(i);
+    if (node.hasPriority(type)) {
+      out << node.getPriority(type) << " ";
+    } else {
+      out << "? ";
+    }
   }
   out << "}]";
   return out;
@@ -317,7 +380,6 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out, const SchedDep &dep) {
   dummy pointers which can't be dereferenced.
   Therefore the comparison operations need to first check
   if the pointers are empty/tombstone before dereferencing.
-  TODO(dtanner) - isEqual() might be simplifiable.
 */
 struct SchedDepDenseMapInfo : llvm::DenseMapInfo<SchedDep> {
 
@@ -392,8 +454,6 @@ struct SchedDag {
       Operation *op = &(*it);
       addOp(op);
     }
-    LDBG("SchedDag() NodeList");
-    LLVM_DEBUG(dumpNodes(llvm::dbgs()));
   }
 
   // Shallow copy constructor.
@@ -450,9 +510,7 @@ struct SchedDag {
     int32_t count = 0;
     for (auto &depType : deps) {
       StringRef depTypeName = depType.getFirst();
-      LDBG(depTypeName);
       DepSet &depSet = depType.getSecond();
-
       int32_t erased = depSet.erase(dep);
       count += erased;
     }
@@ -635,8 +693,9 @@ struct SchedDag {
 
     std::map<StringRef, std::pair<std::string, std::string>> format;
     // Assume later deps are more important to visualize b/c complex.
-    format["Data"] = std::make_pair("gray70", "dotted");
-    format["RefinedOrder"] = std::make_pair("black", "dashed");
+    format["Barrier"] = std::make_pair("gray90", "dotted");
+    format["RefinedOrder"] = std::make_pair("gray50", "dotted");
+    format["Data"] = std::make_pair("black", "dotted");
     format["LocalLoadTypeOrder"] = std::make_pair("darkgreen", "solid");
     format["LocalStoreTypeOrder"] = std::make_pair("darkgreen", "solid");
     format["GlobalLoadCategoryOrder"] = std::make_pair("darkgreen", "solid");
@@ -707,6 +766,40 @@ struct DependencyCalculator {
 struct DataDependencyCalculator : DependencyCalculator {
   DataDependencyCalculator() : DependencyCalculator("Data") {}
 
+  // Add data deps for operands.
+  void calcDeps() {
+    for (auto it = dag->nodeList.begin(); it != dag->nodeList.end(); ++it) {
+      SchedDagNode *node = (*it);
+      for (auto operandValue : node->getOp()->getOperands()) {
+        auto operandDefOp = operandValue.getDefiningOp();
+        SchedDagNode *parentNode = dag->nodeMap[operandDefOp];
+        if (parentNode) {
+          SchedDep dep;
+          dep.parent = parentNode;
+          dep.child = node;
+          depSet.insert(dep);
+        }
+      }
+    }
+  }
+};
+
+/******************************************************************************
+  Creates dependencies based on various barriers.
+  TODO(dtanner) need to add support for below?
+  triton::gpu::AsyncWaitOp
+  triton::nvidia_gpu::TMAStoreWaitOp
+  triton::nvidia_gpu::ArriveBarrierOp
+  RegionBranchOpInterface ?
+  MemoryEffects::Write
+  MemoryEffects::Read
+  triton::CallOp
+  triton::gpu::LocalAllocOp
+  triton::gpu::LocalDeallocOp
+******************************************************************************/
+struct BarrierDependencyCalculator : DependencyCalculator {
+  BarrierDependencyCalculator() : DependencyCalculator("Barrier") {}
+
   // There is an implied data dependency between LDS ops and GPUBarrier.
   template <SchedDirection Direction> void calcDepsLdsGpuBar() {
 
@@ -771,23 +864,6 @@ struct DataDependencyCalculator : DependencyCalculator {
           depSet.insert(dep);
         }
         prevBar = node;
-      }
-    }
-  }
-
-  // Add data deps for operands.
-  void calcDepsOperands() {
-    for (auto it = dag->nodeList.begin(); it != dag->nodeList.end(); ++it) {
-      SchedDagNode *node = (*it);
-      for (auto operandValue : node->getOp()->getOperands()) {
-        auto operandDefOp = operandValue.getDefiningOp();
-        SchedDagNode *parentNode = dag->nodeMap[operandDefOp];
-        if (parentNode) {
-          SchedDep dep;
-          dep.parent = parentNode;
-          dep.child = node;
-          depSet.insert(dep);
-        }
       }
     }
   }
@@ -1014,7 +1090,6 @@ struct DataDependencyCalculator : DependencyCalculator {
   }
 
   void calcDeps() {
-    calcDepsOperands();
     calcDepsLdsGpuBar<SchedDirection::BottomUp>();
     calcDepsLdsGpuBar<SchedDirection::TopDown>();
     calcDepsGpuBarGpuBar();
@@ -1095,6 +1170,74 @@ struct RefinedOpDependencyCalculator : DependencyCalculator {
 };
 
 /*
+  Likely don't want this as it incorrectly ordered GL1 LS1 GL0 LS0
+  And enforced the order with dependencies.
+  Keeping around in case want to adapt the logic to something different later.
+*/
+struct PriorityOrderDependencyCalculator : DependencyCalculator {
+  PriorityOrderDependencyCalculator() : DependencyCalculator("PriorityOrder") {}
+  void calcDeps() {
+
+    for (uint32_t priorityIdx = 0;
+         priorityIdx < static_cast<uint32_t>(SchedDagNodePriorityType::Size);
+         ++priorityIdx) {
+
+      SchedDagNodePriorityType priorityType =
+          static_cast<SchedDagNodePriorityType>(priorityIdx);
+      SchedDagNodePriorityDataType prevPriority = schedDagNodePriorityUnset;
+      SchedDagNodeList prevNodes;
+      SchedDagNodePriorityDataType currPriority = schedDagNodePriorityUnset;
+      SchedDagNodeList currNodes;
+
+      for (auto node : dag->nodeList) {
+        if (node->hasPriority(priorityType)) {
+          auto nodePriority = node->getPriority(priorityType);
+          if (currPriority == schedDagNodePriorityUnset) {
+            currPriority = currPriority;
+          }
+          if (nodePriority == currPriority) {
+            // We're still on the same priority, add deps and node.
+            for (auto n : prevNodes) {
+              SchedDep dep;
+              dep.parent = n;
+              dep.child = node;
+              depSet.insert(dep);
+            }
+            currNodes.push_back(node);
+          } else { // maintain order even when we dropped priority b/c other
+                   // deps.
+            // We're on a new priority; add all deps between prev and curr.
+            for (auto p : prevNodes) {
+              for (auto c : currNodes) {
+                SchedDep dep;
+                dep.parent = p;
+                dep.child = c;
+                depSet.insert(dep);
+              }
+            }
+            // Shift sets forward.
+            prevPriority = currPriority;
+            prevNodes = currNodes;
+            currNodes.clear();
+            currNodes.push_back(node);
+            currPriority = nodePriority;
+          }
+        }
+      }
+      // Done with all nodes; add last group of deps.
+      for (auto p : prevNodes) {
+        for (auto c : currNodes) {
+          SchedDep dep;
+          dep.parent = p;
+          dep.child = c;
+          depSet.insert(dep);
+        }
+      }
+    }
+  }
+};
+
+/*
   Simple DependencyCalculators based on op types (or category) and serializes
   all ops of that type.
 */
@@ -1134,6 +1277,11 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
   }
 }
 
+struct DotOrderDependencyCalculator : DependencyCalculator {
+  DotOrderDependencyCalculator() : DependencyCalculator("DotTypeOrder") {}
+  void calcDeps() { calcDepsOpType<triton::DotOp>(&dag->nodeList, depSet); }
+};
+
 struct LocalLoadOrderDependencyCalculator : DependencyCalculator {
   LocalLoadOrderDependencyCalculator()
       : DependencyCalculator("LocalLoadTypeOrder") {}
@@ -1159,151 +1307,44 @@ struct GlobalLoadOrderDependencyCalculator : DependencyCalculator {
 };
 
 /******************************************************************************
-Create high-level dependencies between the different memory ops where there
-aren't data deps. A basic block has a collection of refined memory ops, GL, LS,
-LL.
+  Create order dependencies between ops which were refined from same original
+  op.
+******************************************************************************/
+struct DotLdsOrderDependencyCalculator : DependencyCalculator {
+  DotLdsOrderDependencyCalculator() : DependencyCalculator("DotLdsOrder") {}
 
-for num_stages=2 without local_prefetch
-the GL and LS have data dependencies, and both can be co-scheduled with the
-local_loads. So we need to specify that the GL should overlap the LL. The LS
-can't overlap LL because of anti-dep enforced by gpu.bar.
+  void calcDeps() {
+    SchedDagNode *prevDot = nullptr;
+    SchedDagNode *prevLds = nullptr;
 
-Example:
-GLA01
-GLB01
-LLA0123
-LLB0123
-LSA01
-LSB01
+    for (auto node : dag->nodeList) {
+      if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(
+              node->getOp())) {
+        if (prevDot) {
+          SchedDep dep;
+          dep.parent = prevDot;
+          dep.child = node;
+          depSet.insert(dep);
+        }
+        prevLds = node;
+      } else if (isa<triton::DotOp>(node->getOp())) {
+        if (prevLds) {
+          SchedDep dep;
+          dep.parent = prevLds;
+          dep.child = node;
+          depSet.insert(dep);
+        }
+        prevDot = node;
+      }
+    }
+  }
+};
 
-Could be serialized like
-
-GLA01 GLB01 LLA0123 LLB0123
-LSA01 LSB01
-
-or
-
-GLA01 GLB01 LLA0123 LLB0123
-LSA01 LSB01
-
-https://github.com/ROCm/triton-internal/issues/736
-Determine Memory Op Order & Co-Scheduling
-We need to determine the relative ordering between or overlap of different
-memory op types; e.g. if global_loads and local_loads can both be scheduled,
-which should have higher priority. The ordering of memory ops have implications
-for performance and register use. This applies to loops where data can be
-prefetched, and also to regions with multiple dots. First, data dependencies
-determine order. Second, critical-path analysis determines order, meaning the
-memory ops which need to be scheduled to get to the mfmas sooner have highest
-priority. Note that for local_loads, some may be on the critical path to get us
-to the first 1-2 dot-tiles, but after other dot-tiles' local_loads can be
-delayed Third, based on scheduling mode: Min-Vgpr mode: preferred order is
-local_store, global_load, local_load. Max-Latency mode: preferred order is
-global_load, local_load, local_store.
-========================================================================
-This applies to loops where data can be prefetched.
-This should also apply to regions with multiple dots.
-First, def-use dependencies kick in to determine order
-If LS overlaps LL (both prefetched, 011, 111)
-  min-vgpr: LS, LL to save vgprs
-  max-latency: LL, LS to maximize GL latency hiding
-  ever want to co-schedule? - no
-If GL overlaps LL (GL and (LS or LL) prefetched; 101, 110, 111)
-  min-vgpr: GL, LL
-  max-latency: GL, LL (same)
-If GL overlaps LS
-  min-vgpr: LS before GL to save vgprs
-  max-latency: GL before LS to maximize latency hiding
-If GL overlaps LS overlaps LL
-  min-vgpr: LS, GL, LL to save vgprs
-  max-latency: GL, LL, LS
-Need to verify the above doesn’t create any cyclic dependencies?
-Need to clarify that some of these “after” are actually “interleave”.
-Need to distinguish between vgpr vs latency for global separate from LDS ops?
-
-The above logic is hyper-focused on gemm, and we need to abstract much more.
-
-==========================================================================
-This is actually mostly determined during StreamPipeliner via clustering and
-num_stages. We need to decide the optimal memoy op ordering (via cluster) during
-StreamPipeliner and covey it forward via the IR. Additionally, we also need
-StreamPipeliner to specify whether op A should fully preceed op B, or whether op
-A and op B can overlap and therefore be interleaved after refining.
-==========================================================================
-
-
-
-This first issue has mostly to do with when everything is prefetched, what order
-should they be in.
-
-
-
-AddDeps: Order deps between different memory types #738
-https://github.com/ROCm/triton-internal/issues/738
-Memory Opr Order Deps
-
-With this ordering of ops, we can create order dependencies between op types so
-we only schedule the ones at a time that we want. E.g. for local prefetch,
-scheduler shouldn’t even see local_loads until very late in the loop.
-
-Insert order dependencies to serialize certain memory ops.
-
-This may need information to be communicated from the stream-pipeliner (or other
-places) to the scheduler. Some examples of what this task means: (1) A gemm with
-num_stages=2 wants local_loads close to the top of the kernel and global_loads
-to come after the first few local_loads but interleaved among later local_loads.
-Whereas enabling local_prefetch puts all the local_loads at the bottom of the
-loop after the global_loads and local_stores. The scheduler needs to know "delay
-the local_loads as much as possible" after most mfmas which have freed registers
-which the local_local loads can then use. The backend gets this wrong because it
-schedules the local_loads early and uses too many vgprs.
-
-(2) For FA num_stages=2 maxDepth=1, the memory structure looks like
-global_load
-local_store <-- these must come before
-global_load <-- these to save vgprs
-local_store
-
-This second issue takes
-
-GLA01 GLB01 LLA0123 LLB0123
-LSA01 LSB01
-
-and further narrows it to
-
-LLA0
-LLB0
-LLB1
-LLA1
-GLA0
-LLA2
-GLA1
-LLB2
-GLB0
-LLB3
-GLB1
-LLA3
-LSA0
-LSA1
-LSB0
-LSB1
-
-Later will AddDeps between the mem ops and
-
-
-global_load before/after local_loads
-global_loads before/after local_stores
-local_load[A] before/after local_load[B]
-global_load[K] before/after global_load[K]
-
-
-Determines which memory ops should overlap other memory ops (vs being
-co-scheduled) when data dependencies allow them to be.
-
-if we have all dots in order, and we do a scheduling with delaying all local
-loads then we can just grab the order of local_loads from that. Can we just keep
-the relative order of local stores as being final? Then have the relative order
-of global loads to match (with loop wrap around).
+/******************************************************************************
+  For kernels with increasing prefetching, there will be many memory
+  ops which can be re-ordered. This begins the analysis of what ordering
+  still need to be figured out.
+  E.g., for FlashAttention how to order the GL, LS for K and V.
 ******************************************************************************/
 struct MemOrderDependencyCalculator : DependencyCalculator {
   MemOrderDependencyCalculator() : DependencyCalculator("MemOrder") {}
@@ -1358,15 +1399,55 @@ struct MemOrderDependencyCalculator : DependencyCalculator {
 
 /******************************************************************************
   Library of comparison functions for scheduling heuristics.
+  prefer*() functions return true if a is preferred over b
+  and if we want the preferred op.
+  This is a strict a > b type of comparison, so they return false if a <= b.
+  The parameter prefer is typically set to Direction==TopDown so that we can
+  specify something like schedule LoadOp closer to top of loop,
+  and these comparison will prefer the LoadOp for TopDown
+  and dis-prefer it for BottomUp (which will push them toward top of loop).
+  One exception is preferMachineState should have prefer=true since
+  it already account for ideal machine state for the two different
+  scheduling direction, i.e. at no point do we prefer a bad machine state.
+
+  The findPreferred*() functions return a or b if one is strictly preferred
+  over the other or nullptr if not. It is often the case that a==b
+  for some of these comparisons, in which case the SchedHeuristic will
+  then move on to the next comparison.
 ******************************************************************************/
 
-// Prefer op based on type.
+// Prefer based on node priority.
+bool preferPriority(SchedDagNode *a, SchedDagNode *b,
+                    SchedDagNodePriorityType priorityType, bool prefer = true) {
+  if (a->hasPriority(priorityType)) {
+    if (b->hasPriority(priorityType)) {
+      return (a->getPriority(priorityType) > b->getPriority(priorityType)) ==
+             prefer;
+    }
+    return prefer;
+  }
+  if (b->hasPriority(priorityType)) {
+    return !prefer;
+  }
+  return false;
+}
+SchedDagNode *findPreferredPriority(SchedDagNode *a, SchedDagNode *b,
+                                    SchedDagNodePriorityType priorityType,
+                                    bool prefer = true) {
+  if (preferPriority(a, b, priorityType, prefer)) {
+    return a;
+  } else if (preferPriority(b, a, priorityType, prefer)) {
+    return b;
+  }
+  return nullptr;
+}
+
+// Prefer based on op type.
 template <typename OpType>
 bool preferOpType(SchedDagNode *a, SchedDagNode *b, bool prefer = true) {
   return (llvm::isa<OpType>(a->getOp()) and !llvm::isa<OpType>(b->getOp())) ==
          prefer;
 }
-
 template <typename OpType>
 SchedDagNode *findPreferredOpType(SchedDagNode *a, SchedDagNode *b,
                                   bool prefer = true) {
@@ -1378,12 +1459,11 @@ SchedDagNode *findPreferredOpType(SchedDagNode *a, SchedDagNode *b,
   return nullptr;
 }
 
-// Prefer op based on category (e.g. opCategoryLoad()).
+// Prefer based on op category (functions).
 bool preferOpCategory(SchedDagNode *a, SchedDagNode *b,
                       bool (*category)(SchedDagNode *), bool prefer = true) {
   return (category(a) and !category(b)) == prefer;
 }
-
 SchedDagNode *findPreferredOpCategory(SchedDagNode *a, SchedDagNode *b,
                                       bool (*category)(SchedDagNode *),
                                       bool prefer = true) {
@@ -1395,9 +1475,21 @@ SchedDagNode *findPreferredOpCategory(SchedDagNode *a, SchedDagNode *b,
   return nullptr;
 }
 
-bool preferLocalLoad(SchedDagNode *a, SchedDagNode *b, bool prefer = true) {
-  return (llvm::isa<triton::gpu::LocalLoadOp>(a->getOp()) and
-          !llvm::isa<triton::gpu::LocalLoadOp>(b->getOp())) == prefer;
+// Prefer based on machine state.
+bool preferMachineState(SchedDagNode *a, SchedDagNode *b, MachineState *machine,
+                        bool prefer = true) {
+  return (machine->getCyclesUntilOpReady(a->getOp()) <
+          machine->getCyclesUntilOpReady(b->getOp())) == prefer;
+}
+SchedDagNode *findPreferredMachineState(SchedDagNode *a, SchedDagNode *b,
+                                        MachineState *machine,
+                                        bool prefer = true) {
+  if (preferMachineState(a, b, machine, prefer)) {
+    return a;
+  } else if (preferMachineState(b, a, machine, prefer)) {
+    return b;
+  }
+  return nullptr;
 }
 
 // Returns ops in original mlir block order.
@@ -1406,60 +1498,282 @@ SchedDagNode *getOriginalOrder(SchedDagNode *a, SchedDagNode *b) {
   return (a->id < b->id) == (Direction == SchedDirection::TopDown) ? a : b;
 }
 
-/*
-  Abstract Base class for a scheduling heuristic recipe.
-  E.g. TopDown, schedule global_loads early and local_stores late.
-*/
-template <SchedDirection Direction> struct SchedHeuristic {
-  virtual SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) = 0;
-  virtual StringRef name() = 0;
-  virtual ~SchedHeuristic() = default;
+/******************************************************************************
+  Each PriorityCalculator gets to see the current dag
+  and set scheduling priorities to nodes.
+******************************************************************************/
+struct PriorityCalculator {
+  PriorityCalculator(SchedDagNodePriorityType type) : priorityType(type) {}
+
+  virtual void calcPriorities() = 0;
+
+  void addPrioritiesToDag(SchedDag *d) {
+    LDBG("PriorityCalculator<" << toString(priorityType)
+                               << ">::addPrioritiesToDag()");
+    dag = d;
+    calcPriorities();
+  }
+  virtual ~PriorityCalculator() = default;
+
+  SchedDagNodePriorityType priorityType;
+  SchedDag *dag;
 };
 
 /******************************************************************************
-  Delay LocalLoads as much as possible so they're adjacent to the dot which
-  needs them. This will then allow for placing deps between local loads.
-  Also delay other memory ops so that order deps can be placed between them too.
-  SchedDirection = BottomUp
+  Add DotCriticalPath weights to nodes to correctly schedule.
+  Priority = 1->N starting at the bottom of the block.
+  Then priorities are propagated (unmodified) to parents and children.
+  Therefore when scheduling TopDown, we know from all ops in the ready list
+  which are needed to get to DotOP(priority=9) asap, and we schedule those
+  first. Therefore we can schedule the critical path to the first DotOp.
+
+  We only want to populate the dag with def/use Data dependencies
+  to highlight the flow of data.
+  Later we can add Barrier deps to the dag and re-propagate priorities
+  to also get the flow of execution.
+
+  Second, propagate priorities.
+  LocalLoadOp a0 = 9 <- want to schedule asap.
+  LocalLoadOp a1 = 6
+  LocalLoadOp a2 = 3
+  LocalLoadOp b0 = 9 <- want to schedule asap.
+  LocalLoadOp b1 = 8
+  LocalLoadOp b2 = 7
+
+  First, assign priorities to DotOps.
+        AB
+  DotOp 00 = 9 <- want to schedule asap.
+  DotOp 01 = 8
+  DotOp 02 = 7
+  DotOp 10 = 6
+  DotOp 11 = 5
+  DotOp 12 = 4
+  DotOp 20 = 3
+  DotOp 21 = 2
+  DotOp 22 = 1
 ******************************************************************************/
-struct SchedHeuristicLocalLoadAdjacentDotOps
-    : public SchedHeuristic<SchedDirection::BottomUp> {
+struct DotCriticalPathPriorityCalculator : public PriorityCalculator {
+
+  DotCriticalPathPriorityCalculator()
+      : PriorityCalculator(SchedDagNodePriorityType::DotCriticalPath) {}
+
+  void calcPriorities() {
+    SchedDagNodePriorityDataType dotPriority = 1;
+    // Prioritize DotOps.
+    for (auto it = dag->nodeList.rbegin(); it != dag->nodeList.rend(); ++it) {
+      SchedDagNode *node = *it;
+      if (isa<triton::DotOp>(node->getOp())) {
+        node->setPriority(SchedDagNodePriorityType::DotCriticalPath,
+                          dotPriority);
+        dotPriority += 1;
+      }
+    }
+
+    // Propagate high priorities up for critical path.
+    for (auto *node : dag->nodeList) {
+      if (isa<triton::DotOp>(node->getOp())) {
+        node->propagateHigherPriorityToParents(
+            SchedDagNodePriorityType::DotCriticalPath);
+      }
+    }
+
+    // Propagate low priorities down for critical path.
+    for (auto it = dag->nodeList.rbegin(); it != dag->nodeList.rend(); ++it) {
+      SchedDagNode *node = *it;
+      if (isa<triton::DotOp>(node->getOp())) {
+        node->propagateLowerPriorityToChildren(
+            SchedDagNodePriorityType::DotCriticalPath);
+      }
+    }
+  }
+};
+
+/******************************************************************************
+  Ideally we want the DotCriticalPath to also be able to label the
+  LocalStoreOps. However LDS semantics make this hard; do we have aliasing
+  information so I can query which LocalStoreOps are needed for a LocalLoadOp.
+
+  Since gpu.barriers enforce that all LocalLoadOps must complete,
+  we can assume that LocalStoreOps are already correctly ordered relative to
+  LocalLoadOps. Here we just want to continue the critical path to specify what
+  is the optimal order of LocalStoreOps, and by consequence the optimal order
+  of LoadOps. Therefore we just want to ensure that LoadOps have the same order.
+
+  TODO(dtanner) Expand this to direct-to-lds.
+  TODO(dtanner) Update this for removing gpu.barriers.
+    For this we will take a LocalLoadOp, determine the dependent LocalStoreOps
+    and continue that propagation.
+******************************************************************************/
+struct LocalStoreCriticalPathPriorityCalculator : public PriorityCalculator {
+
+  LocalStoreCriticalPathPriorityCalculator()
+      : PriorityCalculator(SchedDagNodePriorityType::LocalStoreCriticalPath) {}
+
+  void calcPriorities() {
+    SchedDagNodePriorityDataType priority = 1;
+    for (auto it = dag->nodeList.rbegin(); it != dag->nodeList.rend(); ++it) {
+      SchedDagNode *node = *it;
+      if (isa<triton::gpu::LocalStoreOp>(node->getOp())) {
+        node->setPriority(SchedDagNodePriorityType::LocalStoreCriticalPath,
+                          priority);
+        priority += 1;
+      }
+    }
+
+    // Propagate high priorities up for critical path.
+    for (auto *node : dag->nodeList) {
+      if (isa<triton::gpu::LocalStoreOp>(node->getOp())) {
+        node->propagateHigherPriorityToParents(
+            SchedDagNodePriorityType::LocalStoreCriticalPath);
+      }
+    }
+
+    // Propagate low priorities down for critical path.
+    for (auto it = dag->nodeList.rbegin(); it != dag->nodeList.rend(); ++it) {
+      SchedDagNode *node = *it;
+      if (isa<triton::gpu::LocalStoreOp>(node->getOp())) {
+        node->propagateLowerPriorityToChildren(
+            SchedDagNodePriorityType::LocalStoreCriticalPath);
+      }
+    }
+  }
+};
+
+/*
+  Abstract Base class for scheduling heuristics.
+  E.g. TopDown, schedule LoadOps early and LocalStoreOps late.
+*/
+template <SchedDirection Direction> struct SchedHeuristic {
+  SchedHeuristic(StringRef n) : name(n) {}
+  // Scheduler prints the name of heuristic.
+  StringRef getName() const { return name; }
+  // Scheduler calls before beginning a scheduling pass.
+  virtual void begin() {};
+  // Scheduler calls comparison functor to evaluate ready list.
+  virtual SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) = 0;
+  // Scheduler calls this printer right before evaluating the ready list,
+  // for debugging when the heuristic has state.
+  virtual void dump(llvm::raw_ostream &out) {};
+  // Scheduler allows heuristic to update state based on scheduled op.
+  virtual void selectedOp(SchedDagNode *) {};
+  // Scheduler notifies scheduling is done, for debugging to print final state.
+  virtual void end() {};
+  virtual ~SchedHeuristic() = default;
+  StringRef name;
+};
+
+/******************************************************************************
+  Schedule ops based on priority, which are DotOp and LocalStoreOp critical
+  paths. Priorities themselves have an priority order, Dot is p[0] and
+  LocalStore is p[1]. Therefore, when scheduling TopDown, we first compare
+  based on p[0], and only if they're the same do we examine p[1].
+  This also means that when we schedule BottomUp, not only are we looking for
+  the lowest priority ops first, but we also want to find the lowest
+  p[1] before we look for the lowest p[0].
+******************************************************************************/
+template <SchedDirection Direction>
+struct SchedHeuristicPriority : public SchedHeuristic<Direction> {
+
+  SchedHeuristicPriority() : SchedHeuristic<Direction>("Priority") {}
 
   SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) {
-    // Schedule local loads asap.
-    if (auto selected = findPreferredOpType<triton::gpu::LocalLoadOp>(a, b)) {
-      return selected;
+    uint32_t start = 0;
+    uint32_t stop = static_cast<uint32_t>(SchedDagNodePriorityType::Size);
+    uint32_t incr = 1;
+    if (Direction == SchedDirection::BottomUp) {
+      // Reverse priorities for reversed direction.
+      start = static_cast<uint32_t>(SchedDagNodePriorityType::Size) - 1;
+      stop = -1;
+      incr = -1;
     }
-    // Schedule others that could be in the way of local loads.
-    if (auto selected = findPreferredOpCategory(a, b, opCategoryNop)) {
-      return selected;
+    for (uint32_t i = start; i < stop; i += incr) {
+      SchedDagNodePriorityType priorityType =
+          static_cast<SchedDagNodePriorityType>(i);
+      if (auto selected = findPreferredPriority(
+              a, b, priorityType, Direction == SchedDirection::TopDown)) {
+        return selected;
+      }
     }
-    if (auto selected = findPreferredOpCategory(a, b, opCategoryBarrier)) {
-      return selected;
-    }
-    if (auto selected = findPreferredOpType<triton::gpu::LocalStoreOp>(a, b)) {
+
+    // Fallback to original order.
+    return getOriginalOrder<Direction>(a, b);
+  }
+};
+
+/******************************************************************************
+  Schedule based on MachineModel to reflect resource pipes and data latencies.
+  Note, unlike other heuristics, this one employs prefer=true
+  (rather than prefer=Direction==TopDown) because we always want a good
+  machine state regardless of direction.
+
+  Priority is fallback comparison so that we also stick to the DotOp critical
+  path.
+******************************************************************************/
+template <SchedDirection Direction>
+struct SchedHeuristicMachineModel : public SchedHeuristic<Direction> {
+
+  SchedHeuristicMachineModel()
+      : SchedHeuristic<Direction>("MachineModel"),
+        model(std::make_shared<MachineModelGFX942>()),
+        machine(model.get(), Direction == SchedDirection::TopDown) {}
+
+  void begin() {
+    machine.reset();
+    scheduleCycles.clear();
+  };
+
+  /*
+    First priority is to get to dot.
+  */
+  SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) {
+    // Prefer based on machine state; will select if one cooled down and other
+    // isn't.
+    if (auto selected = findPreferredMachineState(a, b, &machine, true)) {
       return selected;
     }
 
-    // Also delay other memory ops.
-    if (auto selected = findPreferredOpCategory(a, b, opCategoryGlobalStore)) {
-      return selected;
-    }
-    if (auto selected = findPreferredOpCategory(a, b, opCategoryGlobalLoad)) {
-      return selected;
-    }
-
-    // Schedule non-dots, so that all non-dot dependencies are fulfilled
-    // to better guarantee that local loads will be adjacent to dots.
-    if (auto selected = findPreferredOpType<triton::DotOp>(a, b, false)) {
-      return selected;
-    }
-
-    // Final comparison based on orig order.
-    return getOriginalOrder<SchedDirection::BottomUp>(a, b);
+    SchedHeuristicPriority<Direction> shp;
+    return shp(a, b);
   }
 
-  StringRef name() { return "LocalLoadAdjacentDot"; }
+  void selectedOp(SchedDagNode *node) {
+    // MachineModelOpProperties properties =
+    // machine.machineModel->getOpProperties(node->getOp());
+    machine.scheduleOp(node->getOp());
+    scheduleCycles.push_back(std::make_pair(node, machine.getCurrentCycle()));
+    // For anything else (non def/use) that waits, set data dependencies.
+    if constexpr (Direction == SchedDirection::TopDown) {
+      if (opCategoryMem(node)) {
+        for (auto child : node->getChildren()) {
+          if (llvm::isa<mlir::gpu::BarrierOp, mlir::cf::BranchOp>(
+                  child->getOp())) {
+            machine.updateOpDataReady(child->getOp(), node->getOp());
+          }
+        }
+      }
+    } else {
+      if (llvm::isa<mlir::gpu::BarrierOp, mlir::cf::BranchOp>(node->getOp())) {
+        for (auto parent : node->getParents()) {
+          if (opCategoryMem(parent)) {
+            machine.updateOpDataReady(parent->getOp(), node->getOp());
+          }
+        }
+      }
+    }
+  }
+
+  void dump(llvm::raw_ostream &out) { out << "MachineState: " << machine; };
+
+  void end() {
+    LDBG("Machine Schedule Cycles");
+    for (auto entry : scheduleCycles) {
+      LDBG("t=" << entry.second << " " << *entry.first);
+    }
+  }
+
+  std::shared_ptr<MachineModel> model;
+  MachineState machine;
+  SmallVector<std::pair<SchedDagNode *, int32_t>> scheduleCycles;
 };
 
 /******************************************************************************
@@ -1469,21 +1783,22 @@ struct SchedHeuristicLocalLoadAdjacentDotOps
 struct SchedHeuristicOriginalOrder
     : public SchedHeuristic<SchedDirection::TopDown> {
 
+  SchedHeuristicOriginalOrder()
+      : SchedHeuristic<SchedDirection::TopDown>("OriginalOrder") {}
+
   SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) {
     if (auto selected = findPreferredOpCategory(a, b, opCategoryNop)) {
       return selected;
     }
     return getOriginalOrder<SchedDirection::TopDown>(a, b);
   }
-
-  StringRef name() { return "OriginalOrder"; }
 };
 
 /******************************************************************************
-  SchedManager
-  - Tracks dependencies.
+  SchedManager is top-level struct which manipulates the SchedDag:
+  - Add deps and priorities to dag.
   - Prepared dag for scheduling.
-  - Runs scheduler.
+  - Runs scheduling heuristic on the dag.
 ******************************************************************************/
 struct SchedManager {
   SchedManager(Block *block) : dag(block), rescheduleId(0) {}
@@ -1494,51 +1809,38 @@ struct SchedManager {
     depCalc->addDepsToDag(&dag);
   }
 
+  // Calculate new node priorities based on dag.
+  void addPriorities(std::unique_ptr<PriorityCalculator> prioCalc) {
+    prioCalc->addPrioritiesToDag(&dag);
+  }
+
+  // Reschedule the dag.
   template <SchedDirection Direction>
   void reschedule(SchedHeuristic<Direction> *heuristic) {
     LDBG("SchedManager::reschedule("
          << rescheduleId << "), Direction="
          << ((Direction == SchedDirection::TopDown) ? "TopDown" : "BottomUp")
-         << ", Heuristic=" << heuristic->name());
-    // Reset deps right before rescheduling b/c analysis passes
-    // may have altered them.
-    LDBG("dag.resetDeps() before rescheduling");
+         << ", Heuristic=" << heuristic->getName());
+    // Reset deps right before rescheduling b/c analysis passes may have altered
+    // them.
     dag.resetDeps();
-    LDBG("NodeList before reschedule(" << rescheduleId << ")");
-    LLVM_DEBUG(dag.dumpNodes(llvm::dbgs()));
     LDBG("SchedDag before reschedule(" << rescheduleId << ")");
     LLVM_DEBUG(dag.dumpDotFormat(llvm::dbgs()));
 
     // Node readiness is based on direction.
     dag.initReadyNodes<Direction>();
+    heuristic->begin();
 
     // Schedule the dag; this process removes deps from nodes.
     // Store nodes in newly scheduled order.
     SchedDagNodeList rescheduledNodes;
-    const bool printDetails = false;
+    const bool printDetails = rescheduleId > 0;
     for (int iter = 0; !dag.finished(); ++iter) {
-      const auto &readyNodes = dag.getReadyNodes();
-      SchedDagNode *selectedNode = selectFromReadyNodes(readyNodes, heuristic);
-      if (printDetails) {
-        std::string dbgStr;
-        llvm::raw_string_ostream dbgStream(dbgStr);
-        dbgStream << "Iter: " << iter << "\n";
-        dbgStream << "Ready List:\n";
-        for (auto node : readyNodes) {
-          dbgStream << "    " << *node << "\n";
-        }
-        dbgStream << "reschedule(" << rescheduleId
-                  << ") Selected: " << *selectedNode << "\n";
-        LDBG(dbgStream.str());
-      }
-      // Place selected node in list, remove it from dag which updates
-      // readyList.
-      rescheduledNodes.push_back(selectedNode);
-      dag.removeScheduledNode<Direction>(selectedNode);
+      scheduleNextOp<Direction>(heuristic, rescheduledNodes);
     }
+    heuristic->end();
 
     // After scheduling, re-apply deps to prepare for adding additional deps.
-    LDBG("dag.resetDeps() after rescheduling");
     dag.resetDeps();
 
     // Update nodeList after rescheduling.
@@ -1562,6 +1864,36 @@ struct SchedManager {
     rescheduleId++;
   }
 
+  // Single pass of rescheduling the dag.
+  template <SchedDirection Direction>
+  void scheduleNextOp(SchedHeuristic<Direction> *heuristic,
+                      SchedDagNodeList &rescheduledNodes) {
+    const bool printDetails = rescheduleId > 0;
+    // Print ReadyNodes and HeuristicState
+    const auto &readyNodes = dag.getReadyNodes();
+    if (printDetails) {
+      LDBG("Iter: " << rescheduledNodes.size());
+      LDBG("Ready List:");
+      for (auto node : readyNodes) {
+        LDBG("    " << *node);
+      }
+      LLVM_DEBUG(heuristic->dump(llvm::dbgs()));
+      LLVM_DEBUG(llvm::dbgs() << "\n");
+    }
+
+    // Select
+    SchedDagNode *selectedNode = selectFromReadyNodes(readyNodes, heuristic);
+    if (printDetails) {
+      LDBG("Selected: " << *selectedNode);
+    }
+    heuristic->selectedOp(selectedNode);
+
+    // Place selected node in list, remove it from dag which updates
+    // readyList.
+    rescheduledNodes.push_back(selectedNode);
+    dag.removeScheduledNode<Direction>(selectedNode);
+  }
+
   template <SchedDirection Direction>
   SchedDagNode *selectFromReadyNodes(SetVector<SchedDagNode *> readyNodes,
                                      SchedHeuristic<Direction> *heuristic) {
@@ -1583,16 +1915,14 @@ struct SchedManager {
     return opList;
   }
 
-private:
   SchedDag dag;
+  // For debugging only.
   int32_t rescheduleId;
 }; // SchedManager
 
 /******************************************************************************
   TritonAMDGPURescheduleOps::applyReschedulingPasses()
-  Top-level scheduling pass for a single block,
-  whose purpose is to improve ttgir op order, and thereby improve llir op order
-  to help improve scheduling and regalloc of backend compilers.
+  Top-level scheduling pass for a single block.
 ******************************************************************************/
 struct TritonAMDGPURescheduleOps
     : public TritonAMDGPURescheduleOpsBase<TritonAMDGPURescheduleOps> {
@@ -1617,25 +1947,122 @@ struct TritonAMDGPURescheduleOps
     LDBG("TritonAMDGPURescheduleOps::applyReschedulingPasses()");
 
     SchedManager schedManager(mlirBlock);
-    // (0) Add basic deps.
-    schedManager.addDeps(std::make_unique<DataDependencyCalculator>());
-    schedManager.addDeps(std::make_unique<RefinedOpDependencyCalculator>());
 
-    // (1) Considering mfmas are in optimal order, find optimal local_load
-    // order.
-    SchedHeuristicLocalLoadAdjacentDotOps sh0;
-    schedManager.reschedule<SchedDirection::BottomUp>(&sh0);
+    bool dumpGraphs = false;
+    /*
+      Scheduling Pass 0
+      - Dependencies: Data, DotOrder, LocalStoreOrder, Barriers
+      - Priorities: DotCriticalPath, LocalStoreCriticalPath
+      - Heuristic: Priority
+
+      Dependencies accomplish:
+      - Enforced dot relative order.
+      - Enforced LocalStoreOp relative order.
+      Scheduling in order of priority (critical path) accomplishes:
+      - Note that LoadOp are close to LocalStoreOp on purpose.
+      - Determines relative order of LocalLoadOps.
+      - Determines order of tertiary ops to get to the DotOps asap.
+      - Determines the order of LoadOps to match LocalStoreOps.
+    */
+    // Add Data deps based on def-use chains.
+    schedManager.addDeps(std::make_unique<DataDependencyCalculator>());
+    if (dumpGraphs) {
+      LLVM_DEBUG(LDBG("Dag: data");
+                 schedManager.dag.dumpDotFormat(llvm::dbgs()););
+    }
+    // Assume dots are in ideal order and propagate their critical path.
+    schedManager.addDeps(std::make_unique<DotOrderDependencyCalculator>());
+    // Add initial priorities while only data deps exist, before adding other
+    // deps.
+    schedManager.addPriorities(
+        std::make_unique<DotCriticalPathPriorityCalculator>());
+    // Assume LocalStoreOps are in ideal order and propagate their critical
+    // path.
+    schedManager.addDeps(
+        std::make_unique<LocalStoreOrderDependencyCalculator>());
+    schedManager.addPriorities(
+        std::make_unique<LocalStoreCriticalPathPriorityCalculator>());
+    // Add dependencies for barriers (gpu.barrier, sched.barrier, setprio...).
+    schedManager.addDeps(std::make_unique<BarrierDependencyCalculator>());
+    // After creating dependencies for barriers, repeat priority analysis.
+    // This won't override any previous priorities, but for tertiary ops it
+    // determines which are needed to unblock barriers which block other
+    // priorities.
+    schedManager.addPriorities(
+        std::make_unique<DotCriticalPathPriorityCalculator>());
+    schedManager.addPriorities(
+        std::make_unique<LocalStoreCriticalPathPriorityCalculator>());
+    if (dumpGraphs) {
+      LLVM_DEBUG(LDBG("Dag: data, dot:dot, ls:ls, bar:*");
+                 schedManager.dag.dumpDotFormat(llvm::dbgs()););
+    }
+    SchedHeuristicPriority<SchedDirection::TopDown> shp;
+    schedManager.reschedule<SchedDirection::TopDown>(&shp);
+
+    /*
+      Scheduling Pass 1
+      - Dependencies: LocalLoadOrder, GlobalLoadOrder
+      - Priorities: none
+      - Heuristic: MachineModel<BottomUp>
+
+      Dependencies accomplish:
+      - Enforce LocalLoadOp relative order.
+      - Enforce LoadOp relative order.
+      Scheduled in order of MachineModel<BottomUp> accomplishes:
+      - Determines LocalStoreOps before barriers and end of loop.
+      - Spreads LocalStoreOps out.
+      - Determines LocalLoadOps prefetched before DotOps.
+      - Spreads LocalLoadOps out.
+      - Lifts LoadOps as high as possible, which is likely top of block.
+    */
+    // Preserve memory op order determined by critical paths above.
     schedManager.addDeps(
         std::make_unique<LocalLoadOrderDependencyCalculator>());
     schedManager.addDeps(
-        std::make_unique<LocalStoreOrderDependencyCalculator>());
-    schedManager.addDeps(
         std::make_unique<GlobalLoadOrderDependencyCalculator>());
-    schedManager.addDeps(std::make_unique<MemOrderDependencyCalculator>());
+    if (dumpGraphs) {
+      LLVM_DEBUG(LDBG("Dag: data, dot:dot, ls:ls, bar:*, ll:ll, gl:gl");
+                 schedManager.dag.dumpDotFormat(llvm::dbgs()););
+    }
+    // Now that we've ordered lds ops, spread them out with machine model.
+    // This comes first because we want LL and LS as late as possible.
+    // This pass pushes the GL up as high as possible.
+    SchedHeuristicMachineModel<SchedDirection::BottomUp> sh1;
+    schedManager.reschedule<SchedDirection::BottomUp>(&sh1);
 
-    // (F) Final rescheduling restores original order except for dependencies.
-    SchedHeuristicOriginalOrder shOo;
-    schedManager.reschedule<SchedDirection::TopDown>(&shOo);
+    /*
+      Scheduling Pass 2
+      - Dependencies: DotLdsOrder; PriorityOrder
+      - Priorities: 0
+      - Heuristic: EarlyGlobalLoads
+
+      Dependencies accomplish:
+      - Enforce LocalLoadOp relative to DotOps.
+      - Enforce LocalStoreOp relative to DotOps.
+      Scheduled in order of MachineModel<TopDown> accomplishes:
+      - Delays LoadOps until issuing them is hidden by DotOps.
+      - Spreads out LoadOps.
+    */
+    schedManager.addDeps(std::make_unique<DotLdsOrderDependencyCalculator>());
+    if (dumpGraphs) {
+      LLVM_DEBUG(
+          LDBG(
+              "Dag: data, dot:dot, ls:ls, bar:*, ll:ll, gl:gl, ll:dot, ls:dot");
+          schedManager.dag.dumpDotFormat(llvm::dbgs()););
+    }
+    SchedHeuristicMachineModel<SchedDirection::TopDown> sh2;
+    schedManager.reschedule<SchedDirection::TopDown>(&sh2);
+
+    /*
+      TODO(dtanner) - flash-attention (or anything with multiple GL/LS)
+      will need to have some anti-deps to keep some GL after LS so they
+      can use the same registers. This should probably be added after
+      DotLdsOrder dependencies and before the machine model top-down, so that it
+      just delays the LoadOps even further until after the anti-dep.
+      schedManager.addDeps(std::make_unique<LocalStoreGlobalLoadAntiDepsDependencyCalculator>());
+      This is already the beginning of working on this.
+      schedManager.addDeps(std::make_unique<MemOrderDependencyCalculator>());
+    */
 
     LDBG("Rescheduled Ops:");
     SmallVector<Operation *> rescheduledOps = schedManager.getOpList();
@@ -1644,7 +2071,8 @@ struct TritonAMDGPURescheduleOps
       op->print(llvm::dbgs());
       llvm::dbgs() << "\n";
     });
-    // Apply schedule to basic block.
+
+    // Copy scheduled order to basic block.
     for (auto it = rescheduledOps.rbegin(); it != rescheduledOps.rend(); ++it) {
       (*it)->moveBefore(mlirBlock, mlirBlock->begin());
     }
@@ -1665,14 +2093,12 @@ struct TritonAMDGPURescheduleOps
       if (succeeded(verify(block))) {
         LDBG("OpList before applyReschedulingPasses()");
         for (auto it = block->begin(); it != block->end(); ++it) {
-          LLVM_DEBUG((*it).print(llvm::dbgs()));
-          LDBG("");
+          LLVM_DEBUG((*it).print(llvm::dbgs()); llvm::dbgs() << "\n";);
         }
         applyReschedulingPasses(block);
         LDBG("OpList after applyReschedulingPasses()");
         for (auto it = block->begin(); it != block->end(); ++it) {
-          LLVM_DEBUG((*it).print(llvm::dbgs()));
-          LDBG("");
+          LLVM_DEBUG((*it).print(llvm::dbgs()); llvm::dbgs() << "\n";);
         }
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -55,11 +55,69 @@ namespace {
 // TODO (ravil): Note, took function from `SchedInstructions.cpp`.
 // we need to combine these two implementations
 Operation *createSchedBarrier(OpBuilder &rewriter, Location loc,
-                              mlir::amdgpu::sched_barrier_opt_enum maskValue) {
+                              uint32_t maskValue) {
   IntegerAttr mask =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(maskValue));
   return rewriter.create<ROCDL::SchedBarrier>(loc, mask);
 }
+
+/*
+  Bitmasks for sched.barrier(mask). Adding bits to mask allows that op type
+  to cross the barrier. So this mask allows everything to cross.
+  Remove bits later will prevent crossing the barrier.
+  Name mask based on what barrier blocks.
+  This mask has all possible bits turned on except for the non_mem_non_sideffect
+  because it overrides many other bits.
+*/
+uint32_t schedBarMaskBlockNone =
+    0
+    //|static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::none)
+    //|static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect)
+    | static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::salu) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::transcendental);
+
+uint32_t schedBarMaskBlockAll = 0;
+
+uint32_t schedBarMaskBlockDot =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma);
+uint32_t schedBarMaskBlockDsRead =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read);
+uint32_t schedBarMaskBlockDsWrite =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write);
+
+uint32_t schedBarMaskBlockDotLds =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write);
+
+uint32_t schedBarMaskBlockDotLdsGlobal =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write);
+
+uint32_t schedBarMaskBlockGlobal =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write);
 
 enum class SchedDirection { TopDown, BottomUp };
 
@@ -86,7 +144,7 @@ enum class SchedDagNodePriorityType : uint32_t {
   LocalStoreCriticalPath = 1,
   Size // Keep as last to know size().
 };
-using SchedDagNodePriorityDataType = float;
+using SchedDagNodePriorityDataType = int32_t;
 using SchedDagNodePriority =
     SmallVector<SchedDagNodePriorityDataType,
                 static_cast<uint32_t>(SchedDagNodePriorityType::Size)>;
@@ -295,38 +353,58 @@ operator<<(llvm::raw_ostream &out,
 /******************************************************************************
   Categories of ops to facilitate scheduling.
 ******************************************************************************/
-bool opCategoryLoad(SchedDagNode *node) {
+bool nodeCategoryDot(SchedDagNode *node) {
+  Operation *op = node->getOp();
+  return llvm::isa<triton::DotOp>(op);
+}
+
+bool nodeCategoryLocalLoad(SchedDagNode *node) {
+  Operation *op = node->getOp();
+  return llvm::isa<triton::gpu::LocalLoadOp>(op);
+}
+
+bool nodeCategoryLocalStore(SchedDagNode *node) {
+  Operation *op = node->getOp();
+  return llvm::isa<triton::gpu::LocalStoreOp>(op);
+}
+
+bool nodeCategoryLoad(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::LoadOp, triton::gpu::LocalLoadOp,
                    triton::amdgpu::BufferLoadOp>(op);
 }
 
-bool opCategoryStore(SchedDagNode *node) {
+bool nodeCategoryStore(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::StoreOp, triton::gpu::LocalStoreOp>(op);
 }
 
-bool opCategoryMem(SchedDagNode *node) {
-  return opCategoryLoad(node) || opCategoryStore(node);
+bool nodeCategoryMem(SchedDagNode *node) {
+  return nodeCategoryLoad(node) || nodeCategoryStore(node);
 }
 
-bool opCategoryGlobalLoad(SchedDagNode *node) {
+bool nodeCategoryGlobalLoad(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::LoadOp, triton::amdgpu::BufferLoadOp>(op);
 }
 
-bool opCategoryGlobalStore(SchedDagNode *node) {
+bool nodeCategoryGlobalStore(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::StoreOp>(op);
 }
 
-bool opCategoryNop(SchedDagNode *node) {
+bool nodeCategoryGlobal(SchedDagNode *node) {
+  Operation *op = node->getOp();
+  return nodeCategoryGlobalLoad(node) || nodeCategoryGlobalStore(node);
+}
+
+bool nodeCategoryNop(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::gpu::MemDescSubviewOp, triton::gpu::MemDescTransOp,
                    tt::amdgpu::ExtractSliceOp, tt::amdgpu::ConcatOp>(op);
 }
 
-bool opCategoryBarrier(SchedDagNode *node) {
+bool nodeCategoryBarrier(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<mlir::gpu::BarrierOp, ROCDL::SchedBarrier, ROCDL::SetPrioOp>(
       op);
@@ -340,13 +418,13 @@ std::string getNodeColor(SchedDagNode *node) {
     return "yellow";
   } else if (llvm::isa<triton::gpu::LocalStoreOp>(op)) {
     return "orange";
-  } else if (opCategoryGlobalLoad(node)) {
+  } else if (nodeCategoryGlobalLoad(node)) {
     return "red";
-  } else if (opCategoryGlobalStore(node)) {
+  } else if (nodeCategoryGlobalStore(node)) {
     return "green";
-  } else if (opCategoryBarrier(node)) {
+  } else if (nodeCategoryBarrier(node)) {
     return "magenta";
-  } else if (opCategoryNop(node)) {
+  } else if (nodeCategoryNop(node)) {
     return "none";
   } else {
     return "gray80";
@@ -1302,7 +1380,7 @@ struct GlobalLoadOrderDependencyCalculator : DependencyCalculator {
   GlobalLoadOrderDependencyCalculator()
       : DependencyCalculator("GlobalLoadCategoryOrder") {}
   void calcDeps() {
-    calcDepsOpCategory(&dag->nodeList, depSet, opCategoryGlobalLoad);
+    calcDepsOpCategory(&dag->nodeList, depSet, nodeCategoryGlobalLoad);
   }
 };
 
@@ -1355,7 +1433,7 @@ struct MemOrderDependencyCalculator : DependencyCalculator {
     LDBG("Removing non-mem nodes.");
     SchedDagNodeList listCopy = memDag->nodeList;
     for (SchedDagNode *node : listCopy) {
-      if (!opCategoryMem(node) && !isa<triton::DotOp>(node->op)) {
+      if (!nodeCategoryMem(node) && !isa<triton::DotOp>(node->op)) {
         memDag->removeNodeCascadeDeps(node);
       }
     }
@@ -1706,7 +1784,7 @@ struct SchedHeuristicPriority : public SchedHeuristic<Direction> {
   (rather than prefer=Direction==TopDown) because we always want a good
   machine state regardless of direction.
 
-  Priority is fallback comparison so that we also stick to the DotOp critical
+  Fallback comparison is Priority so that we also stick to the DotOp critical
   path.
 ******************************************************************************/
 template <SchedDirection Direction>
@@ -1737,13 +1815,11 @@ struct SchedHeuristicMachineModel : public SchedHeuristic<Direction> {
   }
 
   void selectedOp(SchedDagNode *node) {
-    // MachineModelOpProperties properties =
-    // machine.machineModel->getOpProperties(node->getOp());
     machine.scheduleOp(node->getOp());
     scheduleCycles.push_back(std::make_pair(node, machine.getCurrentCycle()));
     // For anything else (non def/use) that waits, set data dependencies.
     if constexpr (Direction == SchedDirection::TopDown) {
-      if (opCategoryMem(node)) {
+      if (nodeCategoryMem(node)) {
         for (auto child : node->getChildren()) {
           if (llvm::isa<mlir::gpu::BarrierOp, mlir::cf::BranchOp>(
                   child->getOp())) {
@@ -1754,7 +1830,7 @@ struct SchedHeuristicMachineModel : public SchedHeuristic<Direction> {
     } else {
       if (llvm::isa<mlir::gpu::BarrierOp, mlir::cf::BranchOp>(node->getOp())) {
         for (auto parent : node->getParents()) {
-          if (opCategoryMem(parent)) {
+          if (nodeCategoryMem(parent)) {
             machine.updateOpDataReady(parent->getOp(), node->getOp());
           }
         }
@@ -1787,11 +1863,146 @@ struct SchedHeuristicOriginalOrder
       : SchedHeuristic<SchedDirection::TopDown>("OriginalOrder") {}
 
   SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) {
-    if (auto selected = findPreferredOpCategory(a, b, opCategoryNop)) {
+    if (auto selected = findPreferredOpCategory(a, b, nodeCategoryNop)) {
       return selected;
     }
     return getOriginalOrder<SchedDirection::TopDown>(a, b);
   }
+};
+
+/*
+  After scheduling the mlirBlock, we place sched.barriers(mask) to convey
+  certain scheduling constraints to LLVM. E.g., we know one of the Deps passes
+  added deps between LocalLoads and Dots, therefore we iterate through
+  all the adjacent Dots and LocalLoads, and if there exists a dependency for
+  them, we add a sched.barrier(mask=dot|Load); this is only valid since we know
+  that the algorithm which added deps between dots and LocalLoads
+  was ordering ALL dots and ALL local loads, and the sched.barrier
+  prevents ALL from crossing the barrier.
+  The existence of a dep alone does not justify a barrier since a dep
+  only contraints the order of a single parent/child op pair, while
+  a sched.barrier contrains ALL ops above and below, therefore we can
+  only add sched.barriers with knowledge of the AddDeps passes.
+*/
+struct ApplySchedBarriers {
+  ApplySchedBarriers(SchedDag &d, OpBuilder &b) : dag(d), builder(b) {}
+
+  /*
+    Verify parentIter is a parentCategory, then find next node matching
+    childCategory. If parent/child is in deps, then we know we want them
+    ordered. Returns whether a schedBarrier was added.
+  */
+  bool maybeAddSchedBarrier(SchedDagNode **parentIter,
+                            std::function<bool(SchedDagNode *)> parentCategory,
+                            std::function<bool(SchedDagNode *)> childCategory,
+                            const StringRef depTypeName,
+                            uint32_t schedBarMask) {
+    SchedDagNode *parentNode = *parentIter;
+    Operation *op = parentNode->getOp();
+    if (!parentCategory(parentNode)) {
+      return false;
+    }
+    // Find next dot/lds.
+    for (SchedDagNode *const *it = parentIter + 1; it != dag.nodeList.end();
+         it++) {
+      SchedDagNode *childNode = *it;
+      Operation *childOp = childNode->getOp();
+      // Now check for dot/lds
+      if (childCategory(childNode)) {
+        // Check if dep exists.
+        SchedDep dep(parentNode, childNode);
+        if (dag.deps.at(depTypeName).contains(dep)) {
+          auto loc = op->getLoc();
+          builder.setInsertionPointAfter(op);
+          Operation *schedBarOp =
+              createSchedBarrier(builder, loc, schedBarMask);
+          std::shared_ptr<SchedDagNode> schedBarNode =
+              std::make_shared<SchedDagNode>(schedBarOp);
+          dag.nodesHeap.push_back(schedBarNode);
+          // Insert *after* node.
+          LDBG("cap=" << dag.nodeList.capacity()
+                      << ", size=" << dag.nodeList.size()
+                      << ", max=" << dag.nodeList.max_size());
+          LDBG("Inserting parentIter: " << **parentIter);
+          LDBG("Inserting parentIt+1: " << **(parentIter + 1));
+          parentIter = dag.nodeList.insert(parentIter + 1, schedBarNode.get());
+          LDBG("Inserting parentIter: " << **(parentIter) << " (done)");
+          // Skip analyzing the sched.barrier.
+          ++parentIter;
+          return true;
+        } else {
+          // The next child isn't a direct dependent.
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /*
+    For each op, check what sched.barriers should go after it based on the
+    parent/child nodes matching certain categories, and whether the parent/child
+    dep is in the DepSet. Since the masks of sched.barriers can intersect, we
+    first try to use masks with more constraints before falling back to masks
+    which fewer constraints. For example first try adding mask=mfma|ds_read, and
+    if that isn't valid try adding mask=mfma or mask=ds_read
+  */
+  void insertSchedBarriers() {
+    // TODO(dtanner) Had a problem with list getting resizes while inserting;
+    // it caused iterators to become invalidated, even though the implementation
+    // seemed like it should have handled that. Therefore, reserve extra space
+    // for inserting sched.barriers before trying to iterate. The number of
+    // sched.barriers should be < number of ops.
+    dag.nodeList.reserve(dag.nodeList.size() * 3);
+
+    for (auto it = dag.nodeList.begin(); it != dag.nodeList.end(); ++it) {
+      SchedDagNode *node = *it;
+      bool added;
+      // TODO(dtanner) track what category the barrier types adds to add all
+      // needed types but not superfluous.
+
+      // Dot / Lds
+      added = maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
+                                   "DotLdsOrder", schedBarMaskBlockDotLds);
+      if (!added)
+        added = maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
+                                     "DotLdsOrder", schedBarMaskBlockDotLds);
+      if (!added)
+        added =
+            maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalStore,
+                                 "DotLdsOrder", schedBarMaskBlockDotLds);
+      if (!added)
+        added =
+            maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryDot,
+                                 "DotLdsOrder", schedBarMaskBlockDotLds);
+
+      // Dot / Dot
+      if (!added)
+        added = maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot,
+                                     "DotTypeOrder", schedBarMaskBlockDot);
+      // LocalLoad / LocalLoad
+      if (!added)
+        added = maybeAddSchedBarrier(
+            it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
+            "LocalLoadTypeOrder", schedBarMaskBlockDsRead);
+      // LocalStore / LocalStore
+      if (!added)
+        added = maybeAddSchedBarrier(
+            it, nodeCategoryLocalStore, nodeCategoryLocalStore,
+            "LocalStoreTypeOrder", schedBarMaskBlockDsWrite);
+
+      // GlobalLoad / GlobalLoad
+      if (!added)
+        added = maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
+                                     "GlobalLoadCategoryOrder",
+                                     schedBarMaskBlockGlobal);
+      // TODO(dtanner) anchor GlobalLoads with Dots?
+    }
+    LDBG("insertSchedBarriers() - DONE");
+  }
+
+  SchedDag &dag;
+  OpBuilder &builder;
 };
 
 /******************************************************************************
@@ -1801,7 +2012,8 @@ struct SchedHeuristicOriginalOrder
   - Runs scheduling heuristic on the dag.
 ******************************************************************************/
 struct SchedManager {
-  SchedManager(Block *block) : dag(block), rescheduleId(0) {}
+  SchedManager(Block *block, OpBuilder &b)
+      : dag(block), rescheduleId(0), builder(b) {}
 
   // Calculate new deps based on op order and previously determined deps.
   // Insert new deps into dep map and apply them to dat.
@@ -1906,7 +2118,12 @@ struct SchedManager {
     return selected;
   }
 
-  SmallVector<Operation *> getOpList() {
+  void insertSchedBarriers() {
+    ApplySchedBarriers asb(dag, builder);
+    asb.insertSchedBarriers();
+  }
+
+  SmallVector<Operation *> getOpList(bool applySchedBarriers = true) {
     SmallVector<Operation *> opList;
     for (auto node : dag.nodeList) {
       Operation *op = node->getOp();
@@ -1918,6 +2135,7 @@ struct SchedManager {
   SchedDag dag;
   // For debugging only.
   int32_t rescheduleId;
+  OpBuilder &builder;
 }; // SchedManager
 
 /******************************************************************************
@@ -1945,10 +2163,12 @@ struct TritonAMDGPURescheduleOps
 
   void applyReschedulingPasses(Block *mlirBlock) {
     LDBG("TritonAMDGPURescheduleOps::applyReschedulingPasses()");
-
-    SchedManager schedManager(mlirBlock);
-
+    MLIRContext *context = &getContext();
+    OpBuilder builder(&getContext());
+    builder.setInsertionPointToStart(mlirBlock);
+    SchedManager schedManager(mlirBlock, builder);
     bool dumpGraphs = false;
+
     /*
       Scheduling Pass 0
       - Dependencies: Data, DotOrder, LocalStoreOrder, Barriers
@@ -2064,15 +2284,10 @@ struct TritonAMDGPURescheduleOps
       schedManager.addDeps(std::make_unique<MemOrderDependencyCalculator>());
     */
 
-    LDBG("Rescheduled Ops:");
-    SmallVector<Operation *> rescheduledOps = schedManager.getOpList();
-    // Print op (and not node) list.
-    LLVM_DEBUG(for (auto op : rescheduledOps) {
-      op->print(llvm::dbgs());
-      llvm::dbgs() << "\n";
-    });
+    schedManager.insertSchedBarriers();
 
     // Copy scheduled order to basic block.
+    SmallVector<Operation *> rescheduledOps = schedManager.getOpList();
     for (auto it = rescheduledOps.rbegin(); it != rescheduledOps.rend(); ++it) {
       (*it)->moveBefore(mlirBlock, mlirBlock->begin());
     }
@@ -2080,6 +2295,8 @@ struct TritonAMDGPURescheduleOps
   }
 
   void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    OpBuilder b(&getContext());
     ModuleOp mod = getOperation();
     llvm::SmallVector<Block *> blocks;
     mod.walk([&](triton::amdgpu::InstructionSchedHint hint) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -90,6 +90,7 @@ uint32_t schedBarMaskBlockDot =
     schedBarMaskBlockNone ^
     static_cast<uint32_t>(
         mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma);
 uint32_t schedBarMaskBlockDsRead =
     schedBarMaskBlockNone ^
@@ -109,6 +110,7 @@ uint32_t schedBarMaskBlockDotLds =
     schedBarMaskBlockNone ^
     static_cast<uint32_t>(
         mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
@@ -118,6 +120,7 @@ uint32_t schedBarMaskBlockDotGlobal =
     schedBarMaskBlockNone ^
     static_cast<uint32_t>(
         mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -70,10 +70,9 @@ Operation *createSchedBarrier(OpBuilder &rewriter, Location loc,
   because it overrides many other bits.
 */
 uint32_t schedBarMaskBlockNone =
-    0
-    //|static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::none)
-    //|static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect)
-    | static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::none) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) |
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::salu) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) |
@@ -88,16 +87,20 @@ uint32_t schedBarMaskBlockAll = 0;
 
 uint32_t schedBarMaskBlockDot =
     schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma);
 uint32_t schedBarMaskBlockDsRead =
     schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read);
 uint32_t schedBarMaskBlockDsWrite =
     schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write);
 
 uint32_t schedBarMaskBlockDotLds =
     schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
@@ -105,6 +108,7 @@ uint32_t schedBarMaskBlockDotLds =
 
 uint32_t schedBarMaskBlockDotLdsGlobal =
     schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -545,6 +545,12 @@ struct SchedDag {
     assert(false);
   }
 
+  ~SchedDag() {
+    for (SchedDagNode *node : nodeList) {
+      delete node;
+    }
+  }
+
   void addOp(Operation *op) {
     SchedDagNode *node = new SchedDagNode(op);
     nodeMap.insert({op, node});
@@ -806,12 +812,6 @@ struct SchedDag {
     return out;
   }
 
-  ~SchedDag() {
-    for (SchedDagNode *node : nodeList) {
-      delete node;
-    }
-  }
-
   SchedDagNodeList nodeList;
   DepMap deps;
   OpNodeMap nodeMap;
@@ -824,6 +824,7 @@ struct SchedDag {
 ******************************************************************************/
 struct DependencyCalculator {
   DependencyCalculator(StringRef depTypeName) : depTypeName(depTypeName) {}
+  virtual ~DependencyCalculator() = default;
 
   virtual void calcDeps() = 0;
 
@@ -835,7 +836,6 @@ struct DependencyCalculator {
     calcDeps();
     dag->addDeps(depTypeName, depSet);
   }
-  virtual ~DependencyCalculator() = default;
 
   StringRef depTypeName;
   SchedDag *dag;
@@ -1589,6 +1589,7 @@ SchedDagNode *getOriginalOrder(SchedDagNode *a, SchedDagNode *b) {
 struct PriorityCalculator {
   PriorityCalculator(SchedDagNodePriorityType priorityType)
       : priorityType(priorityType) {}
+  virtual ~PriorityCalculator() = default;
 
   virtual void calcPriorities() = 0;
 
@@ -1598,7 +1599,6 @@ struct PriorityCalculator {
     dag = inputDag;
     calcPriorities();
   }
-  virtual ~PriorityCalculator() = default;
 
   SchedDagNodePriorityType priorityType;
   SchedDag *dag;
@@ -1730,10 +1730,11 @@ struct LocalStoreCriticalPathPriorityCalculator : public PriorityCalculator {
 */
 template <SchedDirection Direction> struct SchedHeuristic {
   SchedHeuristic(StringRef name) : name(name) {}
+  virtual ~SchedHeuristic() = default;
   // Scheduler prints the name of heuristic.
   StringRef getName() const { return name; }
-  // Scheduler calls before beginning a scheduling pass.
-  virtual void begin() {};
+  // Scheduler calls before starting a scheduling pass.
+  virtual void start() {};
   // Scheduler calls comparison functor to evaluate ready list.
   virtual SchedDagNode *operator()(SchedDagNode *a, SchedDagNode *b) = 0;
   // Scheduler calls this printer right before evaluating the ready list,
@@ -1742,8 +1743,7 @@ template <SchedDirection Direction> struct SchedHeuristic {
   // Scheduler allows heuristic to update state based on scheduled op.
   virtual void selectedOp(SchedDagNode *) {};
   // Scheduler notifies scheduling is done, for debugging to print final state.
-  virtual void end() {};
-  virtual ~SchedHeuristic() = default;
+  virtual void stop() {};
   StringRef name;
 };
 
@@ -1802,7 +1802,7 @@ struct SchedHeuristicMachineModel : public SchedHeuristic<Direction> {
         model(std::make_shared<MachineModelGFX942>()),
         machine(model.get(), Direction == SchedDirection::TopDown) {}
 
-  void begin() {
+  void start() {
     machine.reset();
     scheduleCycles.clear();
   };
@@ -1847,7 +1847,7 @@ struct SchedHeuristicMachineModel : public SchedHeuristic<Direction> {
 
   void dump(llvm::raw_ostream &out) { out << "MachineState: " << machine; };
 
-  void end() {
+  void stop() {
     LDBG("Machine Schedule Cycles");
     for (auto entry : scheduleCycles) {
       LDBG("t=" << entry.second << " " << *entry.first);
@@ -2034,7 +2034,7 @@ struct SchedManager {
          << rescheduleId << "), Direction="
          << ((Direction == SchedDirection::TopDown) ? "TopDown" : "BottomUp")
          << ", Heuristic=" << heuristic->getName());
-    const bool printDetails = false; // rescheduleId >= 1;
+    const bool printDetails = false;
     // Reset deps right before rescheduling b/c analysis passes may have altered
     // them.
     dag.resetDeps();
@@ -2044,7 +2044,7 @@ struct SchedManager {
     }
     // Node readiness is based on direction.
     dag.initReadyNodes<Direction>();
-    heuristic->begin();
+    heuristic->start();
 
     // Schedule the dag; this process removes deps from nodes.
     // Store nodes in newly scheduled order.
@@ -2052,7 +2052,7 @@ struct SchedManager {
     for (int iter = 0; !dag.finished(); ++iter) {
       scheduleNextOp<Direction>(heuristic, rescheduledNodes, printDetails);
     }
-    heuristic->end();
+    heuristic->stop();
 
     // After scheduling, re-apply deps to prepare for adding additional deps.
     dag.resetDeps();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -146,7 +146,7 @@ enum class SchedDirection { TopDown, BottomUp };
 enum class SchedDagNodePriorityType : uint32_t {
   DotCriticalPath = 0,
   LocalStoreCriticalPath = 1,
-  Size // Keep as last to know size().
+  Size
 };
 using SchedDagNodePriorityDataType = int32_t;
 using SchedDagNodePriority =
@@ -870,15 +870,6 @@ struct DataDependencyCalculator : DependencyCalculator {
 
 /******************************************************************************
   Creates dependencies based on various barriers.
-  TODO(dtanner) may need to add support for below ops
-  triton::gpu::AsyncWaitOp
-  triton::nvidia_gpu::TMAStoreWaitOp
-  triton::nvidia_gpu::ArriveBarrierOp
-  MemoryEffects::Write
-  MemoryEffects::Read
-  triton::CallOp
-  triton::gpu::LocalAllocOp
-  triton::gpu::LocalDeallocOp
 ******************************************************************************/
 struct BarrierDependencyCalculator : DependencyCalculator {
   BarrierDependencyCalculator() : DependencyCalculator("Barrier") {}
@@ -1344,11 +1335,11 @@ void calcDepsOpType(SchedDagNodeList *nodeList, DepSet &depSet) {
 
 // Add deps between ops of same category.
 void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
-                        std::function<bool(SchedDagNode *)> category) {
+                        std::function<bool(SchedDagNode *)> isCategory) {
   SchedDagNode *prevNode = nullptr;
   int32_t prevId = -1;
   for (auto node : *nodeList) {
-    if (category(node)) {
+    if (isCategory(node)) {
       if (prevNode) {
         SchedDep dep;
         dep.parent = prevNode;
@@ -1601,10 +1592,10 @@ struct PriorityCalculator {
 
   virtual void calcPriorities() = 0;
 
-  void addPrioritiesToDag(SchedDag *d) {
+  void addPrioritiesToDag(SchedDag *inputDag) {
     LDBG("PriorityCalculator<" << toString(priorityType)
                                << ">::addPrioritiesToDag()");
-    dag = d;
+    dag = inputDag;
     calcPriorities();
   }
   virtual ~PriorityCalculator() = default;
@@ -2300,8 +2291,7 @@ struct TritonAMDGPURescheduleOps
                       "ls:dot, gl:dot");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
-    if (true)
-      schedManager.insertSchedBarriers();
+    schedManager.insertSchedBarriers();
 
     // Copy scheduled order to basic block.
     SmallVector<Operation *> rescheduledOps = schedManager.getOpList();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -438,7 +438,8 @@ struct SchedDep {
   SchedDagNode *child;
 
   SchedDep() = default;
-  SchedDep(SchedDagNode *p, SchedDagNode *c) : parent(p), child(c) {}
+  SchedDep(SchedDagNode *parent, SchedDagNode *child)
+      : parent(parent), child(child) {}
 
   llvm::raw_ostream &dump(llvm::raw_ostream &out) const {
     out << "p=" << parent->id << " <- c=" << child->id;
@@ -536,8 +537,7 @@ struct SchedDag {
 
   // Deep copy constructor; used for memory analysis.
   SchedDag(const SchedDag &dag)
-      : nodeList(dag.nodeList), deps(dag.deps),
-        nodeMap(dag.nodeMap) {
+      : nodeList(dag.nodeList), deps(dag.deps), nodeMap(dag.nodeMap) {
     // TODO(dtanner) - this needs to create new nodes on the heap
     // for nodeList, then reconstruct deps and nodeMap with
     // the new pointers.
@@ -823,7 +823,7 @@ struct SchedDag {
   as well as all previously applied deps.
 ******************************************************************************/
 struct DependencyCalculator {
-  DependencyCalculator(StringRef name) : depTypeName(name) {}
+  DependencyCalculator(StringRef depTypeName) : depTypeName(depTypeName) {}
 
   virtual void calcDeps() = 0;
 
@@ -870,11 +870,10 @@ struct DataDependencyCalculator : DependencyCalculator {
 
 /******************************************************************************
   Creates dependencies based on various barriers.
-  TODO(dtanner) need to add support for below?
+  TODO(dtanner) may need to add support for below ops
   triton::gpu::AsyncWaitOp
   triton::nvidia_gpu::TMAStoreWaitOp
   triton::nvidia_gpu::ArriveBarrierOp
-  RegionBranchOpInterface ?
   MemoryEffects::Write
   MemoryEffects::Read
   triton::CallOp
@@ -1363,13 +1362,13 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
 
 // Add deps between ops of different categories.
 void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
-                        std::function<bool(SchedDagNode *)> categoryA,
-                        std::function<bool(SchedDagNode *)> categoryB) {
+                        std::function<bool(SchedDagNode *)> isCategoryA,
+                        std::function<bool(SchedDagNode *)> isCategoryB) {
   SchedDagNode *prevA = nullptr;
   SchedDagNode *prevB = nullptr;
 
   for (auto node : *nodeList) {
-    if (categoryA(node)) {
+    if (isCategoryA(node)) {
       if (prevB) {
         SchedDep dep;
         dep.parent = prevB;
@@ -1377,7 +1376,7 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
         depSet.insert(dep);
       }
       prevA = node;
-    } else if (categoryB(node)) {
+    } else if (isCategoryB(node)) {
       if (prevA) {
         SchedDep dep;
         dep.parent = prevA;
@@ -1517,79 +1516,72 @@ struct MemOrderDependencyCalculator : DependencyCalculator {
   then move on to the next comparison.
 ******************************************************************************/
 
-// Prefer based on node priority.
-bool preferPriority(SchedDagNode *a, SchedDagNode *b,
-                    SchedDagNodePriorityType priorityType, bool prefer = true) {
-  if (a->hasPriority(priorityType)) {
-    if (b->hasPriority(priorityType)) {
-      return (a->getPriority(priorityType) > b->getPriority(priorityType)) ==
-             prefer;
-    }
-    return prefer;
-  }
-  if (b->hasPriority(priorityType)) {
-    return !prefer;
-  }
-  return false;
-}
-SchedDagNode *findPreferredPriority(SchedDagNode *a, SchedDagNode *b,
+// Prefer based on node priority, i.e. critical path.
+SchedDagNode *findPreferredPriority(SchedDagNode *lhs, SchedDagNode *rhs,
                                     SchedDagNodePriorityType priorityType,
                                     bool prefer = true) {
-  if (preferPriority(a, b, priorityType, prefer)) {
-    return a;
-  } else if (preferPriority(b, a, priorityType, prefer)) {
-    return b;
-  }
+  auto preferPriority = [&](SchedDagNode *a, SchedDagNode *b) -> bool {
+    if (a->hasPriority(priorityType)) {
+      if (b->hasPriority(priorityType)) {
+        return (a->getPriority(priorityType) > b->getPriority(priorityType)) ==
+               prefer;
+      }
+      return prefer;
+    }
+    if (b->hasPriority(priorityType)) {
+      return !prefer;
+    }
+    return false;
+  };
+
+  if (preferPriority(lhs, rhs))
+    return lhs;
+  if (preferPriority(rhs, lhs))
+    return rhs;
   return nullptr;
 }
 
-// Prefer based on op type.
+// Prefer based on op type; meaning one is optype AND other isn't.
 template <typename OpType>
-bool preferOpType(SchedDagNode *a, SchedDagNode *b, bool prefer = true) {
-  return (llvm::isa<OpType>(a->getOp()) and !llvm::isa<OpType>(b->getOp())) ==
-         prefer;
-}
-template <typename OpType>
-SchedDagNode *findPreferredOpType(SchedDagNode *a, SchedDagNode *b,
+SchedDagNode *findPreferredOpType(SchedDagNode *lhs, SchedDagNode *rhs,
                                   bool prefer = true) {
-  if (preferOpType<OpType>(a, b, prefer)) {
-    return a;
-  } else if (preferOpType<OpType>(b, a, prefer)) {
-    return b;
-  }
+  auto preferOpType = [&](SchedDagNode *a, SchedDagNode *b) -> bool {
+    return (llvm::isa<OpType>(a->getOp()) and !llvm::isa<OpType>(b->getOp())) ==
+           prefer;
+  };
+  if (preferOpType(lhs, rhs))
+    return lhs;
+  if (preferOpType(rhs, lhs))
+    return rhs;
   return nullptr;
 }
 
-// Prefer based on op category (functions).
-bool preferOpCategory(SchedDagNode *a, SchedDagNode *b,
-                      bool (*category)(SchedDagNode *), bool prefer = true) {
-  return (category(a) and !category(b)) == prefer;
-}
-SchedDagNode *findPreferredOpCategory(SchedDagNode *a, SchedDagNode *b,
-                                      bool (*category)(SchedDagNode *),
+// Prefer based on op category.
+SchedDagNode *findPreferredOpCategory(SchedDagNode *lhs, SchedDagNode *rhs,
+                                      bool (*isCategory)(SchedDagNode *),
                                       bool prefer = true) {
-  if (preferOpCategory(a, b, category, prefer)) {
-    return a;
-  } else if (preferOpCategory(b, a, category, prefer)) {
-    return b;
-  }
+  auto preferOpCategory = [&](SchedDagNode *a, SchedDagNode *b) -> bool {
+    return (isCategory(a) and !isCategory(b)) == prefer;
+  };
+  if (preferOpCategory(lhs, rhs))
+    return lhs;
+  if (preferOpCategory(rhs, lhs))
+    return rhs;
   return nullptr;
 }
 
 // Prefer based on machine state.
-bool preferMachineState(SchedDagNode *a, SchedDagNode *b, MachineState *machine,
-                        bool prefer = true) {
-  return (machine->getCyclesUntilOpReady(a->getOp()) <
-          machine->getCyclesUntilOpReady(b->getOp())) == prefer;
-}
-SchedDagNode *findPreferredMachineState(SchedDagNode *a, SchedDagNode *b,
+SchedDagNode *findPreferredMachineState(SchedDagNode *lhs, SchedDagNode *rhs,
                                         MachineState *machine,
                                         bool prefer = true) {
-  if (preferMachineState(a, b, machine, prefer)) {
-    return a;
-  } else if (preferMachineState(b, a, machine, prefer)) {
-    return b;
-  }
+  auto preferMachineState = [&](SchedDagNode *a, SchedDagNode *b) -> bool {
+    return (machine->getCyclesUntilOpReady(a->getOp()) <
+            machine->getCyclesUntilOpReady(b->getOp())) == prefer;
+  };
+  if (preferMachineState(lhs, rhs))
+    return lhs;
+  if (preferMachineState(rhs, lhs))
+    return rhs;
   return nullptr;
 }
 
@@ -1604,7 +1596,8 @@ SchedDagNode *getOriginalOrder(SchedDagNode *a, SchedDagNode *b) {
   and set scheduling priorities to nodes.
 ******************************************************************************/
 struct PriorityCalculator {
-  PriorityCalculator(SchedDagNodePriorityType type) : priorityType(type) {}
+  PriorityCalculator(SchedDagNodePriorityType priorityType)
+      : priorityType(priorityType) {}
 
   virtual void calcPriorities() = 0;
 
@@ -1745,7 +1738,7 @@ struct LocalStoreCriticalPathPriorityCalculator : public PriorityCalculator {
   E.g. TopDown, schedule LoadOps early and LocalStoreOps late.
 */
 template <SchedDirection Direction> struct SchedHeuristic {
-  SchedHeuristic(StringRef n) : name(n) {}
+  SchedHeuristic(StringRef name) : name(name) {}
   // Scheduler prints the name of heuristic.
   StringRef getName() const { return name; }
   // Scheduler calls before beginning a scheduling pass.
@@ -1908,7 +1901,8 @@ struct SchedHeuristicOriginalOrder
   only add sched.barriers with knowledge of the AddDeps passes.
 */
 struct ApplySchedBarriers {
-  ApplySchedBarriers(SchedDag &d, OpBuilder &b) : dag(d), builder(b) {}
+  ApplySchedBarriers(SchedDag &dag, OpBuilder &builder)
+      : dag(dag), builder(builder) {}
 
   /*
     Verify parentIter is a parentCategory, then find next node matching
@@ -1938,8 +1932,7 @@ struct ApplySchedBarriers {
           builder.setInsertionPointAfter(op);
           Operation *schedBarOp =
               createSchedBarrier(builder, loc, schedBarMask);
-          SchedDagNode *schedBarNode =
-              new SchedDagNode(schedBarOp);
+          SchedDagNode *schedBarNode = new SchedDagNode(schedBarOp);
           parentIter = dag.nodeList.insert(parentIter + 1, schedBarNode);
           ++parentIter;
           return true;
@@ -2029,8 +2022,8 @@ struct ApplySchedBarriers {
   - Runs scheduling heuristic on the dag.
 ******************************************************************************/
 struct SchedManager {
-  SchedManager(Block *block, OpBuilder &b)
-      : dag(block), rescheduleId(0), builder(b) {}
+  SchedManager(Block *block, OpBuilder &builder)
+      : dag(block), rescheduleId(0), builder(builder) {}
 
   // Calculate new deps based on op order and previously determined deps.
   // Insert new deps into dep map and apply them to dat.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -20,7 +20,7 @@
 // #define LLVM_DEBUG(X) X
 
 #undef DEBUG_TYPE
-#define DEBUG_TYPE "tritonamdgpu-reschedule"
+#define DEBUG_TYPE "tritonamdgpu-reschedule-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
@@ -71,7 +71,8 @@ Operation *createSchedBarrier(OpBuilder &rewriter, Location loc,
 */
 uint32_t schedBarMaskBlockNone =
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::none) |
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) |
+    static_cast<uint32_t>(
+        mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::valu) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::salu) |
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) |
@@ -87,7 +88,8 @@ uint32_t schedBarMaskBlockAll = 0;
 
 uint32_t schedBarMaskBlockDot =
     schedBarMaskBlockNone ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(
+        mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma);
 uint32_t schedBarMaskBlockDsRead =
     schedBarMaskBlockNone ^
@@ -97,28 +99,26 @@ uint32_t schedBarMaskBlockDsWrite =
     schedBarMaskBlockNone ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write);
+uint32_t schedBarMaskBlockGlobal =
+    schedBarMaskBlockNone ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^
+    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write);
 
 uint32_t schedBarMaskBlockDotLds =
     schedBarMaskBlockNone ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(
+        mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write);
 
-uint32_t schedBarMaskBlockDotLdsGlobal =
+uint32_t schedBarMaskBlockDotGlobal =
     schedBarMaskBlockNone ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
+    static_cast<uint32_t>(
+        mlir::amdgpu::sched_barrier_opt_enum::non_mem_non_sideffect) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_ds) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_read) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::ds_write) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^
-    static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write);
-
-uint32_t schedBarMaskBlockGlobal =
-    schedBarMaskBlockNone ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::all_vmem) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_read) ^
     static_cast<uint32_t>(mlir::amdgpu::sched_barrier_opt_enum::vmem_write);
@@ -370,6 +370,10 @@ bool nodeCategoryLocalLoad(SchedDagNode *node) {
 bool nodeCategoryLocalStore(SchedDagNode *node) {
   Operation *op = node->getOp();
   return llvm::isa<triton::gpu::LocalStoreOp>(op);
+}
+
+bool nodeCategoryLds(SchedDagNode *node) {
+  return nodeCategoryLocalLoad(node) || nodeCategoryLocalStore(node);
 }
 
 bool nodeCategoryLoad(SchedDagNode *node) {
@@ -778,11 +782,13 @@ struct SchedDag {
     format["Barrier"] = std::make_pair("gray90", "dotted");
     format["RefinedOrder"] = std::make_pair("gray50", "dotted");
     format["Data"] = std::make_pair("black", "dotted");
-    format["LocalLoadTypeOrder"] = std::make_pair("darkgreen", "solid");
-    format["LocalStoreTypeOrder"] = std::make_pair("darkgreen", "solid");
-    format["GlobalLoadCategoryOrder"] = std::make_pair("darkgreen", "solid");
-    format["MemOrder"] = std::make_pair("blue", "solid");
-    format["MemInterleave"] = std::make_pair("red", "solid");
+    format["LocalLoadOrder"] = std::make_pair("darkgreen", "solid");
+    format["LocalStoreOrder"] = std::make_pair("darkgreen", "solid");
+    format["GlobalLoadOrder"] = std::make_pair("darkgreen", "solid");
+    format["DotLdsOrder"] = std::make_pair("red", "solid");
+    format["DotGlobalOrder"] = std::make_pair("blue", "solid");
+    // format["MemOrder"] = std::make_pair("blue", "solid");
+    // format["MemInterleave"] = std::make_pair("red", "solid");
 
     for (auto &depType : deps) {
       StringRef depTypeName = depType.getFirst();
@@ -1341,12 +1347,12 @@ void calcDepsOpType(SchedDagNodeList *nodeList, DepSet &depSet) {
   }
 }
 
+// Add deps between ops of same category.
 void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
                         std::function<bool(SchedDagNode *)> category) {
   SchedDagNode *prevNode = nullptr;
   int32_t prevId = -1;
-  for (auto it = nodeList->begin(); it != nodeList->end(); ++it) {
-    SchedDagNode *node = *it;
+  for (auto node : *nodeList) {
     if (category(node)) {
       if (prevNode) {
         SchedDep dep;
@@ -1359,14 +1365,42 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
   }
 }
 
+// Add deps between ops of different categories.
+void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
+                        std::function<bool(SchedDagNode *)> categoryA,
+                        std::function<bool(SchedDagNode *)> categoryB) {
+  SchedDagNode *prevA = nullptr;
+  SchedDagNode *prevB = nullptr;
+
+  for (auto node : *nodeList) {
+    if (categoryA(node)) {
+      if (prevB) {
+        SchedDep dep;
+        dep.parent = prevB;
+        dep.child = node;
+        depSet.insert(dep);
+      }
+      prevA = node;
+    } else if (categoryB(node)) {
+      if (prevA) {
+        SchedDep dep;
+        dep.parent = prevA;
+        dep.child = node;
+        depSet.insert(dep);
+      }
+      prevB = node;
+    }
+  }
+}
+
 struct DotOrderDependencyCalculator : DependencyCalculator {
-  DotOrderDependencyCalculator() : DependencyCalculator("DotTypeOrder") {}
+  DotOrderDependencyCalculator() : DependencyCalculator("DotOrder") {}
   void calcDeps() { calcDepsOpType<triton::DotOp>(&dag->nodeList, depSet); }
 };
 
 struct LocalLoadOrderDependencyCalculator : DependencyCalculator {
   LocalLoadOrderDependencyCalculator()
-      : DependencyCalculator("LocalLoadTypeOrder") {}
+      : DependencyCalculator("LocalLoadOrder") {}
   void calcDeps() {
     calcDepsOpType<triton::gpu::LocalLoadOp>(&dag->nodeList, depSet);
   }
@@ -1374,7 +1408,7 @@ struct LocalLoadOrderDependencyCalculator : DependencyCalculator {
 
 struct LocalStoreOrderDependencyCalculator : DependencyCalculator {
   LocalStoreOrderDependencyCalculator()
-      : DependencyCalculator("LocalStoreTypeOrder") {}
+      : DependencyCalculator("LocalStoreOrder") {}
   void calcDeps() {
     calcDepsOpType<triton::gpu::LocalStoreOp>(&dag->nodeList, depSet);
   }
@@ -1382,16 +1416,24 @@ struct LocalStoreOrderDependencyCalculator : DependencyCalculator {
 
 struct GlobalLoadOrderDependencyCalculator : DependencyCalculator {
   GlobalLoadOrderDependencyCalculator()
-      : DependencyCalculator("GlobalLoadCategoryOrder") {}
+      : DependencyCalculator("GlobalLoadOrder") {}
   void calcDeps() {
     calcDepsOpCategory(&dag->nodeList, depSet, nodeCategoryGlobalLoad);
   }
 };
 
 /******************************************************************************
-  Create order dependencies between ops which were refined from same original
-  op.
+  Add deps between dot ops and lds ops.
 ******************************************************************************/
+struct DotLdsOrderDependencyCalculator : DependencyCalculator {
+  DotLdsOrderDependencyCalculator() : DependencyCalculator("DotLdsOrder") {}
+  void calcDeps() {
+    calcDepsOpCategory(&dag->nodeList, depSet, nodeCategoryDot,
+                       nodeCategoryLds);
+  }
+};
+
+#if 0
 struct DotLdsOrderDependencyCalculator : DependencyCalculator {
   DotLdsOrderDependencyCalculator() : DependencyCalculator("DotLdsOrder") {}
 
@@ -1400,8 +1442,7 @@ struct DotLdsOrderDependencyCalculator : DependencyCalculator {
     SchedDagNode *prevLds = nullptr;
 
     for (auto node : dag->nodeList) {
-      if (isa<triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(
-              node->getOp())) {
+      if (nodeCategoryLds(node)) {
         if (prevDot) {
           SchedDep dep;
           dep.parent = prevDot;
@@ -1419,6 +1460,19 @@ struct DotLdsOrderDependencyCalculator : DependencyCalculator {
         prevDot = node;
       }
     }
+  }
+};
+#endif
+
+/******************************************************************************
+  Add deps between dot ops and global ops.
+******************************************************************************/
+struct DotGlobalOrderDependencyCalculator : DependencyCalculator {
+  DotGlobalOrderDependencyCalculator()
+      : DependencyCalculator("DotGlobalOrder") {}
+  void calcDeps() {
+    calcDepsOpCategory(&dag->nodeList, depSet, nodeCategoryDot,
+                       nodeCategoryGlobalLoad);
   }
 };
 
@@ -1906,12 +1960,11 @@ struct ApplySchedBarriers {
     if (!parentCategory(parentNode)) {
       return false;
     }
-    // Find next dot/lds.
+    // Find next op matching childCategory.
     for (SchedDagNode *const *it = parentIter + 1; it != dag.nodeList.end();
          it++) {
       SchedDagNode *childNode = *it;
       Operation *childOp = childNode->getOp();
-      // Now check for dot/lds
       if (childCategory(childNode)) {
         // Check if dep exists.
         SchedDep dep(parentNode, childNode);
@@ -1923,15 +1976,7 @@ struct ApplySchedBarriers {
           std::shared_ptr<SchedDagNode> schedBarNode =
               std::make_shared<SchedDagNode>(schedBarOp);
           dag.nodesHeap.push_back(schedBarNode);
-          // Insert *after* node.
-          LDBG("cap=" << dag.nodeList.capacity()
-                      << ", size=" << dag.nodeList.size()
-                      << ", max=" << dag.nodeList.max_size());
-          LDBG("Inserting parentIter: " << **parentIter);
-          LDBG("Inserting parentIt+1: " << **(parentIter + 1));
           parentIter = dag.nodeList.insert(parentIter + 1, schedBarNode.get());
-          LDBG("Inserting parentIter: " << **(parentIter) << " (done)");
-          // Skip analyzing the sched.barrier.
           ++parentIter;
           return true;
         } else {
@@ -1940,7 +1985,7 @@ struct ApplySchedBarriers {
         }
       }
     }
-    return true;
+    return false;
   }
 
   /*
@@ -1961,46 +2006,50 @@ struct ApplySchedBarriers {
 
     for (auto it = dag.nodeList.begin(); it != dag.nodeList.end(); ++it) {
       SchedDagNode *node = *it;
-      bool added;
-      // TODO(dtanner) track what category the barrier types adds to add all
-      // needed types but not superfluous.
 
       // Dot / Lds
-      added = maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
-                                   "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!added)
-        added = maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
-                                     "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!added)
-        added =
+      bool addedDotLds =
+          maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
+                               "DotLdsOrder", schedBarMaskBlockDotLds);
+      if (!addedDotLds)
+        addedDotLds =
+            maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
+                                 "DotLdsOrder", schedBarMaskBlockDotLds);
+      if (!addedDotLds)
+        addedDotLds =
             maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalStore,
                                  "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!added)
-        added =
+      if (!addedDotLds)
+        addedDotLds =
             maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryDot,
                                  "DotLdsOrder", schedBarMaskBlockDotLds);
 
+      // Dot / GlobalLoad
+      bool addedDotGlobal =
+          maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryGlobal,
+                               "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+      if (!addedDotGlobal)
+        addedDotGlobal =
+            maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryDot,
+                                 "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+
       // Dot / Dot
-      if (!added)
-        added = maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot,
-                                     "DotTypeOrder", schedBarMaskBlockDot);
+      if (!addedDotLds && !addedDotGlobal)
+        maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot, "DotOrder",
+                             schedBarMaskBlockDot);
       // LocalLoad / LocalLoad
-      if (!added)
-        added = maybeAddSchedBarrier(
-            it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
-            "LocalLoadTypeOrder", schedBarMaskBlockDsRead);
+      if (!addedDotLds)
+        maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
+                             "LocalLoadOrder", schedBarMaskBlockDsRead);
       // LocalStore / LocalStore
-      if (!added)
-        added = maybeAddSchedBarrier(
-            it, nodeCategoryLocalStore, nodeCategoryLocalStore,
-            "LocalStoreTypeOrder", schedBarMaskBlockDsWrite);
+      if (!addedDotLds)
+        maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryLocalStore,
+                             "LocalStoreOrder", schedBarMaskBlockDsWrite);
 
       // GlobalLoad / GlobalLoad
-      if (!added)
-        added = maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
-                                     "GlobalLoadCategoryOrder",
-                                     schedBarMaskBlockGlobal);
-      // TODO(dtanner) anchor GlobalLoads with Dots?
+      if (!addedDotGlobal)
+        maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
+                             "GlobalLoadOrder", schedBarMaskBlockGlobal);
     }
     LDBG("insertSchedBarriers() - DONE");
   }
@@ -2037,12 +2086,14 @@ struct SchedManager {
          << rescheduleId << "), Direction="
          << ((Direction == SchedDirection::TopDown) ? "TopDown" : "BottomUp")
          << ", Heuristic=" << heuristic->getName());
+    const bool printDetails = false; // rescheduleId >= 1;
     // Reset deps right before rescheduling b/c analysis passes may have altered
     // them.
     dag.resetDeps();
-    LDBG("SchedDag before reschedule(" << rescheduleId << ")");
-    LLVM_DEBUG(dag.dumpDotFormat(llvm::dbgs()));
-
+    if (printDetails) {
+      LDBG("SchedDag before reschedule(" << rescheduleId << ")");
+      LLVM_DEBUG(dag.dumpDotFormat(llvm::dbgs()));
+    }
     // Node readiness is based on direction.
     dag.initReadyNodes<Direction>();
     heuristic->begin();
@@ -2050,9 +2101,8 @@ struct SchedManager {
     // Schedule the dag; this process removes deps from nodes.
     // Store nodes in newly scheduled order.
     SchedDagNodeList rescheduledNodes;
-    const bool printDetails = rescheduleId > 0;
     for (int iter = 0; !dag.finished(); ++iter) {
-      scheduleNextOp<Direction>(heuristic, rescheduledNodes);
+      scheduleNextOp<Direction>(heuristic, rescheduledNodes, printDetails);
     }
     heuristic->end();
 
@@ -2083,8 +2133,8 @@ struct SchedManager {
   // Single pass of rescheduling the dag.
   template <SchedDirection Direction>
   void scheduleNextOp(SchedHeuristic<Direction> *heuristic,
-                      SchedDagNodeList &rescheduledNodes) {
-    const bool printDetails = rescheduleId > 0;
+                      SchedDagNodeList &rescheduledNodes,
+                      bool printDetails = false) {
     // Print ReadyNodes and HeuristicState
     const auto &readyNodes = dag.getReadyNodes();
     if (printDetails) {
@@ -2099,11 +2149,10 @@ struct SchedManager {
 
     // Select
     SchedDagNode *selectedNode = selectFromReadyNodes(readyNodes, heuristic);
-    if (printDetails) {
-      LDBG("Selected: " << *selectedNode);
-    }
     heuristic->selectedOp(selectedNode);
-
+    if (printDetails) {
+      LDBG("Selected: " << *selectedNode << "\n");
+    }
     // Place selected node in list, remove it from dag which updates
     // readyList.
     rescheduledNodes.push_back(selectedNode);
@@ -2287,7 +2336,13 @@ struct TritonAMDGPURescheduleOps
       This is already the beginning of working on this.
       schedManager.addDeps(std::make_unique<MemOrderDependencyCalculator>());
     */
-
+    schedManager.addDeps(
+        std::make_unique<DotGlobalOrderDependencyCalculator>());
+    if (dumpGraphs) {
+      LLVM_DEBUG(LDBG("Dag: data, dot:dot, ls:ls, bar:*, ll:ll, gl:gl, ll:dot, "
+                      "ls:dot, gl:dot");
+                 schedManager.dag.dumpDotFormat(llvm::dbgs()););
+    }
     schedManager.insertSchedBarriers();
 
     // Copy scheduled order to basic block.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -16,9 +16,6 @@
 #define GEN_PASS_CLASSES
 #include "TritonAMDGPUTransforms/Passes.h"
 
-// #undef LLVM_DEBUG
-// #define LLVM_DEBUG(X) X
-
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-reschedule-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -2346,7 +2343,8 @@ struct TritonAMDGPURescheduleOps
                       "ls:dot, gl:dot");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
-    schedManager.insertSchedBarriers();
+    if (true)
+      schedManager.insertSchedBarriers();
 
     // Copy scheduled order to basic block.
     SmallVector<Operation *> rescheduledOps = schedManager.getOpList();


### PR DESCRIPTION
Adds support for:
- Setting node priority to reorder memory ops across barrier. Also enables reordering tertiary ops to get to dots asap.
- Adds a machine model to be able to interleave memory ops with dots.
- Scheduling based on machine model.
- DotLdsOrderDependencyCalculator to preserve interleaving of lds read/writes and dots.
- Inserting Sched.Barrier(mask) according to dependencies.