### PR TITLE
backport [AMD][TRITON_KERNELS] Improve MXFP4 matmul_ogs config on RDNA

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -131,20 +131,37 @@ def make_default_opt_flags_amd(
     if get_cdna_version() == 3 and rhs_dtype.bitwidth == 8 and precision_config.b_mx_scale is not None:
         num_stages = 1
 
-    # specific configs for F16 x MXFP4 on CDNA4
-    if is_cdna4 and lhs_dtype.bitwidth == 16 and rhs_dtype.bitwidth == 4 and precision_config.b_mx_scale is not None:
-        split_k = 1
-        if m <= 1024:
-            target_kernel_kwargs["waves_per_eu"] = 3
-            block_n = 128
-            block_k = 128
-            num_warps = 4
-        else:
+    if lhs_dtype.bitwidth == 16 and rhs_dtype.bitwidth == 4 and precision_config.b_mx_scale is not None:
+        # specific configs for F16 x MXFP4 on CDNA4
+        if is_cdna4:
+            split_k = 1
+            if m <= 1024:
+                target_kernel_kwargs["waves_per_eu"] = 3
+                block_n = 128
+                block_k = 128
+                num_warps = 4
+            else:
+                target_kernel_kwargs["waves_per_eu"] = 0
+                block_m = 64
+                block_n = 512
+                block_k = 256
+                num_warps = 8
+
+        # Specific configs for F16 x MXFP4 on RDNA.
+        if get_rdna_version() in (3, 4):
+            split_k = 1
             target_kernel_kwargs["waves_per_eu"] = 0
-            block_m = 64
-            block_n = 512
-            block_k = 256
-            num_warps = 8
+            num_stages = 1
+            if m <= 512:
+                block_m = 16
+                block_n = 64
+                block_k = 512
+                num_warps = 4
+            else:
+                block_m = 64
+                block_n = 128
+                block_k = 128
+                num_warps = 4
 
     def replace_with_valid_constraint(k: str, v):
         if constraints.get(k, None) is not None:


### PR DESCRIPTION
Add RDNA-specific MXFP4 matmul_ogs configs for GPT-OSS MoE shapes.

The configs were selected from an exhaustive search on both RDNA3 and RDNA4. Following the existing CDNA4-specific path, add tuned configs for RDNA by choosing different tile shapes for small and large M.

Backport of triton-lang/triton#10810.

