### PR TITLE
specify rocprofv3 csv out format to fix a error

### DIFF
--- a/python/perf-kernels/tools/tune_gemm/tune_gemm.py
+++ b/python/perf-kernels/tools/tune_gemm/tune_gemm.py
@@ -205,7 +205,7 @@ def profile_batch_kernels(M, N, K, gpuid, gpus, jobs, verbose):
             print(f"profiling {kernel_name} on GPU {gpuid}")
         here = Path(__file__).parent
         run_bash_command_wrapper(
-            f"PYTHONPATH={here} rocprofv3 --kernel-trace -o {get_output_dir()}/{jobId} --log-level fatal -- python {get_filename_profile_driver(M, N, K, jobId)}",
+            f"PYTHONPATH={here} rocprofv3 --kernel-trace -o {get_output_dir()}/{jobId} -f csv --log-level fatal -- python {get_filename_profile_driver(M, N, K, jobId)}",
             capture=(verbose < 2))
         jobId += ngpus
 


### PR DESCRIPTION
rocprofv3 trace output format is SQLite3-based database format by default. Tune_gemm needs to use .csv, so an error reported when parsing profiling results. This PR changes the rocprofv3 output format to `.csv` to fix the rror

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
