### PR TITLE
use cmake==4

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=40.8.0
 wheel
-cmake>=3.20,<4.0
+cmake==4.0
 ninja>=1.11.1
 pybind11>=2.13.1
 lit


### PR DESCRIPTION
Update triton req to use cmake==4
 local build of triton for release/2.10 without that cmake version constraint, and see if it can build successfully with cmake 4
 
 
Able to locally build triton with cmake==4
```
-rw-r--r--  1 root root 341200978 Feb 19 19:10 triton_rocm-3.6.0-cp312-cp312-linux_x86_64.whl
root@rocm-framework-47:/workspace/triton/dist#
 root@rocm-framework-47:/workspace/triton# pip list | grep cmake
cmake                      4.0.0
 
```