### PR TITLE
Update __init__.py

### DIFF
--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = "3.5.1"
+__version__ = '3.5.1'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
Validation:http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/10023/
We will need to update the triton.txt commit
<img width="740" height="195" alt="{0AC18750-EA1B-4ACA-A6DC-379CAA74A165}" src="https://github.com/user-attachments/assets/d46235f7-4a8d-4268-bf0b-e2ed96c23250" />

```

[2025-11-20T05:57:52.903Z] HEAD is now at d63831ae4 Remove git version suffix

[2025-11-20T05:57:53.160Z] Traceback (most recent call last):

[2025-11-20T05:57:53.160Z]   File "/pytorch/.github/scripts/build_triton_wheel.py", line 200, in <module>

[2025-11-20T05:57:53.160Z]     main()

[2025-11-20T05:57:53.160Z]   File "/pytorch/.github/scripts/build_triton_wheel.py", line 187, in main

[2025-11-20T05:57:53.160Z]     build_triton(

[2025-11-20T05:57:53.160Z]   File "/pytorch/.github/scripts/build_triton_wheel.py", line 131, in build_triton

[2025-11-20T05:57:53.160Z]     patch_init_py(

[2025-11-20T05:57:53.160Z]   File "/pytorch/.github/scripts/build_triton_wheel.py", line 48, in patch_init_py

[2025-11-20T05:57:53.160Z]     orig = check_and_replace(

[2025-11-20T05:57:53.160Z]            ^^^^^^^^^^^^^^^^^^

[2025-11-20T05:57:53.160Z]   File "/pytorch/.github/scripts/build_triton_wheel.py", line 36, in check_and_replace

[2025-11-20T05:57:53.160Z]     raise RuntimeError(f"Can't find ${src} in the input")

[2025-11-20T05:57:53.160Z] RuntimeError: Can't find $__version__ = '3.5.1' in the input

script returned exit code 1
```