### PR TITLE
[release/internal/3.5.x] Fix null-ptr crash in TritonAMDGPUOptimizeDotOperands when tt.trans takes load result directly

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDotOperands.cpp
@@ -83,6 +83,8 @@ public:
       if (auto transOp = dyn_cast_or_null<tt::TransOp>(op)) {
         LDBG("Found tranpose op: " << *transOp);
         cvtOp = transOp.getSrc().getDefiningOp<ttg::ConvertLayoutOp>();
+        if (!cvtOp)
+          continue;
         LDBG("Found parent cvt op of transpose: " << *cvtOp);
         usedValue = transOp->getResult(0);
         op =


### PR DESCRIPTION
# [AMD] Fix null-ptr crash in TritonAMDGPUOptimizeDotOperands when tt.trans takes load result directly

## Problem

`TritonAMDGPUOptimizeDotOperands` crashes with `PassManager::run failed` when
compiling the flex attention backward kernel on gfx120x. The
failure is a null-pointer dereference in the `ReuseShmemForDirectAndTransposedUse`
pattern.

When `tt.trans` uses the load result directly,
`transOp.getSrc().getDefiningOp<ConvertLayoutOp>()` returns `nullptr`. The code
then passes this null `cvtOp` into `rewriter.modifyOpInPlace(cvtOp, ...)`,
crashing the pass manager. There is also a latent null-dereference in the `LDBG`
line immediately after (debug builds only).

## Fix

One-line null check: if no `ConvertLayoutOp` precedes `tt.trans`, skip this user
with `continue`. The pattern then falls through to the existing `if (!transDot)`
guard and returns `notifyMatchFailure` gracefully, leaving the IR unchanged.

```cpp
cvtOp = transOp.getSrc().getDefiningOp<ttg::ConvertLayoutOp>();
if (!cvtOp)
  continue;
```

Ref #ROCM-1778

The file has changed in upstream/main, so this should be only 3.5 specific change. There is no failure on version 3.6