### PR TITLE
[elease/internal/3.6.x] update pyproject.toml to use cmake 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=40.8.0", "cmake==4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]


### PR DESCRIPTION
To resolve PyTorch CI build failures due to cmake 4

```
[2026-04-02T19:31:12.119Z] #63 288.9 Processing ./dist/triton-3.6.0-cp312-cp312-linux_x86_64.whl
[2026-04-02T19:31:12.119Z] #63 288.9 Installing collected packages: triton
[2026-04-02T19:31:12.119Z] #63 288.9 Successfully installed triton-3.6.0
[2026-04-02T19:31:12.119Z] #63 288.9 + '[' -n 4.0.0 ']'
[2026-04-02T19:31:12.120Z] #63 288.9 + pip_install cmake==4.0.0
[2026-04-02T19:31:12.120Z] #63 288.9 + as_jenkins conda run -n py_3.12 pip install --progress-bar off cmake==4.0.0
[2026-04-02T19:31:12.120Z] #63 288.9 + sudo -E -H -u jenkins env -u SUDO_UID -u SUDO_GID -u SUDO_COMMAND -u SUDO_USER env PATH=/opt/conda/envs/py_3.12/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LD_LIBRARY_PATH= conda run -n py_3.12 pip install --progress-bar off cmake==4.0.0
[2026-04-02T19:31:13.084Z] #63 289.8 Requirement already satisfied: cmake==4.0.0 in /opt/conda/envs/py_3.12/lib/python3.12/site-packages (4.0.0)
[2026-04-02T19:31:13.084Z] #63 289.8 + '[' -n 2.1.2 ']'
```

from [https://ml-ci-internal.amd.com/job/pytorch/job/pytorch-ci-pipeline/job/PR-3124/2/pipeline-overview/…](https://ml-ci-internal.amd.com/job/pytorch/job/pytorch-ci-pipeline/job/PR-3124/2/pipeline-overview/?selected-node=106)