### PR TITLE
[release/internal/3.8.x] Use CMake 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "cmake>=3.20,<4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=40.8.0", "cmake==4.0", "ninja>=1.11.1", "pybind11>=2.13.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=40.8.0
 wheel
-cmake>=3.20,<4.0
+cmake==4.0
 ninja>=1.11.1
 pybind11>=2.13.1
 lit


### PR DESCRIPTION
## Summary
- Cherry-pick ROCm/triton#955 to use `cmake==4.0` in `python/requirements.txt`.
- Cherry-pick ROCm/triton#936 so `pyproject.toml` build-system requirements also use `cmake==4.0`.
- Keep requirements and PEP 517 build metadata aligned for CMake 4.0 builds.

## Test plan
- [x] `python3 -m pip install --target /tmp/triton-cmake4-build-deps -r python/requirements.txt`
- [x] Verified isolated dependency path uses `cmake version 4.0.0`
- [x] `TRITON_BUILD_DIR=/tmp/triton-cmake4-build TRITON_HOME=/tmp/triton-cmake4-home MAX_JOBS=2 python3 setup.py build --build-base /tmp/triton-cmake4-build-py`

Note: an initial `MAX_JOBS=8` local build was killed by the OS while compiling `BlockPingpong.cpp` (`cc1plus` killed), consistent with local memory pressure. Retrying the same build with `MAX_JOBS=2` completed successfully.

Made with Cursor.

Made with [Cursor](https://cursor.com)