### PR TITLE
Adding more support for machine model cycles per dot/mfma

### DIFF
--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -36,7 +36,6 @@ FailureOr<MfmaIntrinsic> maybeGetMfma(DotOp dotOp) {
   auto mDim = mfmaLayout.getMDim();
   auto nDim = mfmaLayout.getNDim();
   const auto kDimOperandSize = aTensorTy.getShape().back();
-  // auto kDim = mfmaLayout.getKDim();
   auto mfmaVersion = mfmaLayout.getVersion();
   bool allowXF32 =
       dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
@@ -80,7 +79,8 @@ SmallVector<uint32_t> getAsmNumRepsForDotOp(DotOp dotOp) {
           warpShape[2] / asmShape[2]};
 }
 
-// Get cycles per mfma asm instruction, e.g. 32 cycles for rocdl.mfma.f32.32x32x8f16.
+// Get cycles per mfma asm instruction, e.g. 32 cycles for
+// rocdl.mfma.f32.32x32x8_f16.
 // TODO(dtanner) add support for machine version; this is for mi300X.
 uint32_t getCyclesPerMfma(DotOp dotOp) {
   FailureOr<MfmaIntrinsic> maybeMfmaInsn = maybeGetMfma(dotOp);

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -20,70 +20,9 @@ namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
 namespace {
-/*
- TODO - this needs to be MUCH more official.
-*/
 
-// Return warp shape of dot op, e.g. 16x16x128 if kPack>1
-SmallVector<uint32_t> getWarpShapeForDotOp(DotOp dotOp) {
-  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
-      cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
-  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
-  MLIRContext *ctx = dotOp->getContext();
-  Value a = dotOp.getA();
-  Value d = dotOp.getD();
-  auto aTensorTy = cast<RankedTensorType>(a.getType());
-  auto encodeA = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
-  auto dTensorTy = cast<RankedTensorType>(d.getType());
-  auto elemTyA = aTensorTy.getElementType();
-  auto mDim = mfmaLayout.getMDim();
-  auto nDim = mfmaLayout.getNDim();
-  auto shapeA = aTensorTy.getShape();
-  auto shapeD = dTensorTy.getShape();
-  SmallVector<uint32_t> ctaTile = {static_cast<uint32_t>(shapeD[0]),
-                                   static_cast<uint32_t>(shapeD[1]),
-                                   static_cast<uint32_t>(shapeA[1])};
-  SmallVector<uint32_t> warpTile = {ctaTile[0] / warpsPerCTA[0],
-                                    ctaTile[1] / warpsPerCTA[1], ctaTile[2]};
-  return warpTile;
-}
-
-// Get Shape of assembly instructions, e.g. mfma/wmma 16x16x32.
-SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
-  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
-      cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
-  MLIRContext *ctx = dotOp->getContext();
-  Value a = dotOp.getA();
-  Value b = dotOp.getB();
-  auto aTensorTy = cast<RankedTensorType>(a.getType());
-  auto bTensorTy = cast<RankedTensorType>(b.getType());
-  auto elemTyA = aTensorTy.getElementType();
-  auto elemTyB = bTensorTy.getElementType();
-  auto mDim = mfmaLayout.getMDim();
-  auto nDim = mfmaLayout.getNDim();
-  const auto kDimOperandSize = aTensorTy.getShape().back();
-  auto mfmaVersion = mfmaLayout.getVersion();
-  bool allowXF32 =
-      dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
-
-  FailureOr<MfmaIntrinsic> maybeMfmaInsn =
-      MfmaIntrinsic::selectFor(dotOp->getLoc(), mfmaVersion, mDim, nDim,
-                               kDimOperandSize, elemTyA, elemTyB,
-                               /*withScale=*/false, allowXF32);
-  if (failed(maybeMfmaInsn))
-    llvm::report_fatal_error("No match found in MFMA database\n");
-  return {maybeMfmaInsn->mDim, maybeMfmaInsn->nDim, maybeMfmaInsn->kDim};
-}
-
-// Get number of assembly instructions [per wave] for dot op.
-SmallVector<uint32_t> getAsmNumRepsForDotOp(DotOp dotOp) {
-  auto dotShape = getWarpShapeForDotOp(dotOp);
-  auto mfmaShape = getAsmShapeForDotOp(dotOp);
-  return {dotShape[0] / mfmaShape[0], dotShape[1] / mfmaShape[1],
-          dotShape[2] / mfmaShape[2]};
-}
-
-unsigned getCyclesPerMfma(DotOp dotOp) {
+// Get MfmaIntrinsic from DotOp
+FailureOr<MfmaIntrinsic> maybeGetMfma(DotOp dotOp) {
   // Get mfma op type.
   auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
       cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
@@ -102,17 +41,59 @@ unsigned getCyclesPerMfma(DotOp dotOp) {
   bool allowXF32 =
       dotOp.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
 
-  FailureOr<MfmaIntrinsic> maybeMfmaInsn =
-      MfmaIntrinsic::selectFor(dotOp->getLoc(), mfmaVersion, mDim, nDim,
-                               kDimOperandSize, elemTyA, elemTyB,
-                               /*withScale=*/false, allowXF32);
+  return MfmaIntrinsic::selectFor(dotOp->getLoc(), mfmaVersion, mDim, nDim,
+                                  kDimOperandSize, elemTyA, elemTyB,
+                                  /*withScale=*/false, allowXF32);
+}
 
+// Get Shape of assembly instruction, e.g. mfma/wmma 16x16x32.
+SmallVector<uint32_t> getAsmShapeForDotOp(DotOp dotOp) {
+  FailureOr<MfmaIntrinsic> maybeMfmaInsn = maybeGetMfma(dotOp);
   if (failed(maybeMfmaInsn))
     llvm::report_fatal_error("No match found in MFMA database\n");
+  // TODO(dtanner) add wmma.
+  return {maybeMfmaInsn->mDim, maybeMfmaInsn->nDim, maybeMfmaInsn->kDim};
+}
+
+// Return wave shape of dot op, e.g. 16x16x128 if kPack>1.
+SmallVector<uint32_t> getWarpShapeForDotOp(DotOp dotOp) {
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(dotOp.getResult().getType()).getEncoding());
+  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+  auto aTensorTy = cast<RankedTensorType>(dotOp.getA().getType());
+  auto dTensorTy = cast<RankedTensorType>(dotOp.getD().getType());
+  auto shapeA = aTensorTy.getShape();
+  auto shapeD = dTensorTy.getShape();
+  SmallVector<uint32_t> ctaTile = {static_cast<uint32_t>(shapeD[0]),
+                                   static_cast<uint32_t>(shapeD[1]),
+                                   static_cast<uint32_t>(shapeA[1])};
+  SmallVector<uint32_t> warpTile = {ctaTile[0] / warpsPerCTA[0],
+                                    ctaTile[1] / warpsPerCTA[1], ctaTile[2]};
+  return warpTile;
+}
+
+// Get number of assembly instructions [per wave] for dot op.
+SmallVector<uint32_t> getAsmNumRepsForDotOp(DotOp dotOp) {
+  auto warpShape = getWarpShapeForDotOp(dotOp);
+  auto asmShape = getAsmShapeForDotOp(dotOp);
+  return {warpShape[0] / asmShape[0], warpShape[1] / asmShape[1],
+          warpShape[2] / asmShape[2]};
+}
+
+// Get cycles per mfma asm instruction, e.g. 32 cycles for rocdl.mfma.f32.32x32x8f16.
+// TODO(dtanner) add support for machine version; this is for mi300X.
+uint32_t getCyclesPerMfma(DotOp dotOp) {
+  FailureOr<MfmaIntrinsic> maybeMfmaInsn = maybeGetMfma(dotOp);
+  if (failed(maybeMfmaInsn))
+    llvm::report_fatal_error("No match found in MFMA database\n");
+  // TODO(dtanner) add wmma support.
   // Estimate rate of mfma op type.
   unsigned maxBitWidth =
       std::max(maybeMfmaInsn->aElementType.getIntOrFloatBitWidth(),
                maybeMfmaInsn->bElementType.getIntOrFloatBitWidth());
+  // Total ops is 32x32x8 = 8192.
+  int64_t totalOps =
+      maybeMfmaInsn->mDim * maybeMfmaInsn->nDim * maybeMfmaInsn->kDim;
   // Estimate throughput as fma's per cycle.
   unsigned opsPerCycle;
   if (maxBitWidth <= 8) { // fp8, bf8, i8
@@ -124,12 +105,17 @@ unsigned getCyclesPerMfma(DotOp dotOp) {
   } else {
     opsPerCycle = 64; // fp64
   }
-  // total floating point mfmas
-  int64_t totalOps =
-      maybeMfmaInsn->mDim * maybeMfmaInsn->nDim * maybeMfmaInsn->kDim;
   unsigned cyclesPerMfma = static_cast<unsigned>(totalOps / opsPerCycle);
   LDBG(maybeMfmaInsn->name << " = " << cyclesPerMfma << " cycles\n");
   return cyclesPerMfma;
+}
+
+uint32_t getCyclesPerAsm(DotOp dotOp) {
+  FailureOr<MfmaIntrinsic> mfma = maybeGetMfma(dotOp);
+  if (!failed(mfma)) {
+    return getCyclesPerMfma(dotOp);
+  }
+  // TODO(dtanner) add wmma
 }
 
 /*
@@ -252,7 +238,8 @@ SmallVector<unsigned, 3> getMfmasPerRep(const ArrayRef<int64_t> &ctaTile,
   low-level details of the device.
   For example, just a ratio of flops/byte for the given mfma precision.
   And maybe info regarding transpose and how many loads of what precision
-  to know if we'll have
+  to know if we'll have.
+  TODO(dtanner) query localLoadDataLatency from machine model.
 */
 using DotTileShapeType = SmallVector<unsigned, 3>;
 DotTileShapeType

--- a/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/DotTiling.h
@@ -116,6 +116,7 @@ uint32_t getCyclesPerAsm(DotOp dotOp) {
     return getCyclesPerMfma(dotOp);
   }
   // TODO(dtanner) add wmma
+  return 0;
 }
 
 /*

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -192,11 +192,25 @@ struct MachineModelGFX942 : MachineModelGFX90A {
 
     // Mfma
     if (auto dotOp = dyn_cast<triton::DotOp>(op)) {
+      // How many asm instructions are in dot op.
       auto numRepsVec = getAsmNumRepsForDotOp(dotOp);
       auto numReps = product<uint32_t>(numRepsVec);
-      return MachineModelOpProperties(MachineModelResourcePipe::Mfma,
-                                      4 * numReps, "mfma_16x16x16",
-                                      12 * numReps);
+      //SmallVector<uint32_t> dotWarpShape = getWarpShapeForDotOp(op);
+      
+      FailureOr<MfmaIntrinsic> mfma = maybeGetMfma(dotOp);
+      if (!failed(mfma)) {
+        unsigned cyclesPerMfma = getCyclesPerMfma(dotOp);
+        LDBG(mfma->name << " = " << cyclesPerMfma << " cycles / asm\n");
+        int m = mfma->mDim;
+        int n = mfma->mDim;
+        int k = mfma->mDim;
+        int32_t sequencerBusyCycles = cyclesPerMfma / 4;
+        int32_t mfmaPipeBusyCycles = cyclesPerMfma - sequencerBusyCycles;
+        return MachineModelOpProperties(MachineModelResourcePipe::Mfma,
+                                      sequencerBusyCycles * numReps, mfma->name,
+                                      mfmaPipeBusyCycles * numReps);
+      }
+      // TODO(dtanner) check for wmma here.
 
       // LDS Ops
     } else if (isa<triton::gpu::LocalLoadOp>(op)) {

--- a/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/SchedulerMachineModel.h
@@ -195,8 +195,8 @@ struct MachineModelGFX942 : MachineModelGFX90A {
       // How many asm instructions are in dot op.
       auto numRepsVec = getAsmNumRepsForDotOp(dotOp);
       auto numReps = product<uint32_t>(numRepsVec);
-      //SmallVector<uint32_t> dotWarpShape = getWarpShapeForDotOp(op);
-      
+      // SmallVector<uint32_t> dotWarpShape = getWarpShapeForDotOp(op);
+
       FailureOr<MfmaIntrinsic> mfma = maybeGetMfma(dotOp);
       if (!failed(mfma)) {
         unsigned cyclesPerMfma = getCyclesPerMfma(dotOp);
@@ -206,9 +206,9 @@ struct MachineModelGFX942 : MachineModelGFX90A {
         int k = mfma->mDim;
         int32_t sequencerBusyCycles = cyclesPerMfma / 4;
         int32_t mfmaPipeBusyCycles = cyclesPerMfma - sequencerBusyCycles;
-        return MachineModelOpProperties(MachineModelResourcePipe::Mfma,
-                                      sequencerBusyCycles * numReps, mfma->name,
-                                      mfmaPipeBusyCycles * numReps);
+        return MachineModelOpProperties(
+            MachineModelResourcePipe::Mfma, sequencerBusyCycles * numReps,
+            mfma->name, mfmaPipeBusyCycles * numReps);
       }
       // TODO(dtanner) check for wmma here.
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RefineOps.cpp
@@ -13,9 +13,6 @@
 #define GEN_PASS_CLASSES
 #include "TritonAMDGPUTransforms/Passes.h"
 
-// #undef LLVM_DEBUG
-// #define LLVM_DEBUG(X) X
-
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "tritonamdgpu-refine-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -57,8 +57,7 @@ namespace ttg = mlir::triton::gpu;
 
 namespace {
 
-Operation *createSetPrio(OpBuilder &rewriter, Location loc,
-                              int32_t prioValue) {
+Operation *createSetPrio(OpBuilder &rewriter, Location loc, int32_t prioValue) {
   IntegerAttr prio =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(prioValue));
   return rewriter.create<ROCDL::SetPrioOp>(loc, prioValue);
@@ -1909,10 +1908,7 @@ struct SchedHeuristicOriginalOrder
   TODO(dtanner) hiding ds-write issue cycles also benefit from
   using setprio to pingpong between the 2 waves so they make equal progress.
 */
-enum class SetPrioStrategy {
-  None,
-  DotHighLow
-};
+enum class SetPrioStrategy { None, DotHighLow };
 struct ApplySetPrio {
   ApplySetPrio(SchedDag &dag, OpBuilder &builder)
       : dag(dag), builder(builder) {}
@@ -1921,14 +1917,15 @@ struct ApplySetPrio {
 
   /*
     Setprio high before first mfma of dot, and low after last mfma of dot.
-    This works well for non-pingpong FA on mi300X with 4 waves/wg and 2 waves/wg,
-    as it keeps one wg's mfmas overlapped with the other wg's softmax.
+    This works well for non-pingpong FA on mi300X with 4 waves/wg and 2
+    waves/wg, as it keeps one wg's mfmas overlapped with the other wg's softmax.
   */
   void applySetPrioDotHighLow() {
     dag.nodeList.reserve(dag.nodeList.size() + 16);
     // TopDown
     SetVector<int32_t> dotIds;
-    for (SchedDagNodeList::iterator it = std::next(dag.nodeList.begin()); it != dag.nodeList.end(); ++it) {
+    for (SchedDagNodeList::iterator it = std::next(dag.nodeList.begin());
+         it != dag.nodeList.end(); ++it) {
       SchedDagNode *node = *it;
       if (nodeCategoryDot(node)) {
         Operation *op = node->getOp();
@@ -1950,7 +1947,9 @@ struct ApplySetPrio {
 
     // BottomUp
     dotIds.clear();
-    for (SchedDagNodeList::reverse_iterator it = std::next(dag.nodeList.rbegin()); it != dag.nodeList.rend(); ++it) {
+    for (SchedDagNodeList::reverse_iterator it =
+             std::next(dag.nodeList.rbegin());
+         it != dag.nodeList.rend(); ++it) {
       SchedDagNode *node = *it;
       if (nodeCategoryDot(node)) {
         Operation *op = node->getOp();
@@ -1973,12 +1972,13 @@ struct ApplySetPrio {
   // Select which set prio to apply.
   void applySetPrioStrategy(SetPrioStrategy strategy) {
     switch (strategy) {
-      case SetPrioStrategy::DotHighLow:
+    case SetPrioStrategy::DotHighLow:
       applySetPrioDotHighLow();
+      return;
+    case SetPrioStrategy::None:
       return;
     }
   }
-  
 
   SchedDag &dag;
   OpBuilder &builder;
@@ -2070,53 +2070,54 @@ struct ApplySchedBarriers {
       bool addedDotLds = false;
       if (SCHED_OPT_SCHEDBAR_DOT_LOCALLOAD) {
         addedDotLds =
-              maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
-                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+            maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
+                                 "DotLdsOrder", schedBarMaskBlockDotLds);
         if (!addedDotLds)
           addedDotLds =
               maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
-                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+                                   "DotLdsOrder", schedBarMaskBlockDotLds);
       }
       if (SCHED_OPT_SCHEDBAR_DOT_LOCALSTORE) {
         if (!addedDotLds)
           addedDotLds =
               maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalStore,
-                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+                                   "DotLdsOrder", schedBarMaskBlockDotLds);
         if (!addedDotLds)
           addedDotLds =
               maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryDot,
-                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+                                   "DotLdsOrder", schedBarMaskBlockDotLds);
       }
 
       // Dot / GlobalLoad
       bool addedDotGlobal = false;
       if (SCHED_OPT_SCHEDBAR_DOT_GLOBAL) {
         maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryGlobal,
-                               "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+                             "DotGlobalOrder", schedBarMaskBlockDotGlobal);
         if (!addedDotGlobal)
-          addedDotGlobal =
-              maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryDot,
-                                  "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+          addedDotGlobal = maybeAddSchedBarrier(
+              it, nodeCategoryGlobal, nodeCategoryDot, "DotGlobalOrder",
+              schedBarMaskBlockDotGlobal);
       }
 
       if (SCHED_OPT_SCHEDBAR_OPTYPE) {
         // Dot / Dot
         if (!addedDotLds && !addedDotGlobal)
           maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot, "DotOrder",
-                              schedBarMaskBlockDot);
+                               schedBarMaskBlockDot);
         // LocalLoad / LocalLoad
         if (!addedDotLds)
           maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
-                              "LocalLoadOrder", schedBarMaskBlockDsRead);
+                               "LocalLoadOrder", schedBarMaskBlockDsRead);
         // LocalStore / LocalStore
         if (!addedDotLds)
-          maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryLocalStore,
-                              "LocalStoreOrder", schedBarMaskBlockDsWrite);
+          maybeAddSchedBarrier(it, nodeCategoryLocalStore,
+                               nodeCategoryLocalStore, "LocalStoreOrder",
+                               schedBarMaskBlockDsWrite);
 
         // GlobalLoad / GlobalLoad
         if (!addedDotGlobal)
           maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
-                              "GlobalLoadOrder", schedBarMaskBlockGlobal);
+                               "GlobalLoadOrder", schedBarMaskBlockGlobal);
       }
     }
     LDBG("insertSchedBarriers() - DONE");

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -25,6 +25,14 @@ using namespace mlir;
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
+// Knobs for doing scheduling research, especially for optimizing for LLVM.
+#define SCHED_OPT_NUM_PASSES 3
+#define SCHED_OPT_SETPRIO_DOTHIGHLOW false
+#define SCHED_OPT_SCHEDBAR_OPTYPE true
+#define SCHED_OPT_SCHEDBAR_DOT_LOCALLOAD true
+#define SCHED_OPT_SCHEDBAR_DOT_LOCALSTORE true
+#define SCHED_OPT_SCHEDBAR_DOT_GLOBAL true
+
 /******************************************************************************
   Reschedule ttgir after refine-ops-pass to interleave refined ops at the ttgir
   level, and thereby improve llir order which will improve
@@ -1362,6 +1370,10 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
 void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
                         std::function<bool(SchedDagNode *)> isCategoryA,
                         std::function<bool(SchedDagNode *)> isCategoryB) {
+  // If ops of category A and B are already ordered,
+  // then we don't need deps between all A's and B's,
+  // we only need a dep between the first match found.
+  bool firstMatchOnly = true;
   SchedDagNode *prevA = nullptr;
   SchedDagNode *prevB = nullptr;
 
@@ -1372,6 +1384,9 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
         dep.parent = prevB;
         dep.child = node;
         depSet.insert(dep);
+        if (firstMatchOnly) {
+          prevB = nullptr;
+        }
       }
       prevA = node;
     } else if (isCategoryB(node)) {
@@ -1380,6 +1395,9 @@ void calcDepsOpCategory(SchedDagNodeList *nodeList, DepSet &depSet,
         dep.parent = prevA;
         dep.child = node;
         depSet.insert(dep);
+        if (firstMatchOnly) {
+          prevA = nullptr;
+        }
       }
       prevB = node;
     }
@@ -1888,6 +1906,8 @@ struct SchedHeuristicOriginalOrder
   After scheduling the mlirBlock, we place setprio to achieve
   higher multi-wave performance.
   This applies when there are multiple waves / simd.
+  TODO(dtanner) hiding ds-write issue cycles also benefit from
+  using setprio to pingpong between the 2 waves so they make equal progress.
 */
 enum class SetPrioStrategy {
   None,
@@ -1939,7 +1959,7 @@ struct ApplySetPrio {
           int32_t id = attr.getIdUnrefinedOp();
           if (!dotIds.contains(id)) {
             dotIds.insert(id);
-            // Set priority high before this dot.
+            // Set priority high after this dot.
             builder.setInsertionPointAfter(node->getOp());
             auto setPrioOp = createSetPrio(builder, op->getLoc(), lowPriority);
             SchedDagNode *setPrioNode = new SchedDagNode(setPrioOp);
@@ -1997,6 +2017,10 @@ struct ApplySchedBarriers {
     if (!parentCategory(parentNode)) {
       return false;
     }
+    if (!dag.deps.contains(depTypeName)) {
+      return false;
+    }
+
     // Find next op matching childCategory.
     for (SchedDagNode *const *it = parentIter + 1; it != dag.nodeList.end();
          it++) {
@@ -2043,48 +2067,57 @@ struct ApplySchedBarriers {
       SchedDagNode *node = *it;
 
       // Dot / Lds
-      bool addedDotLds =
-          maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
-                               "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!addedDotLds)
+      bool addedDotLds = false;
+      if (SCHED_OPT_SCHEDBAR_DOT_LOCALLOAD) {
         addedDotLds =
-            maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
-                                 "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!addedDotLds)
-        addedDotLds =
-            maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalStore,
-                                 "DotLdsOrder", schedBarMaskBlockDotLds);
-      if (!addedDotLds)
-        addedDotLds =
-            maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryDot,
-                                 "DotLdsOrder", schedBarMaskBlockDotLds);
+              maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalLoad,
+                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+        if (!addedDotLds)
+          addedDotLds =
+              maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryDot,
+                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+      }
+      if (SCHED_OPT_SCHEDBAR_DOT_LOCALSTORE) {
+        if (!addedDotLds)
+          addedDotLds =
+              maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryLocalStore,
+                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+        if (!addedDotLds)
+          addedDotLds =
+              maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryDot,
+                                  "DotLdsOrder", schedBarMaskBlockDotLds);
+      }
 
       // Dot / GlobalLoad
-      bool addedDotGlobal =
-          maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryGlobal,
+      bool addedDotGlobal = false;
+      if (SCHED_OPT_SCHEDBAR_DOT_GLOBAL) {
+        maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryGlobal,
                                "DotGlobalOrder", schedBarMaskBlockDotGlobal);
-      if (!addedDotGlobal)
-        addedDotGlobal =
-            maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryDot,
-                                 "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+        if (!addedDotGlobal)
+          addedDotGlobal =
+              maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryDot,
+                                  "DotGlobalOrder", schedBarMaskBlockDotGlobal);
+      }
 
-      // Dot / Dot
-      if (!addedDotLds && !addedDotGlobal)
-        maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot, "DotOrder",
-                             schedBarMaskBlockDot);
-      // LocalLoad / LocalLoad
-      if (!addedDotLds)
-        maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
-                             "LocalLoadOrder", schedBarMaskBlockDsRead);
-      // LocalStore / LocalStore
-      if (!addedDotLds)
-        maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryLocalStore,
-                             "LocalStoreOrder", schedBarMaskBlockDsWrite);
+      if (SCHED_OPT_SCHEDBAR_OPTYPE) {
+        // Dot / Dot
+        if (!addedDotLds && !addedDotGlobal)
+          maybeAddSchedBarrier(it, nodeCategoryDot, nodeCategoryDot, "DotOrder",
+                              schedBarMaskBlockDot);
+        // LocalLoad / LocalLoad
+        if (!addedDotLds)
+          maybeAddSchedBarrier(it, nodeCategoryLocalLoad, nodeCategoryLocalLoad,
+                              "LocalLoadOrder", schedBarMaskBlockDsRead);
+        // LocalStore / LocalStore
+        if (!addedDotLds)
+          maybeAddSchedBarrier(it, nodeCategoryLocalStore, nodeCategoryLocalStore,
+                              "LocalStoreOrder", schedBarMaskBlockDsWrite);
 
-      // GlobalLoad / GlobalLoad
-      if (!addedDotGlobal)
-        maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
-                             "GlobalLoadOrder", schedBarMaskBlockGlobal);
+        // GlobalLoad / GlobalLoad
+        if (!addedDotGlobal)
+          maybeAddSchedBarrier(it, nodeCategoryGlobal, nodeCategoryGlobal,
+                              "GlobalLoadOrder", schedBarMaskBlockGlobal);
+      }
     }
     LDBG("insertSchedBarriers() - DONE");
   }
