### PR TITLE
[triton_kernels] MoE env. variable update

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -111,7 +111,7 @@ def make_default_opt_flags_amd(
     target_kernel_kwargs = {"waves_per_eu": 3, "matrix_instr_nonkdim": 16, "kpack": 1}
     block_n=128
 
-    use_scale_preshuffling = os.environ.get("TRITON_HIP_PRESHUFFLE_SCALES", "0") == "1"
+    use_scale_preshuffling = os.environ.get("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1") == "1"
 
     if rhs_dtype is FP4 and m <= 1024:
         block_k=256


### PR DESCRIPTION
This PR renames MoE env. variable to better reflect the effect and sets it on by default (VLLM compatibility related)