### PR TITLE
[release/internal/3.8.x] Backport coalesce default order revert

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -32,11 +32,9 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 const ArrayRef<int64_t> &shape,
                                                 Type type, int numWarps);
 
-// Gets the order of a tensor from its contiguity. Places the dimensions with
-// the largest contiguity as the inner most dimension. If the contiguity is
-// all ones, returns the order {dim - 1, dim - 2, ..., 0}
-SmallVector<unsigned, 4>
-getOrderFromContiguity(const SmallVector<int64_t> &contiguity);
+// Return an array of indices enumerating the elements of 'arr' in descending
+// order (so that result[i] is the index of the i-th largest element of 'arr')
+SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr);
 
 // Return the operand used to access the memory in the operation
 Value getMemAccessPtr(Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
@@ -29,7 +29,7 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
   });
 
   auto contiguity = axisInfoAnalysis.getAxisInfo(ptr)->getContiguity();
-  SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
+  SmallVector<unsigned> order = argSort(contiguity);
   LDBG("order=[" << triton::join(order, ", ") << "]");
 
   auto matchesShape = [&refTensorType](const Value &val) {
@@ -46,8 +46,8 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
       Value val = getMemAccessPtr(use);
       if (!val || !matchesShape(val) || memAccessesSameOrder.contains(use))
         continue;
-      auto currOrder = getOrderFromContiguity(
-          axisInfoAnalysis.getAxisInfo(val)->getContiguity());
+      auto currOrder =
+          argSort(axisInfoAnalysis.getAxisInfo(val)->getContiguity());
       if (order == currOrder) {
         LDBG("multi-root-slice: insert to memAccessesSameOrder " << *use);
         memAccessesSameOrder.insert(use);

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -88,11 +88,9 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
   }
 }
 
-SmallVector<unsigned, 4>
-getOrderFromContiguity(const SmallVector<int64_t> &arr) {
+SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr) {
   SmallVector<unsigned, 4> ret(arr.size());
   std::iota(ret.begin(), ret.end(), 0);
-  std::reverse(ret.begin(), ret.end());
   std::stable_sort(ret.begin(), ret.end(),
                    [&](unsigned x, unsigned y) { return arr[x] > arr[y]; });
   return ret;

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -285,20 +285,6 @@ tt.func @coalesce_poison(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [2, 4, 4], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @load_3D_contig_1(%arg: !tt.ptr<i8> {tt.divisibility = 16 : i32}) {
-    %50 = tt.splat %arg : !tt.ptr<i8> -> tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    // This checks that the pass picks the row-major ordering by default for elements with contiguity 1.
-    // CHECK: #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [2, 4, 4], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
-    // CHECK:  tt.load %1 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    %108 = tt.load %50 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    tt.return
-  }
-}
-
-// -----
-
 // CHECK: #[[$LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {


### PR DESCRIPTION
## Summary
- Backports the coalescing default-order revert from ROCm/triton#949 onto `release/internal/3.8.x`.
- Restores `argSort(contiguity)` behavior by removing the reverse fallback that made all-ones contiguity default to row-major ordering.
- Removes the 3D coalesce test that asserted the reverted row-major default behavior.

## Test plan
- `git diff --check`
- IDE lint diagnostics for touched files
- Locally built `triton-opt` and ran the CPU-only coalesce MLIR test:
  `/home/niromero/triton/build-cpu-lit/bin/triton-opt /home/niromero/triton/test/TritonGPU/coalesce.mlir -split-input-file -tritongpu-coalesce | /home/niromero/.local/bin/filecheck --enable-var-scope /home/niromero/triton/test/TritonGPU/coalesce.mlir`
  Result: passed with exit code 0.

Reference: https://github.com/ROCm/triton/pull/949
Cherry-picked-from: 60ae578a86e13dece714aa3b208c566c46c34ed1

Made with [Cursor](https://cursor.com)