### PR TITLE
[release/3.3] [AMD] Implemented hipError discard after a failure to get pointer attributes

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -261,6 +261,7 @@ static const char *hipLibSearchPaths[] = {{"{libhip_path}"}};
 // in this file.
 #define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                     \\
   FOR_EACH_STR_FN(hipGetErrorString, hipError_t hipError)                     \\
+  FOR_EACH_STR_FN(hipGetLastError)                                            \\
   FOR_EACH_ERR_FN(hipModuleLaunchKernel, hipFunction_t f,                     \\
                   unsigned int gridDimX, unsigned int gridDimY,               \\
                   unsigned int gridDimZ, unsigned int blockDimX,              \\
@@ -394,6 +395,8 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
         PyErr_Format(PyExc_ValueError,
                      "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
         ptr_info.valid = false;
+        // Clear and ignore HIP error
+        (void)hipSymbolTable.hipGetLastError();
     }}
     ptr_info.dev_ptr = (hipDeviceptr_t)dev_ptr;
     Py_DECREF(ret);


### PR DESCRIPTION
Since ROCm7.x the error behavior was changed to match its' CUDA counterpart. After unsuccessful getPointerAttr call the error was not discarded and could lead to breaking the Pytorch state when allocating memory after such call.

This PR is created to fix a gating issue and we would like it to merged asap, but there can probably be more places in the code which lead to same results. I didn't conditionalize it for rocm7.0 because for earlier version hipGetLastError would just return nothing of value and get discarded anyway without breaking any logic. This PR will need to be cherry-picked in all of our branches. More on this in a follow-up issue.

P1 Jira: https://ontrack-internal.amd.com/browse/SWDEV-546704
More info about error handling here: https://ontrack-internal.amd.com/browse/SWDEV-438790

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It fixes a potential Pytorch bug`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
