### PR TITLE
[AMD] Backport distributed/padded-layout AsyncCopy for gfx950 + fix MLA decode memory fault

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2044,9 +2044,12 @@ PaddedSharedEncodingAttr PaddedSharedEncodingAttr::get(
   auto outDimNames = standardOutDimNames(context, shape.size());
   StringAttr kOffset = StringAttr::get(context, "offset");
 
+  SmallVector<int64_t> shapePerCTA =
+      getShapePerCTA(cgaLayout.getCTASplitNum(), shape);
+
   // Create identity mapping based on shape and order
-  LinearLayout linearComponent =
-      identityStandardND(kOffset, SmallVector<unsigned>(shape), order);
+  LinearLayout linearComponent = identityStandardND(
+      kOffset, llvm::to_vector_of<unsigned>(shapePerCTA), order);
   linearComponent = combineCtaCgaWithShape(linearComponent, cgaLayout, shape);
 
   return get(context, intervalPads, std::move(linearComponent));

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -1,6 +1,6 @@
 from ..._core import ir, builtin, _unwrap_if_constexpr
 from ..._semantic import _check
-from ..._layouts import BlockedLayout, SliceLayout
+from ..._layouts import DistributedLayout
 from ..cdna3 import _verify_buffer_ops
 
 __all__ = [
@@ -46,8 +46,7 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(ptr.type.is_block(), lambda: "expected ptr to be a tensor")
-    _check(isinstance(ptr.type.layout, (BlockedLayout, SliceLayout)),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+    _check(isinstance(ptr.type.layout, DistributedLayout), lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         dest.shape == ptr.shape, lambda:
         f"expected dest shape to match pointer shape but got dest.shape = {dest.shape}, pointer.shape = {ptr.shape}")
@@ -102,8 +101,8 @@ def buffer_load_to_shared(dest, ptr, offsets, mask=None, other=None, cache_modif
         other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
-    _check(isinstance(offsets.type.layout, (BlockedLayout, SliceLayout)),
-           lambda: "expected offsets type layout to be BlockedLayout or SliceLayout")
+    _check(isinstance(offsets.type.layout, DistributedLayout),
+           lambda: "expected offsets type layout to be a DistributedLayout")
     _verify_buffer_ops(ptr, offsets, mask, other)
 
     mask = _unwrap_if_constexpr(mask)

--- a/python/triton/experimental/gluon/language/amd/gfx1250/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/async_copy.py
@@ -21,7 +21,7 @@ def global_to_shared(smem, pointer, mask=None, other=None, cache_modifier="", _s
     """
     _check(pointer.type.is_block(), lambda: "expected ptr to be a tensor")
     _check(isinstance(pointer.type.layout, DistributedLayout),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+           lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         smem.shape == pointer.shape, lambda:
         f"expected smem shape to match pointer shape but got smem.shape = {smem.shape}, pointer.shape = {pointer.shape}"
@@ -54,7 +54,7 @@ def shared_to_global(pointer, smem, mask=None, cache_modifier="", _semantic=None
     """
     _check(pointer.type.is_block(), lambda: "expected ptr to be a tensor")
     _check(isinstance(pointer.type.layout, DistributedLayout),
-           lambda: "expected ptr type layout to be BlockedLayout or SliceLayout")
+           lambda: "expected ptr type layout to be a DistributedLayout")
     _check(
         smem.shape == pointer.shape, lambda:
         f"expected smem shape to match pointer shape but got smem.shape = {smem.shape}, pointer.shape = {pointer.shape}"

--- a/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=2" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
+
+#blocked1 = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}}vec = 1, {{.*}} order = [1, 0]
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 4], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_shared_vec2_clamp_to_vec1
+  tt.func @async_copy_shared_vec2_clamp_to_vec1(%arg0: tensor<16x32x!tt.ptr<f32>, #blocked1> {tt.contiguity = dense<[1, 2]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+                %arg1: tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<16x32xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <16x32xf32, #shared, #smem, mutable>
+    %cst = arith.constant dense<32> : tensor<16x32xi32, #blocked1>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x32xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x32xf32, #mma>) : i32 {
+      %a = tt.load %arg0 : tensor<16x32x!tt.ptr<f32>, #blocked1>
+      %a_dot = ttg.convert_layout %a : tensor<16x32xf32, #blocked1> -> tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %a_dot, %arg1, %acc : tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x32xf32, #mma>
+      scf.yield %c : tensor<16x32xf32, #mma>
+    }
+    tt.return %result : tensor<16x32xf32, #mma>
+  }
+}
+
+// -----
+
+// Test with #blocked layout (sizePerThread = [1, 1]) for the 32x32 load
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}} order = [1, 0]
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 4], isTransposed = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_shared_layout_vec1_order
+  tt.func @async_copy_shared_layout_vec1_order(%arg0: tensor<32x32x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+                %arg1: tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>,
+                %lb: i32, %ub: i32, %step: i32) -> tensor<16x32xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <32x32xf32, #shared, #smem, mutable>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x32xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x32xf32, #mma>) : i32 {
+      %b = tt.load %arg0 : tensor<32x32x!tt.ptr<f32>, #blocked>
+      %b_dot = ttg.convert_layout %b : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %arg1, %b_dot, %acc : tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x32xf32, #mma>
+      scf.yield %c : tensor<16x32xf32, #mma>
+    }
+    tt.return %result : tensor<16x32xf32, #mma>
+  }
+}

