### PR TITLE
[Triton=kernels] mi300 MoE preshuffle flag change

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -6,6 +6,7 @@ import torch
 from .opt_flags_details import opt_flags_amd, opt_flags_nvidia
 from ..tensor import get_layout
 from triton_kernels.tensor import FP4
+from triton_kernels import target_info
 
 # fmt: off
 
@@ -111,7 +112,7 @@ def make_default_opt_flags_amd(
     target_kernel_kwargs = {"waves_per_eu": 3, "matrix_instr_nonkdim": 16, "kpack": 1}
     block_n=128
 
-    use_scale_preshuffling = os.environ.get("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1") == "1"
+    use_scale_preshuffling = (os.environ.get("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1") == "1" and target_info.is_hip_cdna4())
 
     if rhs_dtype is FP4 and m <= 1024:
         block_k=256


### PR DESCRIPTION
This PR adds functionality to ignore MoE preshuffling (ROCM_TRITON_MOE_PRESHUFFLE_SCALES) flag if device is not cdna4.