### PR TITLE
Fix pr 7780 merge error on release/internal/3.3.x branch

### DIFF
--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -74,9 +74,6 @@ def fast_expf(arg0, _builder=None):
 
 
 @core.extern
-<<<<<<< HEAD
-def fast_dividef(arg0, arg1, _builder=None):
-=======
 def fast_tanhf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__triton_hip_fast_tanhf", core.dtype("fp32")),
@@ -84,8 +81,7 @@ def fast_tanhf(arg0, _semantic=None):
 
 
 @core.extern
-def fast_dividef(arg0, arg1, _semantic=None):
->>>>>>> 353540798c ([AMD] Add fast_tanhf to libdevice (#7780))
+def fast_dividef(arg0, arg1, _builder=None):
     return core.extern_elementwise("", "", [arg0, arg1], {
         (core.dtype("fp32"), core.dtype("fp32")): ("__triton_hip_fast_fdividef", core.dtype("fp32")),
     }, is_pure=True, _builder=_builder)

--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -74,10 +74,10 @@ def fast_expf(arg0, _builder=None):
 
 
 @core.extern
-def fast_tanhf(arg0, _semantic=None):
+def fast_tanhf(arg0, _builder=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__triton_hip_fast_tanhf", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
+    }, is_pure=True, _builder=_builder)
 
 
 @core.extern


### PR DESCRIPTION
This PR fixes the merge error of PR7780 when it was cherry-picked to ROCm release/internal/3.3.x branch.
Problem was detected when building the Pytorch from ROCm release/2.7 branch which uses
the Triton from ROCm release/internal/3.3.x branch.

There are two fixes:
- remove the merge conflict lines
- renames the _semantic from original patch to _builder as used in the 3.3.x branch

Fixes: https://github.com/ROCm/triton/issues/857

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`. This can be tested by running existing tests like python/tutorials/01-vector-add.py to detect the exception caused by the merge conflict.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
