### PR TITLE
[AMD] reimplement fast_tanhf() to avoid overflow (#8551)

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -184,29 +184,48 @@ private:
       assert(operands[0].getType().getIntOrFloatBitWidth() == 32);
       LLVM::FastmathFlagsAttr defaultFlags{};
 
-      // Calculate 2*x
-      auto twoX = rewriter.create<LLVM::FMulOp>(
-          loc, rewriter.getF32Type(), operands[0],
+      // Numerically stable tanh implementation:
+      // For positive x: tanh(x) = 1 - 2/(e^(2x) + 1)
+      // For negative x: tanh(x) = -tanh(-x) = -(1 - 2/(e^(-2x) + 1))
+      //                         = 2/(e^(-2x) + 1) - 1
+      // This avoids overflow when e^(2x) becomes infinity for large x
+
+      // Get absolute value of x
+      auto absX = rewriter.create<LLVM::FAbsOp>(loc, rewriter.getF32Type(),
+                                                operands[0]);
+
+      // Calculate 2*|x|
+      auto twoAbsX = rewriter.create<LLVM::FMulOp>(
+          loc, rewriter.getF32Type(), absX,
           LLVM::createConstantF32(loc, rewriter, 2.0), defaultFlags);
 
-      // Calculate fast_expf(2*x) using the utility function
-      auto exp2X = createFastExpf(rewriter, loc, twoX->getResult(0),
-                                  rewriter.getF32Type(), ftz);
+      // Calculate e^(2*|x|)
+      auto exp2AbsX = createFastExpf(rewriter, loc, twoAbsX->getResult(0),
+                                     rewriter.getF32Type(), ftz);
 
-      // Calculate exp2X - 1
-      auto exp2XMinus1 = rewriter.create<LLVM::FSubOp>(
-          loc, rewriter.getF32Type(), exp2X->getResult(0),
+      // Calculate e^(2*|x|) + 1
+      auto exp2AbsXPlus1 = rewriter.create<LLVM::FAddOp>(
+          loc, rewriter.getF32Type(), exp2AbsX->getResult(0),
           LLVM::createConstantF32(loc, rewriter, 1.0), defaultFlags);
 
-      // Calculate exp2X + 1
-      auto exp2XPlus1 = rewriter.create<LLVM::FAddOp>(
-          loc, rewriter.getF32Type(), exp2X->getResult(0),
-          LLVM::createConstantF32(loc, rewriter, 1.0), defaultFlags);
-
-      // Calculate tanh(X) = (exp2X - 1) / (exp2X + 1)
-      replacementOp = rewriter.create<LLVM::FDivOp>(
-          loc, returnType, exp2XMinus1->getResult(0), exp2XPlus1->getResult(0),
+      // Calculate 2 / (e^(2*|x|) + 1)
+      auto two = LLVM::createConstantF32(loc, rewriter, 2.0);
+      auto ratio = rewriter.create<LLVM::FDivOp>(
+          loc, rewriter.getF32Type(), two, exp2AbsXPlus1->getResult(0),
           defaultFlags);
+
+      // Calculate 1 - 2/(e^(2*|x|) + 1)
+      auto one = LLVM::createConstantF32(loc, rewriter, 1.0);
+      auto posResult = rewriter.create<LLVM::FSubOp>(
+          loc, rewriter.getF32Type(), one, ratio->getResult(0), defaultFlags);
+
+      // Apply the sign of the original input using copysign
+      // tanh(x) = sign(x) * (1 - 2/(e^(2*|x|) + 1))
+      const char *intrinsic = "llvm.copysign.f32";
+      auto args =
+          llvm::SmallVector<Value>{posResult->getResult(0), operands[0]};
+      replacementOp = LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic,
+                                                      returnType, args);
     }
 
     if (replacementOp) {


### PR DESCRIPTION
The original formula is:
```
tanh(x) = (e^(2x) - 1) / (e^(2x) + 1)
```
- Issue with large positive x:
   - When x = 20: e^(40) ≈ 2.4 × 10^17 → manageable
   - When x = 50: e^(100) ≈ 2.7 × 10^43 → overflow to infinity
   - Result: (∞ - 1)/(∞ + 1) = NaN x
- For negative x: The formula actually works fine because e^(2x) → 0, giving (-1)/(1) = -1

- For Positive x: Reformulation
```
tanh(x) = (e^(2x) - 1) / (e^(2x) + 1) = (e^(2x) + 1 - 2) / (e^(2x) + 1) = 1 - 2/(e^(2x) + 1)
```
-  For Negative x: Using Symmetry
```
tanh(-x) = (e^(-2x) - 1) / (e^(-2x) + 1) =  (2/(e^(-2x) + 1) - 1) = -1 × (1 - 2/(e^(2|x|) + 1))
```

```
tanh(x) = sign(x) × (1 - 2/(e^(2|x|) + 1))
```
NOTE: Same as upstream implementation by @xiaohuguo2023 but with old LLVM API.

(cherry picked from commit 3f5eb5075e4f4875a0f12d686c958a0f15e901cc)
(cherry picked from commit 60297e65946a6bdde5b4c32aa68af54c95909560)