### PR TITLE
Add configs for memory bound shapes

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -4,6 +4,7 @@ from triton_kernels.target_info import get_cdna_version
 import torch
 from .opt_flags_details import opt_flags_amd, opt_flags_nvidia
 from ..tensor import get_layout
+from triton_kernels.tensor import FP4
 
 # fmt: off
 
@@ -105,10 +106,17 @@ def make_default_opt_flags_amd(
     num_stages = 2
     # AMD-specific
     target_kernel_kwargs = {"waves_per_eu": 0, "matrix_instr_nonkdim": 16, "kpack": 1}
+    block_n=128
+    if rhs_dtype is FP4 and m <= 512:
+        block_k=256
+        num_warps=4
+    else:
+        block_k=128
+
     ret = OptFlags(
         block_m=block_m,
-        block_n=128, # block_n,
-        block_k=128, # block_k,
+        block_n=block_n,
+        block_k=block_k,
         num_warps=num_warps,
         num_stages=num_stages,
         group_m=group_m,


### PR DESCRIPTION
num_warps=4 seems to show better performance for the memory bound shapes.