### PR TITLE
[Cherry-Pick] [AMD][GFX9] Enable amdgpu-use-amdgpu-trackers LLVM flag

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -540,6 +540,8 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
+        if options.arch in ["gfx942", "gfx950"]:
+            flags.append("amdgpu-use-amdgpu-trackers")
         if is_expert_scheduling_enabled(options.arch):
             flags.append("amdgpu-expert-scheduling-mode")
         features = disable_real_true16_feature(options.arch)


### PR DESCRIPTION
Cherry-pick of:
- https://github.com/triton-lang/triton/pull/11285

This fixes ROCM-27318

