### PR TITLE
remove get_git_version_suffix()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -776,7 +776,7 @@ def get_git_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.4.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+TRITON_VERSION = "3.4.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)


### PR DESCRIPTION
Remove extra git commit hash because we include it in the pytorch triton wheel build 
Relates to 
https://github.com/ROCm/builder/pull/90
https://github.com/ROCm/pytorch/pull/2500