### PR TITLE
Update Triton to include ld.lld path detection fix using rocm-sdk command

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -171,6 +171,25 @@ class HIPBackend(BaseBackend):
             lld = Path(lld_env_path)
             if lld.is_file():
                 return lld
+    
+        # Check ROCM_PATH environment variable
+        rocm_path = os.getenv("ROCM_PATH")
+        if rocm_path is not None:
+            lld = Path(rocm_path) / "llvm/bin/ld.lld"
+            if lld.is_file():
+                return lld
+
+        # Try rocm-sdk command
+        try:
+            sdk_root = subprocess.check_output(
+                ["rocm-sdk", "path", "--root"], text=True
+            ).strip()
+            lld = Path(sdk_root) / "llvm/bin/ld.lld"
+            if lld.is_file():
+                return lld
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            pass
+            
         # Check backend for ld.lld (used for pytorch wheels)
         lld = Path(__file__).parent / "llvm/bin/ld.lld"
         if lld.is_file():

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -179,9 +179,7 @@ class HIPBackend(BaseBackend):
                 return lld
         # Try rocm-sdk command
         try:
-            sdk_root = subprocess.check_output(
-                ["rocm-sdk", "path", "--root"], text=True
-            ).strip()
+            sdk_root = subprocess.check_output(["rocm-sdk", "path", "--root"], text=True).strip()
             lld = Path(sdk_root) / "llvm/bin/ld.lld"
             if lld.is_file():
                 return lld

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -171,14 +171,12 @@ class HIPBackend(BaseBackend):
             lld = Path(lld_env_path)
             if lld.is_file():
                 return lld
-    
         # Check ROCM_PATH environment variable
         rocm_path = os.getenv("ROCM_PATH")
         if rocm_path is not None:
             lld = Path(rocm_path) / "llvm/bin/ld.lld"
             if lld.is_file():
                 return lld
-
         # Try rocm-sdk command
         try:
             sdk_root = subprocess.check_output(
@@ -189,7 +187,6 @@ class HIPBackend(BaseBackend):
                 return lld
         except (FileNotFoundError, subprocess.CalledProcessError):
             pass
-            
         # Check backend for ld.lld (used for pytorch wheels)
         lld = Path(__file__).parent / "llvm/bin/ld.lld"
         if lld.is_file():


### PR DESCRIPTION

Improves the AMD backend's `path_to_rocm_lld()` function to automatically detect the ROCm HIP linker (ld.lld) in more installation scenarios, particularly for ROCm SDK installations where `rocm-sdk` command is available.


Currently, Triton fails to locate `ld.lld` unless the `TRITON_HIP_LLD_PATH` environment variable is explicitly set, even when ROCm is correctly installed and available in the system PATH. This affects users with non-standard ROCm installation paths, particularly those using `rocm-sdk`.

Related issue: ROCm/TheRock#2006

## Changes

**Added ROCM_PATH environment variable support**: Check `ROCM_PATH/llvm/bin/ld.lld` if the variable is set
**Added rocm-sdk command detection**: Run `rocm-sdk path --root` to discover SDK-based ROCm installations

## Testing

Tested on ROCm 7.10.0 with ROCm SDK installation where `ld.lld` is located at `$(rocm-sdk path --root)/llvm/bin/ld.lld`. The fix successfully detects the linker without requiring manual `TRITON_HIP_LLD_PATH` export.

---

**Checklist:**

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these rules.
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

**Testing:**
- [x] This PR does not need a test because it improves runtime path detection logic that depends on the system environment and ROCm installation, which cannot be reliably mocked in unit tests. The fix was manually tested on ROCm 7.10.0

**Lit tests:**
- [x] I have not added any lit tests.