### PR TITLE
[release/internal/3.8.x] Remove git version suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -564,7 +564,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.8.0" + get_triton_version_suffix()
+TRITON_VERSION = "3.8.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)


### PR DESCRIPTION
> Part of the ROCm release/2.11 wheel-build fix stack tracked by ROCm/pytorch#3477 (all pieces validated together in one combined green build). Jira: https://amd-hub.atlassian.net/browse/AIPYTORCH-827

## Why

When a consumer (e.g. PyTorch's `build_triton_wheel.py`) checks out a pinned commit as a detached HEAD, `get_triton_version_suffix()` appends a `+git<sha>` segment. Combined with the externally supplied `TRITON_WHEEL_VERSION_SUFFIX` (e.g. `+rocm<ver>.git<sha>`, whose `+` is then rewritten to `-`), the wheel ends up versioned `3.8.0+git<sha>.rocm<ver>.git<sha>`.

That no longer matches the `triton==3.8.0+rocm<ver>.git<sha>` dependency that gets pinned into the torch wheel, so `pip install torch` fails to resolve triton:

```
ERROR: Could not find a version that satisfies the requirement triton==3.8.0+rocm7.2.4.git4cff872c
       (from versions: ..., 3.8.0+git4cff872c.rocm7.2.4.git4cff872c)
ERROR: No matching distribution found for triton==3.8.0+rocm7.2.4.git4cff872c
```

## Fix

Build `TRITON_VERSION` from the base version plus only the externally supplied `TRITON_WHEEL_VERSION_SUFFIX`, instead of also appending the git commit hash via `get_triton_version_suffix()`.

Mirrors the fix already applied to `release/internal/3.6.x` (#920).

