### PR TITLE
add a heuristic to set kWidth for attention decode

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -10,7 +10,6 @@ import re
 import functools
 import warnings
 from pathlib import Path
-import os
 
 
 def get_min_dot_size(target: GPUTarget):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -10,6 +10,7 @@ import re
 import functools
 import warnings
 from pathlib import Path
+import os
 
 
 def get_min_dot_size(target: GPUTarget):
@@ -260,6 +261,23 @@ class HIPBackend(BaseBackend):
         if use_async_copy:
             amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
         pm.run(mod)
+
+        # It there're multiple kernels and you only want to replace one of them, you can use 
+        # AMD_INSERT_TTGIR="<kernel_name>:<filename>" to filter. Or just use AMD_INSERT_TTGIR="<filename>"
+        if "AMD_INSERT_TTGIR" in os.environ.keys():
+            fn = os.environ['AMD_INSERT_TTGIR']
+            if ':' in fn:
+                kernel_name, insert_module_path = fn.split(':')
+                print(f"Replace kernel {kernel_name}'s ttgir with {insert_module_path}")            
+                if not mod.has_function(kernel_name):
+                    return mod
+            else:
+                insert_module_path = fn
+                print(f"Replace kernel's ttgir with {insert_module_path}")
+            ctx = mod.context
+            mod = ir.parse_mlir_module(insert_module_path, ctx)
+            mod.context = ctx
+            
         return mod
 
     @staticmethod

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -261,23 +261,6 @@ class HIPBackend(BaseBackend):
         if use_async_copy:
             amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
         pm.run(mod)
-
-        # It there're multiple kernels and you only want to replace one of them, you can use 
-        # AMD_INSERT_TTGIR="<kernel_name>:<filename>" to filter. Or just use AMD_INSERT_TTGIR="<filename>"
-        if "AMD_INSERT_TTGIR" in os.environ.keys():
-            fn = os.environ['AMD_INSERT_TTGIR']
-            if ':' in fn:
-                kernel_name, insert_module_path = fn.split(':')
-                print(f"Replace kernel {kernel_name}'s ttgir with {insert_module_path}")            
-                if not mod.has_function(kernel_name):
-                    return mod
-            else:
-                insert_module_path = fn
-                print(f"Replace kernel's ttgir with {insert_module_path}")
-            ctx = mod.context
-            mod = ir.parse_mlir_module(insert_module_path, ctx)
-            mod.context = ctx
-            
         return mod
 
     @staticmethod

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -623,7 +623,6 @@ public:
         oldAType.getShape().front() >= 16 * 2 &&
         oldBType.getShape().back() == 16 && isChainDotHead(dotOp);
 
-
     ttg::AMDMfmaEncodingAttr mfmaEnc;
     if (isMfma16InBwdFA) {
       // Use tilesPerWarp of [2, 1] for the mfma16x16 layout of a chain dot head

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -623,6 +623,7 @@ public:
         oldAType.getShape().front() >= 16 * 2 &&
         oldBType.getShape().back() == 16 && isChainDotHead(dotOp);
 
+
     ttg::AMDMfmaEncodingAttr mfmaEnc;
     if (isMfma16InBwdFA) {
       // Use tilesPerWarp of [2, 1] for the mfma16x16 layout of a chain dot head
@@ -684,7 +685,18 @@ public:
     // to #dotOp (operand 0 of 2nd dot) is a no-op.
     // TODO (lixun): relax the condition for 8-bit elementTy.
     if (is16BitElemTy && isDotChainTail) {
-      kWidth = 4;
+      kWidth = 8;
+      auto mod = dotOp->getParentOfType<ModuleOp>();
+      unsigned iWarpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+
+      auto aShape = oldAType.getShape();
+      auto bShape = oldBType.getShape();
+
+      auto dotASize = aShape.front() * aShape.back();
+      auto dotBSize = bShape.front() * bShape.back();
+      if (kWidth * iWarpSize > dotASize || kWidth * iWarpSize > dotBSize) {
+        kWidth = 4;
+      }
     }
 
     Value newDot;


### PR DESCRIPTION
This PR adds a heuristic to set the KWidth for attention. kWidth is set to 8 by default, but if there are not enough elements for each lane to load 8 elements, kWidth is ajdusted to 4.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