--- a/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-shared-layout-async-copy-gfx9.mlir
@@ -43,3 +43,53 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %result : tensor<16x32xf32, #mma>
   }
 }
+
+// -----
+
+// For sizePerThrad=[1, 1] threadsPerWarp=[1, 64] order=[1, 0] and dim1=64 the registers will be contigious along dim0 which is the *non* contig dimension.
+// Check that we correctly follow the memory order which will be the lane order instead of the register order.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}} order = [1, 0]
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [16, 16, 4], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_lanes_cover_contig_dim
+  tt.func @async_copy_lanes_cover_contig_dim(
+              %arg0: tensor<16x64x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+              %arg1: tensor<64x16xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>,
+              %lb: i32, %ub: i32, %step: i32) -> tensor<16x16xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <16x64xf32, #shared, #smem, mutable>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x16xf32, #mma>) : i32 {
+      %a = tt.load %arg0 : tensor<16x64x!tt.ptr<f32>, #blocked>
+      %a_dot = ttg.convert_layout %a : tensor<16x64xf32, #blocked> -> tensor<16x64xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %a_dot, %arg1, %acc : tensor<16x64xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x16xf32, #mma>
+      scf.yield %c : tensor<16x16xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : tensor<16x16xf32, #mma>
+  }
+}
+
+// -----
+
+// If sizePerThread is > 1 in the non contig dim we still need to choose the actual memory order.
+#blocked = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+// CHECK: #shared = {{.*}} order = [1, 0]
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [16, 16, 4], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_copy_sizeperthread_in_noncontig_dim_not_vectorized
+  tt.func @async_copy_sizeperthread_in_noncontig_dim_not_vectorized(
+              %arg0: tensor<16x64x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+              %arg1: tensor<64x16xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>,
+              %lb: i32, %ub: i32, %step: i32) -> tensor<16x16xf32, #mma> {
+    // CHECK: ttg.async_copy_global_to_local {{.*}} -> <16x64xf32, #shared, #smem, mutable>
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x16xf32, #mma>) : i32 {
+      %a = tt.load %arg0 : tensor<16x64x!tt.ptr<f32>, #blocked>
+      %a_dot = ttg.convert_layout %a : tensor<16x64xf32, #blocked> -> tensor<16x64xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %a_dot, %arg1, %acc : tensor<16x64xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<64x16xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x16xf32, #mma>
+      scf.yield %c : tensor<16x16xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+    tt.return %result : tensor<16x16xf32, #mma>
+  }
+}

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -585,3 +585,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Test bug fix: With warp = [[0], [0]] the warp dimension has free variables,
+// so the load should contribute 0 instructions — non-canonical warps skip the
+// load entirely.
+
+#linear_warp_free = #ttg.linear<{register = [[0]], lane = [[1], [2], [4], [8], [16], [32]], warp = [[0], [0]], block = []}>
+#shared_simple = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: warp_free_variable_returns_zero
+  tt.func public @warp_free_variable_returns_zero(
+      %ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+      %offsets: tensor<64xi32, #linear_warp_free>,
+      %dest: !ttg.memdesc<64xi32, #shared_simple, #smem, mutable>) {
+    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<64xi32, #linear_warp_free>]  -> <64xi32, #shared_simple, #smem, mutable>
+    %1 = ttg.async_commit_group
+
+    // The load above contributes 0 instructions, so waitcnt should be 0
+    // CHECK: amdg.async_wait {num_inst = 0
+    %2 = ttg.async_wait {num = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test bug fix: register zero bases should not inflate instruction count.
+
+#linear_reg_zero = #ttg.linear<{register = [[0]], lane = [[1], [2], [4], [8], [16], [32]], warp = [[64], [128]], block = []}>
+#shared_simple2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: register_zero_bases_not_inflated
+  tt.func public @register_zero_bases_not_inflated(
+      %ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+      %offsets: tensor<256xi32, #linear_reg_zero>,
+      %dest: !ttg.memdesc<256xi32, #shared_simple2, #smem, mutable>) {
+    %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<256xi32, #linear_reg_zero>]  -> <256xi32, #shared_simple2, #smem, mutable>
+    %1 = ttg.async_commit_group
+    // Without zero-base removal, register dim size is 2 which would give
+    // num_inst = 2. With zero-base removal, it correctly gives num_inst = 1.
+    // CHECK: amdg.async_wait {num_inst = 1
+    %2 = ttg.async_wait {num = 1 : i32}
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -674,8 +674,15 @@ bool TargetInfo::supportsDirectToLDSScattering() const {
 bool TargetInfo::requiresAliasInfoForAsyncOps() const {
   switch (getISAFamily()) {
   case ISAFamily::CDNA3:
-  case ISAFamily::CDNA4:
     return true;
+  case ISAFamily::CDNA4:
+    // The no-alias hint is unsound without asyncmark: LLVM drops the vmcnt
+    // wait before a ds_read of direct-to-LDS gathered data, causing stale
+    // reads and GPU faults (Gluon MLA decode paged-KV gather). Upstream
+    // 3.8.x makes it sound via asyncmark (#9883, #10081), but that needs an
+    // LLVM bump we lack on 3.7.x; returning false falls back to conservative,
+    // correct wait insertion. CDNA3 is left unchanged (no reproduced fault).
+    return false;
   default:
     return false;
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -174,15 +174,15 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
         // For architectures that don't support scattering into LDS we must
         // ensure that each warp writes a contiguous memory chunk. This requires
         // the shared memory order to follow the thread order, while preserving
-        // the fastest dimension from the register order to keep vectorization.
+        // the fastest dimension from the memory order if it's contiguous > 1 to
+        // keep vectorization.
         auto llEnc =
             triton::gpu::toLinearEncoding(cast<RankedTensorType>(srcTy));
-        auto regOrder = llEnc.getOrder();
         auto threadOrder = llEnc.getThreadOrder();
 
         SetVector<unsigned> orderSet;
 
-        auto regContig = llEnc.getContigPerThread()[regOrder[0]];
+        auto regContig = llEnc.getContigPerThread()[order[0]];
         unsigned elemBitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
         unsigned finalRegContig =
             fitToValidDirectToLdsVecSize(regContig, elemBitWidth, targetInfo);
@@ -191,7 +191,7 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
         if (finalRegContig > 0) {
           // Preserve the fastest reg dim for contig > 1 to keep vectorization.
           if (finalRegContig > 1)
-            orderSet.insert(regOrder[0]);
+            orderSet.insert(order[0]);
           orderSet.insert(threadOrder.begin(), threadOrder.end());
           order = orderSet.takeVector();
         }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -70,14 +70,27 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
   }
   LinearLayout globalToSharedLayout =
       globalLayout.invertAndCompose(sharedLayout);
+
+  // If the warp dimension has free variables, not all warps execute this async
+  // copy — the lowering will predicate execution to canonical warps only (via
+  // emitRedundantThreadPredicate + emitBranch). Non-canonical warps branch over
+  // the buffer_load instructions entirely, so their vmcnt is not incremented.
+  auto kWarp = StringAttr::get(globalType.getContext(), "warp");
+  if (globalToSharedLayout.getFreeVariableMasks().lookup(kWarp) != 0) {
+    return 0;
+  }
   contig = std::min(contig, globalToSharedLayout.getNumConsecutiveInOut());
 
   if (mask)
     contig = std::min<int>(contig, axisInfo.getMaskAlignment(mask));
 
-  // Divide number of registers by contig to get the number of async intrinsics
-  int numberOfRegisters = globalToSharedLayout.getInDimSize(
-      StringAttr::get(globalType.getContext(), "register"));
+  // Divide number of registers by contig to get the number of async intrinsics.
+  // Strip zero bases from the register dimension first — a zero basis means
+  // multiple register indices map to the same offset, so no additional load
+  // instruction is generated.
+  auto kReg = StringAttr::get(globalType.getContext(), "register");
+  int numberOfRegisters =
+      globalToSharedLayout.removeZeroBasesAlongDim(kReg).getInDimSize(kReg);
   return std::max(1, numberOfRegisters / contig);
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -168,8 +168,7 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   unsigned bitWidth = getIntOrFloatOrPtrBitWidth(srcTy.getElementType());
   unsigned elemByteWidth = std::max(bitWidth / 8u, 1u);
 
-  // NYI: dtypes != 16bit
-  if (elemByteWidth != 2) {
+  if (!llvm::is_contained({1, 2}, elemByteWidth)) {
     return {};
   }
 
@@ -190,38 +189,78 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
     return {};
   }
 
-  if (!llvm::is_contained({4, 8}, kWidth)) {
+  if (!llvm::is_contained({4, 8, 16}, kWidth)) {
     return {};
   }
+
+  unsigned kWidthBytes = kWidth * elemByteWidth;
+  // TODO: if the actual vecSize is smaller than 16 bytes we can do better by
+  // using smaller padding intervals
+  unsigned vecSize = 16 / elemByteWidth;
+  unsigned elemsPer8Bytes = 8 / elemByteWidth;
 
   // Determine row(contig) size
   unsigned contigDim = isKContig ? kDim : nonKDim;
   unsigned nonContigDim = isKContig ? nonKDim : kDim;
 
   // padding to avoid bank conflict
-  // For ds_read_b128. Lanes access LDS in 4 pairs of 16 lanes. we have 64 banks
-  // and each lane loads 4 banks. These lane groups are:
-  //  1: 0-3, 12-15, 20-23, 24-27
-  //  2: 4-7, 8-11, 16-19, 28-31
+  // The bank conflict pattern depends on the ds_load instruction:
+  // 1) ds_read_b128: Uses 64 banks and lanes are grouped into 4 pairs:
+  //  Group1: 0-3, 12-15, 20-23, 24-27
+  //  Group2: 4-7, 8-11, 16-19, 28-31
   // The upper half of the lanes follow the same pattern.
-  // For ds_read_b64, it splits conseuctive lanes into 2 groups which access LDS
-  // one after another
+  // 2) ds_read_b64_tr (and ds_read_b64): Uses 64 banks and lanes are split into
+  // 2 groups which access LDS one after another.
+  // 3) Others: Use only 32 banks and lanes are split into groups each loading
+  // 32 banks.
+
+  bool useDsReadB128 = isKContig && kWidthBytes == 16;
+  bool useDsReadB64Tr = !isKContig && kWidthBytes >= 8;
+
+  // Note for isKContig && kWidthBytes == 8 we do use ds_read2_b64 which uses 32
+  // banks
+  unsigned numberOfBanks = (useDsReadB128 || useDsReadB64Tr) ? 64 : 32;
+  unsigned bytesPerBank = 4;
+  unsigned elemPerBankRow = (numberOfBanks * bytesPerBank) / elemByteWidth;
+
   unsigned padding = 0;
-  if (isKContig) {
+  if (useDsReadB128) {
     padding = mfmaNonKDim == 16 ? (kWidth * 2) : kWidth;
-  } else {
+  } else if (useDsReadB64Tr) {
     padding = mfmaNonKDim == 16 ? 16 : 32;
+  } else {
+    padding = elemsPer8Bytes;
   }
-  constexpr unsigned vecSize = 8; // in favor of dwordX4
+
   unsigned contigLanes = contigDim / vecSize;
-  unsigned wrap = std::min(contigDim, 128u) / padding;
+  unsigned wrap = std::min(contigDim, elemPerBankRow) / padding;
   // wrap == 0 means padding > contigDim, which is not a valid configuration
   if (wrap == 0) {
     return {};
   }
-  unsigned requiredDim = warpSize / contigLanes * wrap;
-  if (nonContigDim < requiredDim) {
+
+  // The staggering of rows only works if we have enough (wrap) rows to stagger.
+  // If we have less rows we get bank conflicts. For each pow2 too small we will
+  // get 2 times more conflicts.
+  unsigned requiredRows = warpSize / contigLanes * wrap;
+  unsigned xWayConflicts =
+      (nonContigDim >= requiredRows)
+          ? 1
+          : (llvm::Log2_32(requiredRows / nonContigDim) + 1);
+  // Heuristic, for ds_read_b128 we do not tolerate any conflicts but for
+  // ds_read_b64(_tr) we tolerate 2-way because swizzling will produce the same
+  // number of conflicts.
+  if ((useDsReadB128 && xWayConflicts > 1) || xWayConflicts > 2) {
     return {};
+  }
+
+  if (xWayConflicts > 1) {
+    // We need to adjust the warp to allow for bank conflicts and to produce a
+    // valid layout
+    wrap /= (1 << (xWayConflicts - 1));
+    if (wrap == 0) {
+      return {};
+    }
   }
 
   // Use 16 rows wrap if block large enough
@@ -235,7 +274,7 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   // We create linear bases mapping from [contigDim, nonContigDim] -> offset,
   std::vector<std::vector<int>> bases;
 
-  // Keep contigSize numbers of elments contiguous in shared memory
+  // Keep contigSize numbers of elements contiguous in shared memory
   for (int elemLog2 = 0; elemLog2 < llvm::Log2_32(contigDim); elemLog2++)
     bases.push_back({1 << elemLog2, 0});
 
@@ -255,25 +294,27 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   for (; rowBase < llvm::Log2_32(nonContigDim); rowBase++)
     bases.push_back({0, 1 << rowBase});
 
-  // Fixup for nonKContig and mfma16
-  if (!isKContig && mfmaNonKDim == 16) {
-    unsigned row4 = 0;
-    unsigned row8 = 0;
+  // Fixup: One ds_read_tr loads 8 bytes so kWidthBytes > 8 will load strided.
+  // To account for this we swap rows which are accessed by the rows 16-31
+  if (useDsReadB64Tr && mfmaNonKDim == 16 && kWidthBytes == 16) {
+    // lane groups wrap at 16 bytes, so we have to exchange
+    // rows representing 16 and 8 bytes to avoid bank conflict
+    unsigned baseIdxGroup0 = 0;
+    unsigned baseIdxGroup1 = 0;
     for (unsigned i = 0; i < bases.size(); i++) {
-      if (bases[i][1] == 8)
-        row8 = i;
-      if (bases[i][1] == 4)
-        row4 = i;
+      if (bases[i][1] == 16 / elemByteWidth)
+        baseIdxGroup1 = i;
+      if (bases[i][1] == 8 / elemByteWidth)
+        baseIdxGroup0 = i;
     }
-    assert(row4 != 0 && row8 != 0);
-    // lane groups wrap at row8, so we have to exchange
-    // row4 and row8 to avoid bank conflict
-    std::swap(bases[row4], bases[row8]);
+    assert(baseIdxGroup0 != 0 && baseIdxGroup1 != 0);
+    std::swap(bases[baseIdxGroup0], bases[baseIdxGroup1]);
   }
 
   // Fixup for KContig and mfma32 when reordered rows can not fit in 64banks
-  if (isKContig && mfmaNonKDim == 32 && useBestWrap && kDim < 128) {
-    bool useWideLayout = kWidth == 8;
+  if (useDsReadB128 && mfmaNonKDim == 32 && useBestWrap &&
+      kDim < (256 / elemByteWidth)) {
+    bool useWideLayout = kWidth == (16 / elemByteWidth);
 
     // For narrow layouts we need to shift every 16th row to the other half of
     // shared memory banks to read from all banks. For the wide layout we need

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -37,3 +37,17 @@ add_triton_ut(
     TritonGPUTransforms
     TritonNvidiaGPUTransforms
 )
+
+add_triton_ut(
+  NAME TestPaddedSharedLayout
+  SRCS PaddedTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonNvidiaGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
+    TritonTools
+    LLVMSupport
+    MLIRSupport
+)

--- a/unittest/Dialect/TritonGPU/PaddedTest.cpp
+++ b/unittest/Dialect/TritonGPU/PaddedTest.cpp
@@ -1,0 +1,48 @@
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+class PaddedTest : public ::testing::Test {
+public:
+  PaddedTest() {
+    ctx.loadDialect<mlir::triton::TritonDialect,
+                    mlir::triton::gpu::TritonGPUDialect>();
+  }
+
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
+
+protected:
+  MLIRContext ctx;
+};
+
+TEST_F(PaddedTest, TestMultiCTA) {
+  std::pair<unsigned, unsigned> intervalPads(64, 8);
+  unsigned order[2] = {1, 0};
+  int64_t shape[2] = {16, 128};
+
+  {
+    auto cgaLL = LinearLayout({{S("block"), {{0, 1}}}}, {S("dim0"), S("dim1")});
+    CGAEncodingAttr cgaLayout = CGAEncodingAttr::get(&ctx, cgaLL);
+
+    auto attr = PaddedSharedEncodingAttr::get(&ctx, intervalPads, order, shape,
+                                              cgaLayout);
+    auto ll = attr.getLinearComponent();
+    auto ofstLayout = ll.sublayout(S("offset"), to_vector(ll.getOutDimNames()));
+
+    EXPECT_TRUE(ofstLayout.isInjective());
+  }
+
+  {
+    auto cgaLL = LinearLayout({{S("block"), {{0, 0}}}}, {S("dim0"), S("dim1")});
+    CGAEncodingAttr cgaLayout = CGAEncodingAttr::get(&ctx, cgaLL);
+
+    auto attr = PaddedSharedEncodingAttr::get(&ctx, intervalPads, order, shape,
+                                              cgaLayout);
+    auto ll = attr.getLinearComponent();
+    auto ofstLayout = ll.sublayout(S("offset"), to_vector(ll.getOutDimNames()));
+    EXPECT_TRUE(ofstLayout.isInjective());
+  }
+}


### PR DESCRIPTION
## Context
  aiter Gluon MLA decode kernel (`_mla_decode_gluon`) on MI355X
  (gfx950 / CDNA4) against a local Triton 3.7.x build. That kernel relies on
  padded / distributed shared-layout direct-to-LDS async copies, which only exist
  on `release/3.8.x`. Rather than move the whole toolchain to 3.8.x, we backport
  just that support into 3.7.x. This PR is that backport plus a fix for a CDNA4
  memory fault it surfaced.

  ## Symptom 1 — compile error (before backport)

  On stock 3.7.x the kernel fails to compile: the Gluon `buffer_load_to_shared`
  frontend rejects the distributed/linear offset layout the kernel uses.

  File ".../gluon/language/amd/cdna4/async_copy.py", line 105, in buffer_load_to_shared
      _check(isinstance(offsets.type.layout, (BlockedLayout, SliceLayout)), ...)
  triton.compiler.errors.CompilationError: at 292:4:
      ...buffer_load_to_shared(buf_q_pe, Q_pe, offs_q_pe, mask=...)
  expected offsets type layout to be BlockedLayout or SliceLayout

  Fixed by cherry-picking the distributed/padded-layout AsyncCopy support from 3.8.x:

  - #9513 — [AMD][GLUON] Allow DistributedLayouts in AsyncCopy and BufferLoadToLocal for gfx950
  - #9632 — [Backend] Fix padded shared layout getter shape
  - #9544 — [AMD][BACKEND] Extend padded layout selection for AsyncCopy on GFX9
  - #9373 — [AMD][BACKEND] Fix shared layout order for AsyncCopy on GFX9
  - #9874 — [AMD][gfx9] Fix async copy shared memory order regarding contig dim
  - #9732 — [AMD] Fix async wait count for warp free variables and register zero bases

  ## Symptom 2 — GPU memory access fault (after backport)

  With the above in place the kernel compiles, but the decode paged-KV gather then
  faults at runtime on CDNA4 (prefill is fine; the fault address varies per run).

  `requiresAliasInfoForAsyncOps()` returns `true` for CDNA4, marking direct-to-LDS
  async copies as not aliasing subsequent `ds` loads. That lets LLVM drop the
  `vmcnt` wait before the `ds_read` consuming a just-gathered page index → stale
  index → wild `global_load_lds` address → fault.

  The fix drops the hint on CDNA4 so LLVM falls back to conservative, correct
  wait-count insertion. CDNA3 unchanged (no reproduced failure).

## Perf note

  The alias hint exists has it's performance reason: it lets LLVM relax `vmcnt` waits
  between direct-to-LDS async copies and dependent `ds` loads. On 3.8.x this stays
  correct because `asyncmark`/`wait_asyncmark` (#9883/#10081) enforce the ordering
  independently; on 3.7.x, without those intrinsics, the hint removes *necessary*
  waits — fast but wrong (the fault). Those intrinsics need an LLVM bump we are
  trying to avoid here, so we drop the hint on CDNA4 instead.

  Measured cost on MLA decode: +6 `s_waitcnt vmcnt(0)` (+0.3% instrs),
  with the steady-state loop's pipelined `vmcnt(18)` waits unchanged (decode
  ~17.5µs). It applies to all CDNA4 direct-to-LDS async-copy kernels; deeper
  pipelined kernels may see more. No LLVM bump. may need further investigation of perf impact.

  ## Tests

  - `test_mla.py -n "12,1" -c 1200 -b 16 -blk 1`: decode passes 5/5 cache-cleared
    runs, correct numerics, zero faults (previously: compile error, then fault).
  - Verified across `c=512/1200/2048` (`b=8/16/4`): prefill + decode pass, no faults.