### PR TITLE
tune_gemm: use correct output option for rocprofv3

### DIFF
--- a/python/perf-kernels/tools/tune_gemm/tune_gemm.py
+++ b/python/perf-kernels/tools/tune_gemm/tune_gemm.py
@@ -205,7 +205,7 @@ def profile_batch_kernels(M, N, K, gpuid, gpus, jobs, verbose):
             print(f"profiling {kernel_name} on GPU {gpuid}")
         here = Path(__file__).parent
         run_bash_command_wrapper(
-            f"PYTHONPATH={here} rocprofv3 --kernel-trace -o {get_output_dir()}/{jobId} --log-level fatal -- python {get_filename_profile_driver(M, N, K, jobId)}",
+            f"PYTHONPATH={here} rocprofv3 --kernel-trace --output-format csv -o {get_output_dir()}/{jobId} --log-level fatal -- python {get_filename_profile_driver(M, N, K, jobId)}",
             capture=(verbose < 2))
         jobId += ngpus
 


### PR DESCRIPTION
Without this, rocprofv3 (at least some versions of it) does not produce a csv output as required in the later stages of tune_gemm.

Tested with:

```console
# rocprofv3 --version
             version: 1.0.0
        git_revision: 18af6a58b74558c91ba09376d86d2401da2cf76f
        library_arch: x86_64-linux-gnu
         system_name: Linux
    system_processor: x86_64
      system_version: 5.15.0-151-generic
         compiler_id: GNU
    compiler_version: 11.4.0
        rocm_version: 7.0.0
```

Also tested with rocprofv3 from ROCm 6.4.4 (`rocm/pytorch:rocm6.4.4_ubuntu24.04_py3.12_pytorch_release_2.7.1` docker image).

---

Sample error message without this PR:

<details>

```console
# ./tune_gemm.py --gemm_size_file t.yaml
Tuning 1 gemm sizes starts at: 2025-10-03 15:41:40.953138
SIZE: 8192 8192 8192 TN nConfigs: 6 Traceback (most recent call last):
  File "/dockerx/triton/python/perf-kernels/tools/tune_gemm/./tune_gemm.py", line 725, in <module>
    sys.exit(main())
             ^^^^^^
  File "/dockerx/triton/python/perf-kernels/tools/tune_gemm/./tune_gemm.py", line 655, in main
    minTime, bestConfig, compile_time, profile_time, post_time = tune_gemm_config(
                                                                 ^^^^^^^^^^^^^^^^^
  File "/dockerx/triton/python/perf-kernels/tools/tune_gemm/./tune_gemm.py", line 255, in tune_gemm_config
    df_prof = [pd.read_csv(f"{get_output_dir()}/{i}_kernel_trace.csv") for i in range(jobs)]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1026, in read_csv
    return _read(filepath_or_buffer, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 620, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1620, in __init__
    self._engine = self._make_engine(f, self.engine)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1880, in _make_engine
    self.handles = get_handle(
                   ^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pandas/io/common.py", line 873, in get_handle
    handle = open(
             ^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/dockerx/triton/python/perf-kernels/tools/tune_gemm/output/0_kernel_trace.csv'
```

</details>

---

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
