### PR TITLE
[release/internal/3.6.x] Remove git version suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -803,7 +803,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.6.0" + get_triton_version_suffix()
+TRITON_VERSION = "3.6.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)


### PR DESCRIPTION
Cherry-pick of d63831ae4a73b8fdac814f1bc060d669a8ae1b06 to release/internal/3.6.x

This removes the git version suffix from the Triton version string.