### PR TITLE
[AMD] Fix buffer_load_to_local with other: write other in the after-l…

### DIFF
--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -385,3 +385,56 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: @buffer_load_to_local_other_in_after_block
+  tt.func @buffer_load_to_local_other_in_after_block(%ptr: !tt.ptr<f32>, %lds: !ttg.memdesc<64xf32, #shared, #smem, mutable>, %mask: tensor<64xi1, #blocked>) {
+    %off = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
+    %other = arith.constant dense<0.000000e+00> : tensor<64xf32, #blocked>
+    // The conditional branch enters the load block only when pred is true.
+    // COMMON: llvm.cond_br %{{.*}}, ^[[LOAD_BB:bb[0-9]+]], ^[[AFTER_BB:bb[0-9]+]]
+    // COMMON-NEXT: ^[[LOAD_BB]]:
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NEXT: llvm.br ^[[AFTER_BB]]
+    // The `other` store must appear in the after-load block so it is reached
+    // regardless of whether the load branch was taken (i.e., for masked-out lanes).
+    // COMMON-NEXT: ^[[AFTER_BB]]:
+    // COMMON: llvm.store
+    amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : <f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The blocked layout will return contiguity of 2 because the repeat pattern to cover the full tensor.
+// Check that we lower it to 2 separate instructions because the order of blocked layout and shared layout disagree.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: buffer_load_to_local_order_mismatch_clamped_vec
+  tt.func public @buffer_load_to_local_order_mismatch_clamped_vec(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                %arg1: !ttg.memdesc<64x2xf32, #shared, #smem, mutable>) {
+    %cst = arith.constant dense<2> : tensor<64x1xi32, #blocked>
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %1 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = arith.muli %2, %cst : tensor<64x1xi32, #blocked>
+    %4 = tt.broadcast %3 : tensor<64x1xi32, #blocked> -> tensor<64x2xi32, #blocked>
+    %5 = tt.expand_dims %1 {axis = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x2xi32, #blocked>
+    %6 = tt.broadcast %5 : tensor<1x2xi32, #blocked> -> tensor<64x2xi32, #blocked>
+    %7 = arith.addi %4, %6 : tensor<64x2xi32, #blocked>
+
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
+    %8 = amdg.buffer_load_to_local %arg0[%7] into %arg1 : <f32>[tensor<64x2xi32, #blocked>] -> <64x2xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -410,31 +410,3 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 }
 
-// -----
-
-// The blocked layout will return contiguity of 2 because the repeat pattern to cover the full tensor.
-// Check that we lower it to 2 separate instructions because the order of blocked layout and shared layout disagree.
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // COMMON-LABEL: buffer_load_to_local_order_mismatch_clamped_vec
-  tt.func public @buffer_load_to_local_order_mismatch_clamped_vec(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %arg1: !ttg.memdesc<64x2xf32, #shared, #smem, mutable>) {
-    %cst = arith.constant dense<2> : tensor<64x1xi32, #blocked>
-    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %1 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %2 = tt.expand_dims %0 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
-    %3 = arith.muli %2, %cst : tensor<64x1xi32, #blocked>
-    %4 = tt.broadcast %3 : tensor<64x1xi32, #blocked> -> tensor<64x2xi32, #blocked>
-    %5 = tt.expand_dims %1 {axis = 0 : i32} : tensor<2xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x2xi32, #blocked>
-    %6 = tt.broadcast %5 : tensor<1x2xi32, #blocked> -> tensor<64x2xi32, #blocked>
-    %7 = arith.addi %4, %6 : tensor<64x2xi32, #blocked>
-
-    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
-    %8 = amdg.buffer_load_to_local %arg0[%7] into %arg1 : <f32>[tensor<64x2xi32, #blocked>] -> <64x2xf32, #shared, #smem, mutable>
-    tt.return
-  }
-}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -864,13 +864,13 @@ struct BufferLoadToLocalOpConversion
         if (targetInfo.requiresAliasInfoForAsyncOps())
           AMD::addAsyncCopyAliasScope(bufferLoadToLds);
 
+        rewriter.setInsertionPointToStart(afterLoadBlock);
+
         if (hasOther) {
           emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy,
                          maskElem, otherElems, shmemAddr, laneId,
                          requiresSrcPtrSwizzling, swizzleLaneOffset);
         }
-
-        rewriter.setInsertionPointToStart(afterLoadBlock);
       }
 
       return {};


### PR DESCRIPTION
BufferLoadToLocalOpConversion lowered a masked async buffer-load-to-LDS with an `other` value by emitting a branch on `pred = threadPred && mask`, then placing `emitOtherStore` inside the load block (the block entered only when `pred` is true). However, `emitOtherStore` writes the other value precisely for lanes where the mask is false, so those lanes never took the branch, and the other store was dead code — leaving stale LDS contents instead of the other fill value. This patch moves the insertion point to `afterLoadBlock` before calling `emitOtherStore`, making the other store unconditional.

