### PR TITLE
cherry pick pr9444 from upstream to allow explicit module unload

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -2,6 +2,7 @@ import expecttest
 import importlib.util
 import itertools
 import os
+import gc
 import shutil
 import pathlib
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
@@ -825,3 +826,34 @@ def test_higher_order_kernel(device, fresh_triton_cache, capsys):
 Compiling with fn_a
 Compiling with fn_a after modification
 """)
+
+def test_module_load_unload(device, fresh_knobs):
+
+    @triton.jit
+    def kernel(out_ptr, val) -> None:
+        tl.store(out_ptr, val)
+
+    # we should hit the module unload call to decrese the counter from 1 to 0
+    counter = 1
+
+    def module_unload(*args, **kwargs):
+        nonlocal counter
+        counter -= 1
+
+    # turn off python garbage collector, so the callback is not called
+    # in the garbage collector
+    gc.disable()
+    triton.knobs.runtime.module_unload_hook.add(module_unload)
+
+    out = torch.randn(1, dtype=torch.float32, device=device)
+    pre_compile = kernel.warmup(out, 1, grid=(1, ))
+    pre_compile._init_handles()
+
+    assert counter == 1
+    assert pre_compile.module is not None
+    pre_compile.__del__()
+
+    assert counter == 0
+    assert pre_compile.module is None
+    # turn on garbage collector
+    gc.enable()

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -827,6 +827,7 @@ Compiling with fn_a
 Compiling with fn_a after modification
 """)
 
+
 def test_module_load_unload(device, fresh_knobs):
 
     @triton.jit

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -433,6 +433,15 @@ class CompiledKernel:
         self.function = None
         self._run = None
 
+    def __del__(self):
+
+        if self.module is not None:
+            if knobs.runtime.module_unload_hook is not None:
+                knobs.runtime.module_unload_hook(self.module, self.function, self.name, self.metadata_group, self.hash)
+
+            driver.active.utils.unload_module(self.module)
+            self.module = None
+
     def _init_handles(self):
         if self.module is not None:
             return

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -470,6 +470,9 @@ class runtime_knobs(base_knobs):
     kernel_load_start_hook: HookChain[InitHandleHook] = HookChain()
     kernel_load_end_hook: HookChain[InitHandleHook] = HookChain(reversed=True)
 
+    # hook to unload module when kernel is freed
+    module_unload_hook: HookChain[InitHandleHook] = HookChain()
+
     # Hook for inspecting compiled functions and modules
     jit_cache_hook: Optional[JITHook] = None
     # Hook to signal that a kernel is done compiling and inspect compiled function.

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -130,6 +130,7 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
   FOR_EACH_ERR_FN(hipModuleLoadDataEx, hipModule_t *module, const void *image, \
                   unsigned int numOptions, hipJitOption *options,              \
                   void **optionValues)                                         \
+  FOR_EACH_ERR_FN(hipModuleUnload, hipModule_t module)                         \
   FOR_EACH_ERR_FN(hipModuleGetFunction, hipFunction_t *function,               \
                   hipModule_t module, const char *kname)                       \
   FOR_EACH_ERR_FN(hipFuncGetAttribute, int *, hipFunction_attribute attr,      \
@@ -469,9 +470,22 @@ cleanup:
   return NULL;
 }
 
+static PyObject *unloadModule(PyObject *self, PyObject *args) {
+  hipModule_t mod;
+  if (!PyArg_ParseTuple(args, "K", &mod)) {
+    return NULL;
+  }
+
+  HIP_CHECK(hipSymbolTable.hipModuleUnload(mod))
+
+  return Py_None;
+}
+
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided hsaco into HIP driver"},
+    {"unload_module", unloadModule, METH_VARARGS,
+     "unload provided module to free memory"},
     {"get_device_properties", getDeviceProperties, METH_VARARGS,
      "Get the properties for a given device"},
     {"create_tdm_descriptor", createTDMDescriptor, METH_VARARGS,

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -175,6 +175,7 @@ class HIPUtils(object):
         src = src.replace('/*py_libhip_search_path*/', libhip_path, 1)
         mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)
         self.load_binary = mod.load_binary
+        self.unload_module = mod.unload_module
         self.get_device_properties = mod.get_device_properties
         self.create_tdm_descriptor = mod.create_tdm_descriptor
         global PyTDMDescriptor

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -163,6 +163,19 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
                        n_spills, n_max_threads);
 }
 
+static PyObject *unloadModule(PyObject *self, PyObject *args) {
+  CUmodule mod;
+  if (!PyArg_ParseTuple(args, "K", &mod)) {
+    return NULL;
+  }
+
+  Py_BEGIN_ALLOW_THREADS;
+  CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuModuleUnload(mod));
+  Py_END_ALLOW_THREADS;
+
+  return Py_None;
+}
+
 typedef CUresult (*cuOccupancyMaxActiveClusters_t)(
     int *numClusters, CUfunction func, const CUlaunchConfig *config);
 
@@ -480,6 +493,8 @@ cleanup:
 static PyMethodDef ModuleMethods[] = {
     {"load_binary", loadBinary, METH_VARARGS,
      "Load provided cubin into CUDA driver"},
+    {"unload_module", unloadModule, METH_VARARGS,
+     "Unload provided module to free memory"},
     {"get_device_properties", getDeviceProperties, METH_VARARGS,
      "Get the properties for a given device"},
     {"cuOccupancyMaxActiveClusters", occupancyMaxActiveClusters, METH_VARARGS,

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -69,6 +69,7 @@ class CudaUtils(object):
         global PyCUtensorMap
         PyCUtensorMap = mod.PyCUtensorMap
         self.load_binary = mod.load_binary
+        self.unload_module = mod.unload_module
         self.get_device_properties = mod.get_device_properties
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters
         self.set_printf_fifo_size = mod.set_printf_fifo_size


### PR DESCRIPTION
This PR is a cherry-pick of upstream (PR#9444)(https://github.com/triton-lang/triton/pull/9444) to allow explicit module unload.


- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
