### PR TITLE
[AMD] flash-attention: Support all gfx10/11/12 targets

### DIFF
--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -383,8 +383,8 @@ def is_cdna():
 
 
 def is_rdna():
-    return is_hip() and triton.runtime.driver.active.get_current_target().arch in ("gfx1030", "gfx1100", "gfx1101",
-                                                                                   "gfx1102", "gfx1200", "gfx1201")
+    arch = triton.runtime.driver.active.get_current_target().arch
+    return is_hip() and (arch.startswith("gfx10") or arch.startswith("gfx11") or arch.startswith("gfx12"))
 
 
 def get_cdna_autotune_configs():


### PR DESCRIPTION
When computing the auto-tuning configs for flash attention, support all targets from the gfx10/11/12 families instead of just a limited list. In particular, this adds support for the gfx1103, gfx1150, gfx1151, gfx1152, gfx1153 targets.

I have run `python3 -m pytest -v --tb=short ./python/perf-kernels/flash-attention.py` on gfx1150, and most test cases pass.
The failures I saw are out-of-memory on large sequence lengths (gfx1150 doesn't have much VRAM).
And a flaky
```
______________ test_op_fwd_int8[bhsd-True-True-4-48-1024-1024-64] ______________
python/perf-kernels/flash-attention.py:1597: in test_op_fwd_int8
    torch.testing.assert_close(ref_out, tri_out, atol=2e-2, rtol=2e-2)
E   AssertionError: Tensor-likes are not close!
E   
E   Mismatched elements: 431 / 12582912 (0.0%)
E   Greatest absolute difference: 0.11566162109375 at index (1, 2, 10, 2) (up to 0.02 allowed)
E   Greatest relative difference: 52.9375 at index (0, 2, 264, 19) (up to 0.02 allowed)
```
which passed on rerun.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] This PR does not need a test because the existing tests cover it.