@@ -2210,8 +2243,9 @@ struct SchedManager {
     ApplySetPrio asp(dag, builder);
     // TODO(dtanner) select strategy here based on wg and kernel.
     // Note: it is valid to apply multiple strategies.
-    SetPrioStrategy strategy = SetPrioStrategy::DotHighLow;
-    asp.applySetPrioStrategy(strategy);
+    if (SCHED_OPT_SETPRIO_DOTHIGHLOW) {
+      asp.applySetPrioStrategy(SetPrioStrategy::DotHighLow);
+    }
   }
 
   void insertSchedBarriers() {
@@ -2265,20 +2299,14 @@ struct TritonAMDGPURescheduleOps
     SchedManager schedManager(mlirBlock, builder);
     bool dumpGraphs = false;
 
+#if SCHED_OPT_NUM_PASSES >= 0
     /*
-      Scheduling Pass 0
-      - Dependencies: Data, DotOrder, LocalStoreOrder, Barriers
-      - Priorities: DotCriticalPath, LocalStoreCriticalPath
-      - Heuristic: Priority
-
-      Dependencies accomplish:
-      - Enforced dot relative order.
-      - Enforced LocalStoreOp relative order.
-      Scheduling in order of priority (critical path) accomplishes:
-      - Note that LoadOp are close to LocalStoreOp on purpose.
-      - Determines relative order of LocalLoadOps.
-      - Determines order of tertiary ops to get to the DotOps asap.
-      - Determines the order of LoadOps to match LocalStoreOps.
+      Prepare for Scheduling Pass 1
+      Dependencies: Data, DotOrder, LocalStoreOrder, Barriers:
+      - Enforce dot relative order.
+      - Enforce LocalStoreOp relative order.
+      Priorities: DotCriticalPath, LocalStoreCriticalPath:
+      - Enables critical path scheduling.
     */
     // Add Data deps based on def-use chains.
     schedManager.addDeps(std::make_unique<DataDependencyCalculator>());
@@ -2312,26 +2340,22 @@ struct TritonAMDGPURescheduleOps
       LLVM_DEBUG(LDBG("Dag: data, dot:dot, ls:ls, bar:*");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
-    SchedHeuristicPriority<SchedDirection::TopDown> shp;
-    schedManager.reschedule<SchedDirection::TopDown>(&shp);
+#endif
 
+#if SCHED_OPT_NUM_PASSES >= 1
     /*
       Scheduling Pass 1
-      - Dependencies: LocalLoadOrder, GlobalLoadOrder
-      - Priorities: none
-      - Heuristic: MachineModel<BottomUp>
-
-      Dependencies accomplish:
+      Heuristic: Priority (critical path):
+      - Note that LoadOp will be close to LocalStoreOp on purpose.
+      - Determines relative order of LocalLoadOps.
+      - Determines order of tertiary ops to get to the DotOps asap.
+      - Determines the order of LoadOps to match LocalStoreOps.
+      Dependencies: LocalLoadOrder, GlobalLoadOrder:
       - Enforce LocalLoadOp relative order.
       - Enforce LoadOp relative order.
-      Scheduled in order of MachineModel<BottomUp> accomplishes:
-      - Determines LocalStoreOps before barriers and end of loop.
-      - Spreads LocalStoreOps out.
-      - Determines LocalLoadOps prefetched before DotOps.
-      - Spreads LocalLoadOps out.
-      - Lifts LoadOps as high as possible, which is likely top of block.
     */
-    // Preserve memory op order determined by critical paths above.
+    SchedHeuristicPriority<SchedDirection::TopDown> shp;
+    schedManager.reschedule<SchedDirection::TopDown>(&shp);
     schedManager.addDeps(
         std::make_unique<LocalLoadOrderDependencyCalculator>());
     schedManager.addDeps(
@@ -2340,25 +2364,27 @@ struct TritonAMDGPURescheduleOps
       LLVM_DEBUG(LDBG("Dag: data, dot:dot, ls:ls, bar:*, ll:ll, gl:gl");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
-    // Now that we've ordered lds ops, spread them out with machine model.
-    // This comes first because we want LL and LS as late as possible.
-    // This pass pushes the GL up as high as possible.
-    SchedHeuristicMachineModel<SchedDirection::BottomUp> sh1;
-    schedManager.reschedule<SchedDirection::BottomUp>(&sh1);
+#endif
 
+#if SCHED_OPT_NUM_PASSES >= 2
     /*
       Scheduling Pass 2
-      - Dependencies: DotLdsOrder; PriorityOrder
-      - Priorities: 0
-      - Heuristic: EarlyGlobalLoads
+      - Heuristic: MachineModel<BottomUp>
+      - Dependencies: DotLdsOrder
 
+      Scheduled in order of MachineModel<BottomUp> accomplishes:
+      - Determines LocalStoreOps before barriers and end of loop.
+      - Spreads LocalStoreOps out.
+      - Determines LocalLoadOps prefetched before DotOps.
+      - Spreads LocalLoadOps out.
+      - Lifts LoadOps as high as possible, which is likely top of block.
       Dependencies accomplish:
       - Enforce LocalLoadOp relative to DotOps.
       - Enforce LocalStoreOp relative to DotOps.
-      Scheduled in order of MachineModel<TopDown> accomplishes:
-      - Delays LoadOps until issuing them is hidden by DotOps.
-      - Spreads out LoadOps.
     */
+    SchedHeuristicMachineModel<SchedDirection::BottomUp> sh1;
+    schedManager.reschedule<SchedDirection::BottomUp>(&sh1);
+
     schedManager.addDeps(std::make_unique<DotLdsOrderDependencyCalculator>());
     if (dumpGraphs) {
       LLVM_DEBUG(
@@ -2366,19 +2392,21 @@ struct TritonAMDGPURescheduleOps
               "Dag: data, dot:dot, ls:ls, bar:*, ll:ll, gl:gl, ll:dot, ls:dot");
           schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
+#endif
+
+#if SCHED_OPT_NUM_PASSES >= 3
+    /*
+      Scheduling Pass 3
+      Heuristic: MachineModel<TopDown>
+      - Schedule LoadOps as early as possible within all other constraints.
+      - Delays LoadOps until issuing them is hidden by DotOps.
+      - Spreads out LoadOps.
+      Dependencies: DotGlobalOrder
+      - Enforce Global relative to DotOps.
+    */
     SchedHeuristicMachineModel<SchedDirection::TopDown> sh2;
     schedManager.reschedule<SchedDirection::TopDown>(&sh2);
 
-    /*
-      TODO(dtanner) - flash-attention (or anything with multiple GL/LS)
-      will need to have some anti-deps to keep some GL after LS so they
-      can use the same registers. This should probably be added after
-      DotLdsOrder dependencies and before the machine model top-down, so that it
-      just delays the LoadOps even further until after the anti-dep.
-      schedManager.addDeps(std::make_unique<LocalStoreGlobalLoadAntiDepsDependencyCalculator>());
-      This is already the beginning of working on this.
-      schedManager.addDeps(std::make_unique<MemOrderDependencyCalculator>());
-    */
     schedManager.addDeps(
         std::make_unique<DotGlobalOrderDependencyCalculator>());
     if (dumpGraphs) {
@@ -2386,6 +2414,8 @@ struct TritonAMDGPURescheduleOps
                       "ls:dot, gl:dot");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
+#endif
+
     schedManager.applySetPrio();
     schedManager.insertSchedBarriers();
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RescheduleOps.cpp
@@ -49,6 +49,13 @@ namespace ttg = mlir::triton::gpu;
 
 namespace {
 
+Operation *createSetPrio(OpBuilder &rewriter, Location loc,
+                              int32_t prioValue) {
+  IntegerAttr prio =
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(prioValue));
+  return rewriter.create<ROCDL::SetPrioOp>(loc, prioValue);
+}
+
 // TODO (ravil): Note, took function from `SchedInstructions.cpp`.
 // we need to combine these two implementations
 Operation *createSchedBarrier(OpBuilder &rewriter, Location loc,
@@ -1878,6 +1885,86 @@ struct SchedHeuristicOriginalOrder
 };
 
 /*
+  After scheduling the mlirBlock, we place setprio to achieve
+  higher multi-wave performance.
+  This applies when there are multiple waves / simd.
+*/
+enum class SetPrioStrategy {
+  None,
+  DotHighLow
+};
+struct ApplySetPrio {
+  ApplySetPrio(SchedDag &dag, OpBuilder &builder)
+      : dag(dag), builder(builder) {}
+  const int32_t highPriority = 3;
+  const int32_t lowPriority = 0;
+
+  /*
+    Setprio high before first mfma of dot, and low after last mfma of dot.
+    This works well for non-pingpong FA on mi300X with 4 waves/wg and 2 waves/wg,
+    as it keeps one wg's mfmas overlapped with the other wg's softmax.
+  */
+  void applySetPrioDotHighLow() {
+    dag.nodeList.reserve(dag.nodeList.size() + 16);
+    // TopDown
+    SetVector<int32_t> dotIds;
+    for (SchedDagNodeList::iterator it = std::next(dag.nodeList.begin()); it != dag.nodeList.end(); ++it) {
+      SchedDagNode *node = *it;
+      if (nodeCategoryDot(node)) {
+        Operation *op = node->getOp();
+        if (auto attr = op->getAttrOfType<triton::amdgpu::RefinedOpAttr>(
+                triton::amdgpu::RefinedOpAttr::getMnemonic())) {
+          int32_t id = attr.getIdUnrefinedOp();
+          if (!dotIds.contains(id)) {
+            dotIds.insert(id);
+            // Set priority high before this dot.
+            Operation *insertOp = (*std::prev(it))->getOp();
+            builder.setInsertionPointAfter(insertOp);
+            auto setPrioOp = createSetPrio(builder, op->getLoc(), highPriority);
+            SchedDagNode *setPrioNode = new SchedDagNode(setPrioOp);
+            dag.nodeList.insert(it, setPrioNode);
+          }
+        }
+      }
+    }
+
+    // BottomUp
+    dotIds.clear();
+    for (SchedDagNodeList::reverse_iterator it = std::next(dag.nodeList.rbegin()); it != dag.nodeList.rend(); ++it) {
+      SchedDagNode *node = *it;
+      if (nodeCategoryDot(node)) {
+        Operation *op = node->getOp();
+        if (auto attr = op->getAttrOfType<triton::amdgpu::RefinedOpAttr>(
+                triton::amdgpu::RefinedOpAttr::getMnemonic())) {
+          int32_t id = attr.getIdUnrefinedOp();
+          if (!dotIds.contains(id)) {
+            dotIds.insert(id);
+            // Set priority high before this dot.
+            builder.setInsertionPointAfter(node->getOp());
+            auto setPrioOp = createSetPrio(builder, op->getLoc(), lowPriority);
+            SchedDagNode *setPrioNode = new SchedDagNode(setPrioOp);
+            dag.nodeList.insert(it.base(), setPrioNode);
+          }
+        }
+      }
+    }
+  }
+
+  // Select which set prio to apply.
+  void applySetPrioStrategy(SetPrioStrategy strategy) {
+    switch (strategy) {
+      case SetPrioStrategy::DotHighLow:
+      applySetPrioDotHighLow();
+      return;
+    }
+  }
+  
+
+  SchedDag &dag;
+  OpBuilder &builder;
+};
+
+/*
   After scheduling the mlirBlock, we place sched.barriers(mask) to convey
   certain scheduling constraints to LLVM. E.g., we know one of the Deps passes
   added deps between LocalLoads and Dots, therefore we iterate through
@@ -2119,12 +2206,20 @@ struct SchedManager {
     return selected;
   }
 
+  void applySetPrio() {
+    ApplySetPrio asp(dag, builder);
+    // TODO(dtanner) select strategy here based on wg and kernel.
+    // Note: it is valid to apply multiple strategies.
+    SetPrioStrategy strategy = SetPrioStrategy::DotHighLow;
+    asp.applySetPrioStrategy(strategy);
+  }
+
   void insertSchedBarriers() {
     ApplySchedBarriers asb(dag, builder);
     asb.insertSchedBarriers();
   }
 
-  SmallVector<Operation *> getOpList(bool applySchedBarriers = true) {
+  SmallVector<Operation *> getOpList() {
     SmallVector<Operation *> opList;
     for (auto node : dag.nodeList) {
       Operation *op = node->getOp();
@@ -2291,6 +2386,7 @@ struct TritonAMDGPURescheduleOps
                       "ls:dot, gl:dot");
                  schedManager.dag.dumpDotFormat(llvm::dbgs()););
     }
+    schedManager.applySetPrio();
     schedManager.insertSchedBarriers();
 
     // Copy scheduled order to basic block.


### PR DESCRIPTION
Adding support for FA. Machine model correctly calculates cycles per dot for differing dot sizes and for different instruction nonk dim. Adds some enable/disable "knobs" to ScheduleOps to control experiments. Adds one type of SetPrio strategy for FA.