### PR TITLE
[3.4.x] cherry pick 7793 for range analysis to fix a memory access segfault

### DIFF
--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -9,12 +9,18 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %numps = tt.get_num_programs x : i32
+    %c65536_i32 = arith.constant 65536 : i32
+    %cmpule_programs = arith.cmpi ule, %numps, %c65536_i32 : i32
+    llvm.intr.assume %cmpule_programs : i1
     %2 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
     %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
     %4 = tt.load %3 : tensor<1024x!tt.ptr<f32>>
@@ -59,6 +65,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -80,6 +89,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -111,6 +123,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -139,6 +154,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -191,6 +209,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -239,6 +260,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -293,6 +317,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -341,6 +368,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -378,6 +408,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -416,6 +449,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -439,6 +475,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 16776960] signed : [0, 16776960]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c256_i32 : i32
@@ -479,6 +518,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 8388480] signed : [0, 8388480]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c128_i32 : i32
@@ -517,6 +559,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -550,6 +595,9 @@ module attributes {"ttg.num-ctas" = 1 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -577,6 +625,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     %1 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
     %2 = tt.addptr %arg0, %0 : !tt.ptr<f32>, i32
     // expected-remark@+2 {{unsigned : [0, 1024] signed : [0, 1024]}}
@@ -685,6 +736,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -742,6 +796,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -821,6 +878,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid : i1
     // expected-remark@+2 {{unsigned : [0, 67107840] signed : [0, 67107840]}}
     // expected-remark@+1 {{non-neg}}
     %1 = arith.muli %0, %c1024_i32 : i32
@@ -1230,12 +1290,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_num_programs x : i32
+    %c65536_i32 = arith.constant 65536 : i32
+    %cmpule_num_program0 = arith.cmpi ule, %0, %c65536_i32 : i32
+    llvm.intr.assume %cmpule_num_program0 : i1
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %1 = tt.get_num_programs y : i32
+    %cmpule_num_program1 = arith.cmpi ule, %1, %c65536_i32 : i32
+    llvm.intr.assume %cmpule_num_program1 : i1
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %2 = tt.get_num_programs z : i32
+    %cmpule_num_program2 = arith.cmpi ule, %2, %c65536_i32 : i32
+    llvm.intr.assume %cmpule_num_program2 : i1
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %3 = arith.minsi %0, %1 : i32
@@ -1564,12 +1631,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %0 = tt.get_program_id x : i32
+    %c65535_i32 = arith.constant 65535 : i32
+    %cmpule_pid0 = arith.cmpi ule, %0, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid0 : i1
     // expected-remark@+2 {{unsigned : [0, 65535] signed : [0, 65535]}}
     // expected-remark@+1 {{non-neg}}
     %1 = tt.get_program_id y : i32
+    %cmpule_pid1 = arith.cmpi ule, %1, %c65535_i32 : i32
+    llvm.intr.assume %cmpule_pid1 : i1
     // expected-remark@+2 {{unsigned : [0, 65536] signed : [0, 65536]}}
     // expected-remark@+1 {{non-neg}}
     %2 = tt.get_num_programs y : i32
+    %c65536_i32 = arith.constant 65536 : i32
+    %cmpule_num_program1 = arith.cmpi ule, %2, %c65536_i32 : i32
+    llvm.intr.assume %cmpule_num_program1 : i1
     // expected-remark@+2 {{unsigned : [0, 2097120] signed : [0, 2097120]}}
     // expected-remark@+1 {{non-neg}}
     %3 = arith.muli %0, %c32_i32 : i32

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -87,7 +87,7 @@ triton::AMD::TritonIntegerRangeAnalysis::maybeGetTripCount(
 namespace {
 
 constexpr int64_t kDefaultMaxTripCount = 1024;
-constexpr int64_t kDefaultMaxPrograms = 2 << 15; // 65536
+constexpr uint64_t kDefaultMaxPrograms = 1L << 31; // 2147483648
 
 void getEnclosingLoops(Operation &op, SmallVector<LoopLikeOpInterface> &ops) {
   Operation *currOp = op.getParentOp();


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is to cherry-pick the PR7793 to the release/internal/3.4.x to fix a segfault issue in torch inductor.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
