### PR TITLE
[triton_kernels] TopK kernel fixes

### DIFF
--- a/python/triton_kernels/pyproject.toml
+++ b/python/triton_kernels/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "triton_kernels"
 version = "1.0.0"
-dependencies = ["torch", "numpy", "pytest"]
+dependencies = ["numpy", "pytest"]
 
 [build-system]
 requires = ["setuptools>=64.0"]

--- a/python/triton_kernels/triton_kernels/reduction_details/reduce_bitmatrix.py
+++ b/python/triton_kernels/triton_kernels/reduction_details/reduce_bitmatrix.py
@@ -50,8 +50,8 @@ def _sum_bitmatrix_memset(Ret, BLOCK: tl.constexpr):
 
 
 @triton.jit
-def _sum_bitmatrix_rows(B, shape_bm, stride_bm: tl.constexpr, stride_bn: tl.constexpr,  # input bitmatrix
-                        Ret, Partials, stride_pm: tl.constexpr, stride_pn, shape_pn,  # outputs
+def _sum_bitmatrix_rows(B, shape_bm, stride_bm, stride_bn,  # input bitmatrix
+                        Ret, Partials, stride_pm, stride_pn, shape_pn,  # outputs
                         BLOCK_MM: tl.constexpr, BLOCK_M: tl.constexpr):
 
     tl.static_assert(BLOCK_MM % BLOCK_M == 0)

--- a/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk_forward.py
@@ -89,7 +89,7 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
 @triton.jit
 def _topk_forward(X, stride_xm,  # inputs
                   Yv, Yi, stride_ym,  # topk values/indices
-                  USE_PROVIDED_INDX: tl.constexpr, Bits, stride_rm: tl.constexpr, stride_rn: tl.constexpr,  # bitmatrix
+                  USE_PROVIDED_INDX: tl.constexpr, Bits, stride_rm, stride_rn,  # bitmatrix
                   n_rows, n_expts_tot,  # shape
                   S, BLOCK_S: tl.constexpr, s_blocks,  # thing to memset
                   APPLY_SOFTMAX: tl.constexpr,  # constant


### PR DESCRIPTION
This PR contains the following changes:

- Removing torch dependency from triton_kernels
- Removing constant strides from _sum_bitmatrix_rows and _topk_forward

The issue was excessive recompilations, possibly triggered by the constant strides in these kernels.